### PR TITLE
Rename Record "Value" to "Response" for consistency

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/repository/DataRepository.java
+++ b/gnd/src/main/java/com/google/android/gnd/repository/DataRepository.java
@@ -22,7 +22,7 @@ import com.google.android.gnd.service.RemoteDataService;
 import com.google.android.gnd.service.firestore.DocumentNotFoundException;
 import com.google.android.gnd.system.AuthenticationManager.User;
 import com.google.android.gnd.vo.Feature;
-import com.google.android.gnd.vo.FeatureUpdate.RecordUpdate.ValueUpdate;
+import com.google.android.gnd.vo.FeatureUpdate.RecordUpdate.ResponseUpdate;
 import com.google.android.gnd.vo.Project;
 import com.google.android.gnd.vo.Record;
 import com.google.common.collect.ImmutableList;
@@ -161,7 +161,7 @@ public class DataRepository {
   }
 
   public Observable<Resource<Record>> saveChanges(
-      Record record, ImmutableList<ValueUpdate> updates, User user) {
+      Record record, ImmutableList<ResponseUpdate> updates, User user) {
     record = attachUser(record, user);
     return remoteDataService
         .saveChanges(record, updates)

--- a/gnd/src/main/java/com/google/android/gnd/rx/RxTask.java
+++ b/gnd/src/main/java/com/google/android/gnd/rx/RxTask.java
@@ -38,7 +38,7 @@ public abstract class RxTask {
     return Maybe.create(
         emitter ->
             task.get()
-                .addOnSuccessListener(v -> onSuccess(v, emitter))
+                .addOnSuccessListener(result -> onSuccess(result, emitter))
                 .addOnFailureListener(emitter::onError));
   }
 
@@ -58,7 +58,7 @@ public abstract class RxTask {
     return Single.create(
         emitter ->
             task.get()
-                .addOnSuccessListener(v -> onNullableSuccess(v, emitter))
+                .addOnSuccessListener(result -> onNullableSuccess(result, emitter))
                 .addOnFailureListener(emitter::onError));
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/service/RemoteDataService.java
+++ b/gnd/src/main/java/com/google/android/gnd/service/RemoteDataService.java
@@ -18,7 +18,7 @@ package com.google.android.gnd.service;
 
 import com.google.android.gnd.system.AuthenticationManager.User;
 import com.google.android.gnd.vo.Feature;
-import com.google.android.gnd.vo.FeatureUpdate.RecordUpdate.ValueUpdate;
+import com.google.android.gnd.vo.FeatureUpdate.RecordUpdate.ResponseUpdate;
 import com.google.android.gnd.vo.Project;
 import com.google.android.gnd.vo.Record;
 import com.google.common.collect.ImmutableList;
@@ -40,7 +40,7 @@ public interface RemoteDataService {
 
   Single<Record> loadRecordDetails(Feature feature, String recordId);
 
-  Single<Record> saveChanges(Record record, ImmutableList<ValueUpdate> updates);
+  Single<Record> saveChanges(Record record, ImmutableList<ResponseUpdate> updates);
 
   Single<Feature> addFeature(Feature feature);
 }

--- a/gnd/src/main/java/com/google/android/gnd/service/firestore/FirestoreDataService.java
+++ b/gnd/src/main/java/com/google/android/gnd/service/firestore/FirestoreDataService.java
@@ -146,9 +146,9 @@ public class FirestoreDataService implements RemoteDataService {
           responseUpdate
               .getResponse()
               .ifPresent(
-                  value ->
+                  response ->
                       updatedResponses.put(
-                          responseUpdate.getElementId(), RecordDoc.toObject(value)));
+                          responseUpdate.getElementId(), RecordDoc.toObject(response)));
           break;
         case DELETE:
           // FieldValue.delete() is not working in nested objects; if it doesn't work in the future

--- a/gnd/src/main/java/com/google/android/gnd/service/firestore/FirestoreDataService.java
+++ b/gnd/src/main/java/com/google/android/gnd/service/firestore/FirestoreDataService.java
@@ -146,9 +146,7 @@ public class FirestoreDataService implements RemoteDataService {
           responseUpdate
               .getResponse()
               .ifPresent(
-                  response ->
-                      updatedResponses.put(
-                          responseUpdate.getElementId(), RecordDoc.toObject(response)));
+                  r -> updatedResponses.put(responseUpdate.getElementId(), RecordDoc.toObject(r)));
           break;
         case DELETE:
           // FieldValue.delete() is not working in nested objects; if it doesn't work in the future

--- a/gnd/src/main/java/com/google/android/gnd/service/firestore/RecordDoc.java
+++ b/gnd/src/main/java/com/google/android/gnd/service/firestore/RecordDoc.java
@@ -23,9 +23,9 @@ import android.util.Log;
 import com.google.android.gnd.vo.Feature;
 import com.google.android.gnd.vo.Form;
 import com.google.android.gnd.vo.Record;
-import com.google.android.gnd.vo.Record.MultipleChoiceValue;
-import com.google.android.gnd.vo.Record.TextValue;
-import com.google.android.gnd.vo.Record.Value;
+import com.google.android.gnd.vo.Record.MultipleChoiceResponse;
+import com.google.android.gnd.vo.Record.Response;
+import com.google.android.gnd.vo.Record.TextResponse;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.IgnoreExtraProperties;
 import com.google.firebase.firestore.ServerTimestamp;
@@ -60,12 +60,12 @@ public class RecordDoc {
 
   @Nullable public Map<String, Object> responses;
 
-  public static RecordDoc forUpdates(Record record, Map<String, Object> valueUpdates) {
+  public static RecordDoc forUpdates(Record record, Map<String, Object> responseUpdates) {
     RecordDoc rd = new RecordDoc();
     rd.featureId = record.getFeature().getId();
     rd.featureTypeId = record.getFeature().getFeatureType().getId();
     rd.formId = record.getForm().getId();
-    rd.responses = valueUpdates;
+    rd.responses = responseUpdates;
     rd.clientTimeModified = new Date();
     rd.createdBy = UserDoc.fromObject(record.getCreatedBy());
     rd.modifiedBy = UserDoc.fromObject(record.getModifiedBy());
@@ -89,7 +89,7 @@ public class RecordDoc {
         .setProject(feature.getProject())
         .setFeature(feature)
         .setForm(form.get())
-        .putAllValues(convertValues(rd.responses))
+        .putAllResponses(convertResponses(rd.responses))
         .setCreatedBy(UserDoc.toObject(rd.createdBy))
         .setModifiedBy(UserDoc.toObject(rd.modifiedBy))
         .setServerTimestamps(toTimestamps(rd.serverTimeCreated, rd.serverTimeModified))
@@ -97,33 +97,33 @@ public class RecordDoc {
         .build();
   }
 
-  private static Map<String, Value> convertValues(Map<String, Object> docValues) {
-    Map<String, Value> values = new HashMap<>();
-    for (Map.Entry<String, Object> entry : docValues.entrySet()) {
-      putValue(values, entry.getKey(), entry.getValue());
+  private static Map<String, Response> convertResponses(Map<String, Object> docResponses) {
+    Map<String, Response> responses = new HashMap<>();
+    for (Map.Entry<String, Object> entry : docResponses.entrySet()) {
+      putResponse(responses, entry.getKey(), entry.getValue());
     }
-    return values;
+    return responses;
   }
 
-  private static void putValue(Map<String, Value> values, String fieldId, Object obj) {
+  private static void putResponse(Map<String, Response> responses, String fieldId, Object obj) {
     if (obj instanceof String) {
-      TextValue.fromString(((String) obj).trim()).ifPresent(v -> values.put(fieldId, v));
+      TextResponse.fromString(((String) obj).trim()).ifPresent(v -> responses.put(fieldId, v));
       // } else if (obj instanceof Float) {
-      //   values.put(key, new NumberValue((Float) obj));
+      //   responses.put(key, new NumericResponse((Float) obj));
     } else if (obj instanceof List) {
-      MultipleChoiceValue.fromList(((List<String>) obj)).ifPresent(v -> values.put(fieldId, v));
+      MultipleChoiceResponse.fromList(((List<String>) obj)).ifPresent(v -> responses.put(fieldId, v));
     } else {
       Log.d(TAG, "Unsupported obj in db: " + obj.getClass().getName());
     }
   }
 
-  public static Object toObject(Value value) {
-    if (value instanceof TextValue) {
-      return ((TextValue) value).getText();
-    } else if (value instanceof MultipleChoiceValue) {
-      return ((MultipleChoiceValue) value).getChoices();
+  public static Object toObject(Response response) {
+    if (response instanceof TextResponse) {
+      return ((TextResponse) response).getText();
+    } else if (response instanceof MultipleChoiceResponse) {
+      return ((MultipleChoiceResponse) response).getChoices();
     } else {
-      Log.w(TAG, "Unknown value type: " + value.getClass().getName());
+      Log.w(TAG, "Unknown response type: " + response.getClass().getName());
       return null;
     }
   }

--- a/gnd/src/main/java/com/google/android/gnd/service/firestore/RecordDoc.java
+++ b/gnd/src/main/java/com/google/android/gnd/service/firestore/RecordDoc.java
@@ -18,8 +18,8 @@ package com.google.android.gnd.service.firestore;
 
 import static com.google.android.gnd.service.firestore.FirestoreDataService.toTimestamps;
 
-import androidx.annotation.Nullable;
 import android.util.Log;
+import androidx.annotation.Nullable;
 import com.google.android.gnd.vo.Feature;
 import com.google.android.gnd.vo.Form;
 import com.google.android.gnd.vo.Record;
@@ -107,11 +107,12 @@ public class RecordDoc {
 
   private static void putResponse(Map<String, Response> responses, String fieldId, Object obj) {
     if (obj instanceof String) {
-      TextResponse.fromString(((String) obj).trim()).ifPresent(v -> responses.put(fieldId, v));
+      TextResponse.fromString(((String) obj).trim()).ifPresent(r -> responses.put(fieldId, r));
       // } else if (obj instanceof Float) {
       //   responses.put(key, new NumericResponse((Float) obj));
     } else if (obj instanceof List) {
-      MultipleChoiceResponse.fromList(((List<String>) obj)).ifPresent(v -> responses.put(fieldId, v));
+      MultipleChoiceResponse.fromList(((List<String>) obj))
+          .ifPresent(r -> responses.put(fieldId, r));
     } else {
       Log.d(TAG, "Unsupported obj in db: " + obj.getClass().getName());
     }

--- a/gnd/src/main/java/com/google/android/gnd/ui/common/BindingAdapters.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/common/BindingAdapters.java
@@ -20,6 +20,7 @@ import androidx.databinding.BindingAdapter;
 import androidx.databinding.DataBindingUtil;
 import androidx.databinding.ViewDataBinding;
 import androidx.annotation.Nullable;
+import com.google.android.gnd.vo.Record.Response;
 import com.google.android.material.textfield.TextInputEditText;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -29,7 +30,6 @@ import com.google.android.gnd.databinding.MultipleChoiceInputFieldBinding;
 import com.google.android.gnd.databinding.TextInputFieldBinding;
 import com.google.android.gnd.ui.editrecord.MultipleChoiceFieldLayout;
 import com.google.android.gnd.vo.Form.Field;
-import com.google.android.gnd.vo.Record.Value;
 import java8.util.function.Consumer;
 
 public class BindingAdapters {
@@ -37,14 +37,14 @@ public class BindingAdapters {
   private static final String TAG = BindingAdapters.class.getSimpleName();
 
   @BindingAdapter("android:text")
-  public static void bindText(TextInputEditText view, Value value) {
+  public static void bindText(TextInputEditText view, Response response) {
     ViewDataBinding binding = findBinding(view);
     Field field = getField(binding);
     if (field == null) {
       // Binding update before attached to field.
       return;
     }
-    String newText = value == null ? "" : value.getDetailsText(field);
+    String newText = response == null ? "" : response.getDetailsText(field);
     if (!view.getText().toString().equals(newText)) {
       view.setText(newText);
     }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/EditRecordFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/EditRecordFragment.java
@@ -207,16 +207,16 @@ public class EditRecordFragment extends AbstractFragment implements BackPressLis
 
   public void onShowDialog(Field field) {
     Cardinality cardinality = field.getMultipleChoice().getCardinality();
-    Optional<Response> currentValue = viewModel.getValue(field.getId());
+    Optional<Response> currentResponse = viewModel.getResponse(field.getId());
     switch (cardinality) {
       case SELECT_MULTIPLE:
         multiSelectDialogFactory
-            .create(field, currentValue, v -> viewModel.onValueChanged(field, v))
+            .create(field, currentResponse, v -> viewModel.onResponseChanged(field, v))
             .show();
         break;
       case SELECT_ONE:
         singleSelectDialogFactory
-            .create(field, currentValue, v -> viewModel.onValueChanged(field, v))
+            .create(field, currentResponse, v -> viewModel.onResponseChanged(field, v))
             .show();
         break;
       default:

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/EditRecordFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/EditRecordFragment.java
@@ -20,14 +20,14 @@ import static com.google.android.gnd.ui.util.ViewUtil.assignGeneratedId;
 
 import android.app.ProgressDialog;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import butterknife.BindView;
 import butterknife.OnClick;
 import com.google.android.gnd.MainActivity;
@@ -211,12 +211,12 @@ public class EditRecordFragment extends AbstractFragment implements BackPressLis
     switch (cardinality) {
       case SELECT_MULTIPLE:
         multiSelectDialogFactory
-            .create(field, currentResponse, v -> viewModel.onResponseChanged(field, v))
+            .create(field, currentResponse, r -> viewModel.onResponseChanged(field, r))
             .show();
         break;
       case SELECT_ONE:
         singleSelectDialogFactory
-            .create(field, currentResponse, v -> viewModel.onResponseChanged(field, v))
+            .create(field, currentResponse, r -> viewModel.onResponseChanged(field, r))
             .show();
         break;
       default:

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/EditRecordFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/EditRecordFragment.java
@@ -47,7 +47,7 @@ import com.google.android.gnd.vo.Form;
 import com.google.android.gnd.vo.Form.Field;
 import com.google.android.gnd.vo.Form.MultipleChoice.Cardinality;
 import com.google.android.gnd.vo.Record;
-import com.google.android.gnd.vo.Record.Value;
+import com.google.android.gnd.vo.Record.Response;
 import java8.util.Optional;
 import javax.inject.Inject;
 
@@ -207,7 +207,7 @@ public class EditRecordFragment extends AbstractFragment implements BackPressLis
 
   public void onShowDialog(Field field) {
     Cardinality cardinality = field.getMultipleChoice().getCardinality();
-    Optional<Value> currentValue = viewModel.getValue(field.getId());
+    Optional<Response> currentValue = viewModel.getValue(field.getId());
     switch (cardinality) {
       case SELECT_MULTIPLE:
         multiSelectDialogFactory

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/EditRecordViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/EditRecordViewModel.java
@@ -102,7 +102,7 @@ public class EditRecordViewModel extends AbstractViewModel {
     Log.v(
         TAG, "onResponseChanged: " + field.getId() + " = '" + Response.toString(newResponse) + "'");
     newResponse.ifPresentOrElse(
-        v -> responses.put(field.getId(), v), () -> responses.remove(field.getId()));
+        r -> responses.put(field.getId(), r), () -> responses.remove(field.getId()));
     updateError(field, newResponse);
   }
 
@@ -229,10 +229,10 @@ public class EditRecordViewModel extends AbstractViewModel {
     return getChanges(r).collect(toImmutableList());
   }
 
-  private Stream<ResponseUpdate> getChanges(Record r, Field field) {
+  private Stream<ResponseUpdate> getChanges(Record record, Field field) {
     String fieldId = field.getId();
-    Optional<Response> originalResponse = r.getResponse(fieldId);
-    Optional<Response> currentResponse = getResponse(fieldId).filter(v -> !v.isEmpty());
+    Optional<Response> originalResponse = record.getResponse(fieldId);
+    Optional<Response> currentResponse = getResponse(fieldId).filter(r -> !r.isEmpty());
     if (currentResponse.equals(originalResponse)) {
       return stream(Collections.emptyList());
     }
@@ -270,7 +270,7 @@ public class EditRecordViewModel extends AbstractViewModel {
 
   private void updateError(Field field, Optional<Response> response) {
     String key = field.getId();
-    if (field.isRequired() && !response.filter(v -> !v.isEmpty()).isPresent()) {
+    if (field.isRequired() && !response.filter(r -> !r.isEmpty()).isPresent()) {
       Log.d(TAG, "Missing: " + key);
       errors.put(field.getId(), resources.getString(R.string.required_field));
     } else {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/MultiSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/MultiSelectDialogFactory.java
@@ -73,12 +73,12 @@ class MultiSelectDialogFactory {
       checkedItems = new boolean[options.size()];
       // TODO: Check cast.
       initialResponse.ifPresent(
-          v ->
+          response ->
               IntStreams.range(0, options.size())
                   .forEach(
                       i ->
                           checkedItems[i] =
-                              ((MultipleChoiceResponse) v).isSelected(options.get(i))));
+                              ((MultipleChoiceResponse) response).isSelected(options.get(i))));
     }
 
     private Optional<Response> getSelectedValues(List<Option> options) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/MultiSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/MultiSelectDialogFactory.java
@@ -41,18 +41,20 @@ class MultiSelectDialogFactory {
   }
 
   AlertDialog create(
-      Field field, Optional<Response> initialValue, Consumer<Optional<Response>> valueChangeCallback) {
+      Field field,
+      Optional<Response> initialResponse,
+      Consumer<Optional<Response>> responseChangeCallback) {
     MultipleChoice multipleChoice = field.getMultipleChoice();
     AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
     List<Option> options = multipleChoice.getOptions();
-    final DialogState state = new DialogState(multipleChoice, initialValue);
+    final DialogState state = new DialogState(multipleChoice, initialResponse);
     dialogBuilder.setMultiChoiceItems(
         getLabels(multipleChoice), state.checkedItems, (dialog, which, isChecked) -> {});
     dialogBuilder.setCancelable(false);
     dialogBuilder.setTitle(field.getLabel());
     dialogBuilder.setPositiveButton(
         R.string.apply_multiple_choice_changes,
-        (dialog, which) -> valueChangeCallback.accept(state.getSelectedValues(options)));
+        (dialog, which) -> responseChangeCallback.accept(state.getSelectedValues(options)));
     dialogBuilder.setNegativeButton(
         R.string.discard_multiple_choice_changes, (dialog, which) -> {});
     return dialogBuilder.create();
@@ -66,15 +68,17 @@ class MultiSelectDialogFactory {
 
     private boolean[] checkedItems;
 
-    public DialogState(MultipleChoice multipleChoice, Optional<Response> initialValue) {
+    public DialogState(MultipleChoice multipleChoice, Optional<Response> initialResponse) {
       ImmutableList<Option> options = multipleChoice.getOptions();
       checkedItems = new boolean[options.size()];
       // TODO: Check cast.
-      initialValue.ifPresent(
+      initialResponse.ifPresent(
           v ->
               IntStreams.range(0, options.size())
                   .forEach(
-                      i -> checkedItems[i] = ((MultipleChoiceResponse) v).isSelected(options.get(i))));
+                      i ->
+                          checkedItems[i] =
+                              ((MultipleChoiceResponse) v).isSelected(options.get(i))));
     }
 
     private Optional<Response> getSelectedValues(List<Option> options) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/MultiSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/MultiSelectDialogFactory.java
@@ -73,12 +73,12 @@ class MultiSelectDialogFactory {
       checkedItems = new boolean[options.size()];
       // TODO: Check cast.
       initialResponse.ifPresent(
-          response ->
+          r ->
               IntStreams.range(0, options.size())
                   .forEach(
                       i ->
                           checkedItems[i] =
-                              ((MultipleChoiceResponse) response).isSelected(options.get(i))));
+                              ((MultipleChoiceResponse) r).isSelected(options.get(i))));
     }
 
     private Optional<Response> getSelectedValues(List<Option> options) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/MultiSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/MultiSelectDialogFactory.java
@@ -23,8 +23,8 @@ import com.google.android.gnd.R;
 import com.google.android.gnd.vo.Form.Field;
 import com.google.android.gnd.vo.Form.MultipleChoice;
 import com.google.android.gnd.vo.Form.MultipleChoice.Option;
-import com.google.android.gnd.vo.Record.MultipleChoiceValue;
-import com.google.android.gnd.vo.Record.Value;
+import com.google.android.gnd.vo.Record.MultipleChoiceResponse;
+import com.google.android.gnd.vo.Record.Response;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java8.util.Optional;
@@ -41,7 +41,7 @@ class MultiSelectDialogFactory {
   }
 
   AlertDialog create(
-      Field field, Optional<Value> initialValue, Consumer<Optional<Value>> valueChangeCallback) {
+      Field field, Optional<Response> initialValue, Consumer<Optional<Response>> valueChangeCallback) {
     MultipleChoice multipleChoice = field.getMultipleChoice();
     AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
     List<Option> options = multipleChoice.getOptions();
@@ -66,7 +66,7 @@ class MultiSelectDialogFactory {
 
     private boolean[] checkedItems;
 
-    public DialogState(MultipleChoice multipleChoice, Optional<Value> initialValue) {
+    public DialogState(MultipleChoice multipleChoice, Optional<Response> initialValue) {
       ImmutableList<Option> options = multipleChoice.getOptions();
       checkedItems = new boolean[options.size()];
       // TODO: Check cast.
@@ -74,17 +74,17 @@ class MultiSelectDialogFactory {
           v ->
               IntStreams.range(0, options.size())
                   .forEach(
-                      i -> checkedItems[i] = ((MultipleChoiceValue) v).isSelected(options.get(i))));
+                      i -> checkedItems[i] = ((MultipleChoiceResponse) v).isSelected(options.get(i))));
     }
 
-    private Optional<Value> getSelectedValues(List<Option> options) {
+    private Optional<Response> getSelectedValues(List<Option> options) {
       ImmutableList.Builder<String> choices = new ImmutableList.Builder<>();
       for (int i = 0; i < options.size(); i++) {
         if (checkedItems[i]) {
           choices.add(options.get(i).getCode());
         }
       }
-      return MultipleChoiceValue.fromList(choices.build());
+      return MultipleChoiceResponse.fromList(choices.build());
     }
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editrecord/SingleSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editrecord/SingleSelectDialogFactory.java
@@ -24,8 +24,8 @@ import com.google.android.gnd.R;
 import com.google.android.gnd.vo.Form.Field;
 import com.google.android.gnd.vo.Form.MultipleChoice;
 import com.google.android.gnd.vo.Form.MultipleChoice.Option;
-import com.google.android.gnd.vo.Record.MultipleChoiceValue;
-import com.google.android.gnd.vo.Record.Value;
+import com.google.android.gnd.vo.Record.MultipleChoiceResponse;
+import com.google.android.gnd.vo.Record.Response;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java8.util.Optional;
@@ -41,7 +41,7 @@ class SingleSelectDialogFactory {
   }
 
   AlertDialog create(
-      Field field, Optional<Value> initialValue, Consumer<Optional<Value>> valueChangeCallback) {
+      Field field, Optional<Response> initialValue, Consumer<Optional<Response>> valueChangeCallback) {
     MultipleChoice multipleChoice = field.getMultipleChoice();
     AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
     List<Option> options = multipleChoice.getOptions();
@@ -66,12 +66,12 @@ class SingleSelectDialogFactory {
 
     private int checkedItem;
 
-    public DialogState(MultipleChoice multipleChoice, Optional<Value> initialValue) {
+    public DialogState(MultipleChoice multipleChoice, Optional<Response> initialValue) {
       // TODO: Check type.
       checkedItem =
           initialValue
-              .map(MultipleChoiceValue.class::cast)
-              .flatMap(MultipleChoiceValue::getFirstCode)
+              .map(MultipleChoiceResponse.class::cast)
+              .flatMap(MultipleChoiceResponse::getFirstCode)
               .flatMap(multipleChoice::getIndex)
               .orElse(-1);
     }
@@ -86,10 +86,10 @@ class SingleSelectDialogFactory {
       }
     }
 
-    private Optional<Value> getSelectedValue(Field field, List<Option> options) {
+    private Optional<Response> getSelectedValue(Field field, List<Option> options) {
       if (checkedItem >= 0) {
         return Optional.of(
-            new MultipleChoiceValue(ImmutableList.of((options.get(checkedItem).getCode()))));
+            new MultipleChoiceResponse(ImmutableList.of((options.get(checkedItem).getCode()))));
       } else {
         return Optional.empty();
       }

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListItemViewHolder.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListItemViewHolder.java
@@ -35,7 +35,7 @@ import com.google.android.gnd.vo.Form;
 import com.google.android.gnd.vo.Form.Element;
 import com.google.android.gnd.vo.Form.Field;
 import com.google.android.gnd.vo.Record;
-import com.google.android.gnd.vo.Record.Value;
+import com.google.android.gnd.vo.Record.Response;
 import java.text.DateFormat;
 import java.util.Date;
 import java8.util.Optional;
@@ -94,7 +94,7 @@ class RecordListItemViewHolder extends RecyclerView.ViewHolder {
       switch (elem.getType()) {
         case FIELD:
           Field field = elem.getField();
-          Optional<Value> value = Optional.ofNullable(record.getValueMap().get(field.getId()));
+          Optional<Response> value = Optional.ofNullable(record.getResponseMap().get(field.getId()));
           fieldLabelRow.addView(
               newFieldTextView(field.getLabel(), R.style.RecordListText_FieldLabel));
           fieldValueRow.addView(

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListItemViewHolder.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListItemViewHolder.java
@@ -16,17 +16,17 @@
 
 package com.google.android.gnd.ui.home.featuresheet;
 
-import androidx.lifecycle.MutableLiveData;
 import android.content.Context;
 import android.content.res.Resources;
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils.TruncateAt;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TableRow;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.lifecycle.MutableLiveData;
+import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import com.google.android.gnd.R;
@@ -94,12 +94,13 @@ class RecordListItemViewHolder extends RecyclerView.ViewHolder {
       switch (elem.getType()) {
         case FIELD:
           Field field = elem.getField();
-          Optional<Response> value = Optional.ofNullable(record.getResponseMap().get(field.getId()));
+          Optional<Response> response =
+              Optional.ofNullable(record.getResponseMap().get(field.getId()));
           fieldLabelRow.addView(
               newFieldTextView(field.getLabel(), R.style.RecordListText_FieldLabel));
           fieldValueRow.addView(
               newFieldTextView(
-                  value.map(v -> v.getSummaryText(field)).orElse(""),
+                  response.map(r -> r.getSummaryText(field)).orElse(""),
                   R.style.RecordListText_Field));
           break;
       }

--- a/gnd/src/main/java/com/google/android/gnd/ui/projectselector/ProjectSelectorViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/projectselector/ProjectSelectorViewModel.java
@@ -48,7 +48,7 @@ public class ProjectSelectorViewModel extends AbstractViewModel {
         authManager
             .getUser()
             .flatMap(user -> dataRepository.getProjectSummaries(user))
-            .subscribe(v -> projectSummaries.setValue(v)));
+            .subscribe(summaries -> projectSummaries.setValue(summaries)));
   }
 
   public LiveData<Resource<List<Project>>> getProjectSummaries() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
@@ -17,8 +17,6 @@
 package com.google.android.gnd.ui.recorddetails;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -28,11 +26,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import com.google.android.gnd.databinding.RecordDetailsFragBinding;
 import com.google.android.gnd.MainActivity;
 import com.google.android.gnd.R;
+import com.google.android.gnd.databinding.RecordDetailsFragBinding;
 import com.google.android.gnd.inject.ActivityScoped;
 import com.google.android.gnd.repository.Resource;
 import com.google.android.gnd.ui.common.AbstractFragment;
@@ -148,7 +148,7 @@ public class RecordDetailsFragment extends AbstractFragment {
     fieldViewHolder.setLabel(field.getLabel());
     record
         .getResponse(field.getId())
-        .map(v -> v.getDetailsText(field))
+        .map(r -> r.getDetailsText(field))
         .ifPresent(fieldViewHolder::setValue);
     recordDetailsLayout.addView(fieldViewHolder.getRoot());
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/recorddetails/RecordDetailsFragment.java
@@ -147,7 +147,7 @@ public class RecordDetailsFragment extends AbstractFragment {
     FieldViewHolder fieldViewHolder = FieldViewHolder.newInstance(getLayoutInflater());
     fieldViewHolder.setLabel(field.getLabel());
     record
-        .getValue(field.getId())
+        .getResponse(field.getId())
         .map(v -> v.getDetailsText(field))
         .ifPresent(fieldViewHolder::setValue);
     recordDetailsLayout.addView(fieldViewHolder.getRoot());

--- a/gnd/src/main/java/com/google/android/gnd/vo/FeatureUpdate.java
+++ b/gnd/src/main/java/com/google/android/gnd/vo/FeatureUpdate.java
@@ -16,7 +16,7 @@
 
 package com.google.android.gnd.vo;
 
-import com.google.android.gnd.vo.Record.Value;
+import com.google.android.gnd.vo.Record.Response;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.Date;
@@ -64,7 +64,7 @@ public abstract class FeatureUpdate {
 
     public abstract Operation getOperation();
 
-    public abstract ImmutableList<ValueUpdate> getValueUpdates();
+    public abstract ImmutableList<ResponseUpdate> getResponseUpdates();
 
     public static Builder newBuilder() {
       return new AutoValue_FeatureUpdate_RecordUpdate.Builder();
@@ -76,33 +76,34 @@ public abstract class FeatureUpdate {
 
       public abstract Builder setOperation(Operation newOperation);
 
-      public abstract Builder setValueUpdates(ImmutableList<ValueUpdate> newValueUpdatesList);
+      public abstract Builder setResponseUpdates(
+          ImmutableList<ResponseUpdate> newResponseUpdatesList);
 
       public abstract RecordUpdate build();
     }
 
     @AutoValue
-    public abstract static class ValueUpdate {
+    public abstract static class ResponseUpdate {
       public abstract String getElementId();
 
-      public abstract Optional<Value> getValue();
+      public abstract Optional<Response> getResponse();
 
       public abstract Operation getOperation();
 
       public static Builder newBuilder() {
-        return new AutoValue_FeatureUpdate_RecordUpdate_ValueUpdate.Builder()
-            .setValue(Optional.empty());
+        return new AutoValue_FeatureUpdate_RecordUpdate_ResponseUpdate.Builder()
+            .setResponse(Optional.empty());
       }
 
       @AutoValue.Builder
       public abstract static class Builder {
         public abstract Builder setElementId(String newElementId);
 
-        public abstract Builder setValue(Optional<Value> newValue);
+        public abstract Builder setResponse(Optional<Response> newResponse);
 
         public abstract Builder setOperation(Operation newOperation);
 
-        public abstract ValueUpdate build();
+        public abstract ResponseUpdate build();
       }
     }
   }

--- a/gnd/src/main/java/com/google/android/gnd/vo/Record.java
+++ b/gnd/src/main/java/com/google/android/gnd/vo/Record.java
@@ -55,14 +55,14 @@ public abstract class Record {
   @Nullable
   public abstract Timestamps getClientTimestamps();
 
-  public abstract ImmutableMap<String, Value> getValueMap();
+  public abstract ImmutableMap<String, Response> getResponseMap();
 
   public static Builder newBuilder() {
     return new AutoValue_Record.Builder();
   }
 
-  public Optional<Value> getValue(String id) {
-    return Optional.ofNullable(getValueMap().get(id));
+  public Optional<Response> getValue(String id) {
+    return Optional.ofNullable(getResponseMap().get(id));
   }
 
   public abstract Record.Builder toBuilder();
@@ -85,39 +85,39 @@ public abstract class Record {
 
     public abstract Builder setClientTimestamps(@Nullable Timestamps newClientTimestamps);
 
-    public abstract ImmutableMap.Builder<String, Value> valueMapBuilder();
+    public abstract ImmutableMap.Builder<String, Response> responseMapBuilder();
 
-    public Builder putValue(String id, Value value) {
-      valueMapBuilder().put(id, value);
+    public Builder putResponse(String id, Response response) {
+      responseMapBuilder().put(id, response);
       return this;
     }
 
-    public Builder putAllValues(Map<String, Value> values) {
-      valueMapBuilder().putAll(values);
+    public Builder putAllResponses(Map<String, Response> responses) {
+      responseMapBuilder().putAll(responses);
       return this;
     }
 
     public abstract Record build();
   }
 
-  public interface Value {
+  public interface Response {
 
     String getSummaryText(Field field);
 
     String getDetailsText(Field field);
 
-    static String toString(Optional<Value> value) {
-      return value.map(Value::toString).orElse("");
+    static String toString(Optional<Response> response) {
+      return response.map(Response::toString).orElse("");
     }
 
     boolean isEmpty();
   }
 
-  public static class TextValue implements Value {
+  public static class TextResponse implements Response {
 
     private String text;
 
-    public TextValue(String text) {
+    public TextResponse(String text) {
       this.text = text;
     }
 
@@ -142,10 +142,10 @@ public abstract class Record {
 
     @Override
     public boolean equals(Object obj) {
-      if (obj == null || !(obj instanceof TextValue)) {
+      if (obj == null || !(obj instanceof TextResponse)) {
         return false;
       }
-      return text.equals(((TextValue) obj).text);
+      return text.equals(((TextResponse) obj).text);
     }
 
     @Override
@@ -158,16 +158,16 @@ public abstract class Record {
       return text;
     }
 
-    public static Optional<Value> fromString(String text) {
-      return text.isEmpty() ? Optional.empty() : Optional.of(new TextValue(text));
+    public static Optional<Response> fromString(String text) {
+      return text.isEmpty() ? Optional.empty() : Optional.of(new TextResponse(text));
     }
   }
 
-  public static class MultipleChoiceValue implements Value {
+  public static class MultipleChoiceResponse implements Response {
 
     private List<String> choices;
 
-    public MultipleChoiceValue(List<String> choices) {
+    public MultipleChoiceResponse(List<String> choices) {
       this.choices = choices;
     }
 
@@ -205,10 +205,10 @@ public abstract class Record {
 
     @Override
     public boolean equals(Object obj) {
-      if (obj == null || !(obj instanceof MultipleChoiceValue)) {
+      if (obj == null || !(obj instanceof MultipleChoiceResponse)) {
         return false;
       }
-      return choices.equals(((MultipleChoiceValue) obj).choices);
+      return choices.equals(((MultipleChoiceResponse) obj).choices);
     }
 
     @Override
@@ -221,11 +221,11 @@ public abstract class Record {
       return stream(choices).sorted().collect(Collectors.joining(","));
     }
 
-    public static Optional<Value> fromList(List<String> codes) {
+    public static Optional<Response> fromList(List<String> codes) {
       if (codes.isEmpty()) {
         return Optional.empty();
       } else {
-        return Optional.of(new MultipleChoiceValue(codes));
+        return Optional.of(new MultipleChoiceResponse(codes));
       }
     }
   }

--- a/gnd/src/main/java/com/google/android/gnd/vo/Record.java
+++ b/gnd/src/main/java/com/google/android/gnd/vo/Record.java
@@ -190,7 +190,7 @@ public abstract class Record {
     // TODO: Make these inner classes non-static and access Form directly.
     public String getDetailsText(Field field) {
       return stream(choices)
-          .map(v -> field.getMultipleChoice().getOption(v))
+          .map(code -> field.getMultipleChoice().getOption(code))
           .filter(Optional::isPresent)
           .map(Optional::get)
           .map(Option::getLabel)

--- a/gnd/src/main/java/com/google/android/gnd/vo/Record.java
+++ b/gnd/src/main/java/com/google/android/gnd/vo/Record.java
@@ -61,7 +61,7 @@ public abstract class Record {
     return new AutoValue_Record.Builder();
   }
 
-  public Optional<Response> getValue(String id) {
+  public Optional<Response> getResponse(String id) {
     return Optional.ofNullable(getResponseMap().get(id));
   }
 

--- a/gnd/src/main/res/layout/multiple_choice_input_field.xml
+++ b/gnd/src/main/res/layout/multiple_choice_input_field.xml
@@ -58,7 +58,7 @@
         android:editable="false"
         android:focusable="true"
         android:focusableInTouchMode="true"
-        android:text="@{viewModel.values[field.id]}"
+        android:text="@{viewModel.responses[field.id]}"
         android:textColor="@color/field_value"
         app:errorText="@{viewModel.errors[field.id]}"
         tools:text="One, two, three, four, five"/>

--- a/gnd/src/main/res/layout/text_input_field.xml
+++ b/gnd/src/main/res/layout/text_input_field.xml
@@ -50,7 +50,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:maxLines="1"
-          android:text="@{viewModel.values[field.id]}"
+          android:text="@{viewModel.responses[field.id]}"
           app:errorText="@{viewModel.errors[field.id]}"
           app:onTextChanged="@{s -> viewModel.onTextChanged(field, (String) s)}"
           app:onFocusChange="@{(v, hasFocus) -> viewModel.onFocusChange(field, hasFocus)}"


### PR DESCRIPTION
Also, the meaning of "Value" is broad and conflicts with other symbols. This became apparent when implementing local db support because edits can refer to user responses but also changes to featute coordinates, for example.