### PR TITLE
Warn against unwitting PR commits in the README (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ changes reviewed and merged into the base repository. Reference the
 [issue](https://github.com/google/ground-android/issues) your changes resolve in
 either the commit message for your changes or in your pull request.
     
-    > :exclamation: Any changes you subsequently commit to the branch you used
+    > :exclamation: Any subsequent changes committed to the branch you used
     > to open your PR are automatically included in the PR. If you've opened a
-    > PR but would like to continue to make other unrelated changes, be sure to
-    > start a new branch to track those change and follow this workflow.
+    > PR but would like to continue to work on unrelated changes, be sure to
+    > start a new branch to track those changes. 
 
     For more information on creating pull requests, see
     <https://help.github.com/articles/creating-a-pull-request/>. 

--- a/README.md
+++ b/README.md
@@ -3,26 +3,26 @@
 Ground is a free, map-centric data collection platform for occasionally
 connected devices.
 
-This is not an officially supported Google product; it is currently
-being developed by volunteers on a best-effort basis.
+This is not an officially supported Google product; it is currently being
+developed by volunteers on a best-effort basis.
 
 ## Contributing
 
 First, read the [contribution guidelines](CONTRIBUTING.md). Ensure you
-understand the code review and community guidelines and have signed 
-the appropriate [CLA](https://cla.developers.google.com/). 
+understand the code review and community guidelines and have signed the
+appropriate [CLA](https://cla.developers.google.com/). 
 
-> :exclamation: We cannot accept contributions from contributors that 
-> have not signed the appropriate CLA, so please be sure to sign one 
-> before submitting your hard work!
+> :exclamation: We cannot accept contributions from contributors that have not
+> signed the appropriate CLA, so please be sure to sign one before submitting
+> your hard work!
 
-After you have read and understood the contribution guidelines, read the 
+After you have read and understood the contribution guidelines, read the
 following sections to learn how to fork this repository and contribute.
 
 ### Setup
 
-The following instructions describe how to fork this repository in order 
-to contribute to the ground-android codebase.
+The following instructions describe how to fork this repository in order to
+contribute to the ground-android codebase.
 
 1. Fork this repository, see <https://help.github.com/articles/fork-a-repo/>.
 
@@ -36,13 +36,15 @@ to contribute to the ground-android codebase.
     
     `git remote add upstream https://github.com/google/ground-android.git`
 
-4. Follow the instructions under the [Initial build configuration](#initial-build-configuration) section of this readme to set up your development environment.
+4. Follow the instructions under the [Initial build
+configuration](#initial-build-configuration) section of this readme to set up
+your development environment.
 
 ### Development Workflow
 
-After you have forked and cloned the repository, use the following steps to
-make and manage changes. After you have finished making changes, you can 
-submit them to the base repository using a pull request. 
+After you have forked and cloned the repository, use the following steps to make
+and manage changes. After you have finished making changes, you can submit them
+to the base repository using a pull request. 
 
 1. Pull changes from the base repository's master branch:
     
@@ -63,7 +65,8 @@ submit them to the base repository using a pull request.
     
     Where `<files>` are the files you changed.
     
-    > **Note:** Run `git add .` to add all currently modified files to the staging area.
+    > **Note:** Run `git add .` to add all currently modified files to the
+    > staging area.
 
 1. Commit your changes:
     
@@ -73,7 +76,7 @@ submit them to the base repository using a pull request.
     your changes.
 
 1. Pull changes from the base repository's master branch, resolve conflicts if
-   necessary:
+necessary:
       
     `git pull upstream master`
 
@@ -83,12 +86,23 @@ submit them to the base repository using a pull request.
     
     Where `<branch>` is the branch name you used in step 2.
 
-1. Create a [pull request](https://help.github.com/articles/about-pull-requests/) to have your changes reviewed and merged into the base 
-repository. Reference the [issue](https://github.com/google/ground-android/issues) your changes resolve in either the commit message for your changes or in your pull request. 
-
-    For more information on creating pull requests, see <https://help.github.com/articles/creating-a-pull-request/>. 
+1. Create a [pull
+request](https://help.github.com/articles/about-pull-requests/) to have your
+changes reviewed and merged into the base repository. Reference the
+[issue](https://github.com/google/ground-android/issues) your changes resolve in
+either the commit message for your changes or in your pull request.
     
-    To learn more about referencing issues in your pull request or commit messages, see <https://help.github.com/articles/closing-issues-using-keywords/>.
+    > :exclamation: Any changes you subsequently commit to the branch you used
+    > to open your PR are automatically included in the PR. If you've opened a
+    > PR but would like to continue to make other unrelated changes, be sure to
+    > start a new branch to track those change and follow this workflow.
+
+    For more information on creating pull requests, see
+    <https://help.github.com/articles/creating-a-pull-request/>. 
+    
+    To learn more about referencing issues in your pull request or commit
+    messages, see
+    <https://help.github.com/articles/closing-issues-using-keywords/>.
 1. Celebrate!
 
 ## Initial build configuration
@@ -103,28 +117,24 @@ following the instructions at:
 In `gnd/src/debug/res/values` and `gnd/src/release/res/values` create
 `google_maps_api.xml` with the following contents:
 
-``` xml
-<resources>
-  <string name="google_maps_key" templateMergeStrategy="preserve"
-  translatable="false">API_KEY</string>
-</resources>
-```
+``` xml <resources> <string name="google_maps_key"
+templateMergeStrategy="preserve" translatable="false">API_KEY</string>
+</resources> ```
 
-In `gnd/src/debug/res/values` replace `API_KEY` with your Google Maps debug API key. In `gnd/src/release/res/values` replace
-`API_KEY` with your Google Maps release API key.
+In `gnd/src/debug/res/values` replace `API_KEY` with your Google Maps debug API
+key. In `gnd/src/release/res/values` replace `API_KEY` with your Google Maps
+release API key.
 
-Verify the SHA-1 certificate fingerprint described in the API key generation instructions is  
-registered with package name `com.google.android.gnd`. To check, visit
+Verify the SHA-1 certificate fingerprint described in the API key generation
+instructions is  registered with package name `com.google.android.gnd`. To
+check, visit
 
   https://console.cloud.google.com/apis/credentials
 
 To view the SHA-1 of the debug key generated by Android Studio run:
 
-```
-$ keytool -list -v -keystore "$HOME/.android/debug.keystore" \
-  -alias androiddebugkey \
-  -storepass android -keypass android
-```
+``` $ keytool -list -v -keystore "$HOME/.android/debug.keystore" \ -alias
+androiddebugkey \ -storepass android -keypass android ```
 
 ### Set up Firebase
 


### PR DESCRIPTION
Thankfully, we already recommend creating a new branch for each PR in step two. I've added a note warning readers about open PRs and automatic commit inclusion—hopefully this makes it clear. Presumably this is the proper place for it in the flow, as it comes in when the developer has completed a logical  group of changes. 

The note in question starts at line 95.

Fixes #42