### PR TITLE
Move progress bar logic out of the RecordDetailsFragment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ captures/
 
 # IntelliJ
 *.iml
+
+# Ctags
+**/tags

--- a/gnd/src/main/java/com/google/android/gnd/repository/DataRepository.java
+++ b/gnd/src/main/java/com/google/android/gnd/repository/DataRepository.java
@@ -121,13 +121,13 @@ public class DataRepository {
                     .orElse(Single.error(new DocumentNotFoundException())));
   }
 
-  public Observable<Resource<Record>> getRecordDetails(
+  public Flowable<Resource<Record>> getRecordDetails(
       String projectId, String featureId, String recordId) {
     return getFeature(projectId, featureId)
         .flatMap(feature -> remoteDataService.loadRecordDetails(feature, recordId))
         .map(Resource::loaded)
         .onErrorReturn(Resource::error)
-        .toObservable();
+        .toFlowable();
   }
 
   public Single<Resource<Record>> getRecordSnapshot(

--- a/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
@@ -27,10 +27,10 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 import android.widget.TextView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import com.google.android.gnd.databinding.RecordDetailsFragBinding;
 import com.google.android.gnd.MainActivity;
 import com.google.android.gnd.R;
 import com.google.android.gnd.inject.ActivityScoped;
@@ -55,9 +55,6 @@ public class RecordDetailsFragment extends AbstractFragment {
   @BindView(R.id.form_name)
   TextView formNameView;
 
-  @BindView(R.id.record_details_progress_bar)
-  ProgressBar progressBar;
-
   @BindView(R.id.record_details_layout)
   LinearLayout recordDetailsLayout;
 
@@ -72,7 +69,10 @@ public class RecordDetailsFragment extends AbstractFragment {
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-    return inflater.inflate(R.layout.record_details_frag, container, false);
+    RecordDetailsFragBinding binding = 
+      RecordDetailsFragBinding.inflate(inflater, container, false);
+    binding.setViewModel(viewModel);
+    return binding.getRoot();
   }
 
   @Override
@@ -122,12 +122,10 @@ public class RecordDetailsFragment extends AbstractFragment {
     toolbar.setSubtitle("");
     formNameView.setText("");
     recordDetailsLayout.setVisibility(View.GONE);
-    progressBar.setVisibility(View.VISIBLE);
   }
 
   // TODO: Move into separate ViewHolder class.
   private void showRecord(Record record) {
-    progressBar.setVisibility(View.GONE);
     toolbar.setTitle(record.getFeature().getTitle());
     toolbar.setSubtitle(record.getFeature().getSubtitle());
     formNameView.setText(record.getForm().getTitle());

--- a/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
@@ -62,12 +62,12 @@ public class RecordDetailsFragment extends AbstractFragment {
     super.onCreate(savedInstanceState);
     RecordDetailsFragmentArgs args = getRecordDetailFragmentArgs();
     viewModel = getViewModel(RecordDetailsViewModel.class);
-    viewModel.loadRecordDetails(args);
     // TODO: Move toolbar setting logic into the ViewModel once we have
     // determined the fate of the toolbar.
     viewModel.toolbarTitle.observe(this, this::setToolbarTitle);
     viewModel.toolbarSubtitle.observe(this, this::setToolbarSubtitle);
     viewModel.records.observe(this, this::onUpdate);
+    viewModel.loadRecordDetails(args);
   }
 
   @Override
@@ -103,11 +103,15 @@ public class RecordDetailsFragment extends AbstractFragment {
   }
 
   private void setToolbarTitle(String title) {
-    toolbar.setTitle(title);
+    if (toolbar != null) {
+      toolbar.setTitle(title);
+    }
   }
 
   private void setToolbarSubtitle(String subtitle) {
-    toolbar.setSubtitle(subtitle);
+    if (toolbar != null) {
+      toolbar.setSubtitle(subtitle);
+    }
   }
 
   private void onUpdate(Resource<Record> record) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
@@ -72,6 +72,7 @@ public class RecordDetailsFragment extends AbstractFragment {
     RecordDetailsFragBinding binding = 
       RecordDetailsFragBinding.inflate(inflater, container, false);
     binding.setViewModel(viewModel);
+    binding.setLifecycleOwner(this);
     return binding.getRoot();
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
@@ -62,8 +62,8 @@ public class RecordDetailsFragment extends AbstractFragment {
     super.onCreate(savedInstanceState);
     RecordDetailsFragmentArgs args = getRecordDetailFragmentArgs();
     viewModel = getViewModel(RecordDetailsViewModel.class);
-    viewModel.getRecordDetailsRequest(args);
-    //TODO: Move toolbar setting logic into the ViewModel once we have
+    viewModel.loadRecordDetails(args);
+    // TODO: Move toolbar setting logic into the ViewModel once we have
     // determined the fate of the toolbar.
     viewModel.toolbarTitle.observe(this, this::setToolbarTitle);
     viewModel.toolbarSubtitle.observe(this, this::setToolbarSubtitle);
@@ -74,8 +74,7 @@ public class RecordDetailsFragment extends AbstractFragment {
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
-    RecordDetailsFragBinding binding =
-      RecordDetailsFragBinding.inflate(inflater, container, false);
+    RecordDetailsFragBinding binding = RecordDetailsFragBinding.inflate(inflater, container, false);
     binding.setViewModel(viewModel);
     binding.setLifecycleOwner(this);
     return binding.getRoot();

--- a/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsViewModel.java
@@ -18,6 +18,9 @@ package com.google.android.gnd.ui.recorddetails;
 
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
+import android.databinding.ObservableInt;
+import android.view.View;
+
 import com.google.android.gnd.repository.DataRepository;
 import com.google.android.gnd.repository.Resource;
 import com.google.android.gnd.ui.common.AbstractViewModel;
@@ -28,6 +31,7 @@ public class RecordDetailsViewModel extends AbstractViewModel {
 
   private final DataRepository dataRepository;
   private final MutableLiveData<Resource<Record>> record;
+  public final ObservableInt progressBarVisibility = new ObservableInt();
 
   @Inject
   RecordDetailsViewModel(DataRepository dataRepository) {
@@ -43,6 +47,21 @@ public class RecordDetailsViewModel extends AbstractViewModel {
     disposeOnClear(
         dataRepository
             .getRecordDetails(projectId, featureId, recordId)
-            .subscribe(record::setValue));
+            .subscribe(this::onRecordUpdate));
+  }
+
+  private void onRecordUpdate(Resource<Record> r) {
+    switch (r.operationState().get()) {
+      case LOADING:
+        progressBarVisibility.set(View.VISIBLE);
+        break;
+      case LOADED:
+        progressBarVisibility.set(View.GONE);
+        break;
+      case NOT_FOUND:
+      case ERROR:
+        break;
+    }
+    record.setValue(r);
   }
 }

--- a/gnd/src/main/res/layout/record_details_frag.xml
+++ b/gnd/src/main/res/layout/record_details_frag.xml
@@ -75,6 +75,7 @@
             android:textAllCaps="true"
             android:textColor="@color/colorForeground"
             android:textSize="12sp"
+            android:text="@{viewModel.formNameView}"
             />
   
         </LinearLayout>

--- a/gnd/src/main/res/layout/record_details_frag.xml
+++ b/gnd/src/main/res/layout/record_details_frag.xml
@@ -34,7 +34,16 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:orientation="vertical">
-  
+
+      <ProgressBar
+        android:id="@+id/record_details_progress_bar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="48dp"
+        android:visibility="@{safeUnbox(viewModel.progressBarVisibility)}"/>
+
       <!-- CardView is used to create the drop shadow effect -->
       <android.support.v7.widget.CardView
         android:id="@+id/record_details_header"
@@ -71,15 +80,6 @@
         </LinearLayout>
   
       </android.support.v7.widget.CardView>
-  
-      <ProgressBar
-        android:id="@+id/record_details_progress_bar"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:padding="48dp"
-          android:visibility="@{viewModel.progressBarVisibility}"/>
   
       <ScrollView
         android:layout_width="match_parent"

--- a/gnd/src/main/res/layout/record_details_frag.xml
+++ b/gnd/src/main/res/layout/record_details_frag.xml
@@ -14,79 +14,88 @@
   ~ limitations under the License.
   -->
 
-<android.support.design.widget.CoordinatorLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:fitsSystemWindows="true"
-  android:navigationBarColor="@color/colorGrey500"
-  app:statusBarBackground="@color/colorGrey500">
+<layout>
+  <data>
+    <variable
+        name="viewModel"
+        type="com.google.android.gnd.ui.recorddetails.RecordDetailsViewModel"/>
+  </data>
 
-  <RelativeLayout
+  <android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
-
-    <!-- CardView is used to create the drop shadow effect -->
-    <android.support.v7.widget.CardView
-      android:id="@+id/record_details_header"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      app:cardCornerRadius="0dp"
-      app:cardElevation="@dimen/toolbar_elevation">
-
-      <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <com.google.android.gnd.ui.common.TwoLineToolbar
-          android:id="@+id/record_details_toolbar"
-          android:layout_width="match_parent"
-          android:layout_height="?attr/actionBarSize"
-          android:layout_gravity="top"
-          android:theme="@style/WhiteToolbarTheme"/>
-
-        <TextView
-          android:id="@+id/form_name"
-          android:textStyle="bold"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:paddingBottom="6dp"
-          android:background="@color/colorBackground"
-          android:textAlignment="center"
-          android:textAllCaps="true"
-          android:textColor="@color/colorForeground"
-          android:textSize="12sp"
-          />
-
-      </LinearLayout>
-
-    </android.support.v7.widget.CardView>
-
-    <ProgressBar
-      android:id="@+id/record_details_progress_bar"
-      style="?android:attr/progressBarStyle"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_gravity="center"
-      android:padding="48dp"/>
-
-    <ScrollView
+    android:fitsSystemWindows="true"
+    android:navigationBarColor="@color/colorGrey500"
+    app:statusBarBackground="@color/colorGrey500">
+  
+    <RelativeLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:layout_below="@id/record_details_header"
-      android:background="@color/colorBackground">
-
-      <LinearLayout
-        android:id="@+id/record_details_layout"
+      android:orientation="vertical">
+  
+      <!-- CardView is used to create the drop shadow effect -->
+      <android.support.v7.widget.CardView
+        android:id="@+id/record_details_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"/>
-
-    </ScrollView>
-
-  </RelativeLayout>
-
-</android.support.design.widget.CoordinatorLayout>
+        app:cardCornerRadius="0dp"
+        app:cardElevation="@dimen/toolbar_elevation">
+  
+        <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="vertical">
+  
+          <com.google.android.gnd.ui.common.TwoLineToolbar
+            android:id="@+id/record_details_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="top"
+            android:theme="@style/WhiteToolbarTheme"/>
+  
+          <TextView
+            android:id="@+id/form_name"
+            android:textStyle="bold"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="6dp"
+            android:background="@color/colorBackground"
+            android:textAlignment="center"
+            android:textAllCaps="true"
+            android:textColor="@color/colorForeground"
+            android:textSize="12sp"
+            />
+  
+        </LinearLayout>
+  
+      </android.support.v7.widget.CardView>
+  
+      <ProgressBar
+        android:id="@+id/record_details_progress_bar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="48dp"
+          android:visibility="@{viewModel.progressBarVisibility}"/>
+  
+      <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/record_details_header"
+        android:background="@color/colorBackground">
+  
+        <LinearLayout
+          android:id="@+id/record_details_layout"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="vertical"/>
+  
+      </ScrollView>
+  
+    </RelativeLayout>
+  
+  </android.support.design.widget.CoordinatorLayout>
+</layout>


### PR DESCRIPTION
This changes moves the progress bar visibility logic out of the RecordDetailsFragment and into its associated viewModel. See issue #9 

Since this is my first go at this, there may be some flubs. I followed the example of 8f4719ef. Please leave comments and push back as needed!