### PR TITLE
Fix Leaky Subscriptions in the Home Screen

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: 'com.android.application'
 
 project.ext {
-    autoDisposeVersion = "0.8.0"
+    autoDisposeVersion = "1.2.0"
     autoValueVersion = "1.6"
     butterKnifeVersion = "10.1.0"
     constraintLayoutVersion = "1.0.2"
@@ -30,11 +30,11 @@ project.ext {
     junitVersion = "4.12"
     lifecycleVersion = "2.0.0-beta01"
     navigationVersion = "1.0.0-alpha05"
-    rxAndroidVersion = "2.0.1"
+    rxAndroidVersion = "2.1.1"
     rxBindingVersion = "2.1.1"
     rxFirebaseVersion = "1.5.0"
-    rxJava2DebugVersion = "1.2.2"
-    rxJavaVersion = "2.1.6"
+    rxJava2DebugVersion = "1.4.0"
+    rxJavaVersion = "2.2.8"
     streamSupportVersion = "1.6.3"
     supportLibraryVersion = "1.0.0-beta01"
     tabLayoutHelper = "0.9.0"

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -117,7 +117,7 @@ public class HomeScreenFragment extends AbstractFragment
   private HomeScreenViewModel viewModel;
   private MapContainerFragment mapContainerFragment;
   private BottomSheetBehavior<View> bottomSheetBehavior;
-  private PublishSubject<FragmentManager> showFeatureDialogRequests;
+  private PublishSubject<Object> showFeatureDialogRequests;
 
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -133,11 +133,10 @@ public class HomeScreenFragment extends AbstractFragment
 
     showFeatureDialogRequests = PublishSubject.create();
 
-    Observable<Feature> featureStream =
-        showFeatureDialogRequests.flatMapMaybe(
-            fragmentManager -> addFeatureDialogFragment.show(fragmentManager));
-
-    featureStream.as(autoDisposable(this)).subscribe(viewModel::addFeature);
+    showFeatureDialogRequests
+        .flatMapMaybe(__ -> addFeatureDialogFragment.show(getChildFragmentManager()))
+        .as(autoDisposable(this))
+        .subscribe(viewModel::addFeature);
   }
 
   @Nullable
@@ -284,7 +283,7 @@ public class HomeScreenFragment extends AbstractFragment
     }
     // TODO: Pause location updates while dialog is open.
     // TODO: Show spinner?
-    showFeatureDialogRequests.onNext(getChildFragmentManager());
+    showFeatureDialogRequests.onNext(new Object());
   }
 
   private void onFeatureSheetStateChange(FeatureSheetState state) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -134,7 +134,7 @@ public class HomeScreenFragment extends AbstractFragment
     showFeatureDialogRequests = PublishSubject.create();
 
     showFeatureDialogRequests
-        .flatMapMaybe(__ -> addFeatureDialogFragment.show(getChildFragmentManager()))
+        .switchMapMaybe(__ -> addFeatureDialogFragment.show(getChildFragmentManager()))
         .as(autoDisposable(this))
         .subscribe(viewModel::addFeature);
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -70,7 +70,8 @@ public class HomeScreenViewModel extends AbstractViewModel {
   }
 
   private void onAddFeatureError(Throwable throwable) {
-    Log.d(TAG, "Couldn't add feature.");
+    //TODO: Show an error message to the user.
+    Log.e(TAG, "Couldn't add feature.", throwable);
   }
 
   public LiveData<Void> getOpenDrawerRequests() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -70,7 +70,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
   }
 
   private void onAddFeatureError(Throwable throwable) {
-    //TODO: Show an error message to the user.
+    // TODO: Show an error message to the user.
     Log.e(TAG, "Couldn't add feature.", throwable);
   }
 


### PR DESCRIPTION
This change introduces the Result wrapper and fixes leaky subscriptions in the HomsScreenViewModel and HomeScreenFragment. 

I've opted to branch off and open separate PRs as I think it will be easier to go back and review each segment of change this way. I'm cherry-picking my existing work from the original pr-fix-leaky-subscriptions branch.

Counts toward #24 
