### PR TITLE
Plumb leaky subscriptions in the RecordListViewModel

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/rx/Result.java
+++ b/gnd/src/main/java/com/google/android/gnd/rx/Result.java
@@ -16,9 +16,10 @@
 
 package com.google.android.gnd.rx;
 
-import androidx.annotation.NonNull;
 import io.reactivex.Single;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
 import javax.annotation.Nullable;
 
 public class Result<T> {
@@ -61,11 +62,12 @@ public class Result<T> {
     return error;
   }
 
-  public static <T> Single<Result<T>> wrap(Single<T> single) {
-    return single.map(Result::success).onErrorReturn(Result::error);
+  public static <T, R> Function<T, Single<Result<R>>> wrapErrors(
+      @NonNull Function<T, Single<R>> fn) {
+    return (T value) -> fn.apply(value).map(Result::success).onErrorReturn(Result::error);
   }
 
-  public static <T> Consumer<? super Result<T>> unwrap(
+  public static <T> Consumer<? super Result<T>> unwrapErrors(
       Consumer<T> onSuccess, Consumer<Throwable> onError) {
     return result -> {
       switch (result.getState()) {

--- a/gnd/src/main/java/com/google/android/gnd/rx/Result.java
+++ b/gnd/src/main/java/com/google/android/gnd/rx/Result.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gnd.rx;
+
+import androidx.annotation.NonNull;
+import io.reactivex.Single;
+import io.reactivex.functions.Consumer;
+import javax.annotation.Nullable;
+
+public class Result<T> {
+  public enum State {
+    SUCCESS,
+    ERROR
+  }
+
+  private final State state;
+
+  @Nullable private final T value;
+  @Nullable private final Throwable error;
+
+  private Result(State state, @Nullable T value, @Nullable Throwable error) {
+    this.state = state;
+    this.value = value;
+    this.error = error;
+  }
+
+  public static <T> Result<T> success(@NonNull T result) {
+    return new Result<>(State.SUCCESS, result, null);
+  }
+
+  public static <T> Result<T> error(@NonNull Throwable t) {
+    return new Result<>(State.ERROR, null, t);
+  }
+
+  @Nullable
+  public State getState() {
+    return state;
+  }
+
+  @Nullable
+  public T get() {
+    return value;
+  }
+
+  @Nullable
+  public Throwable getError() {
+    return error;
+  }
+
+  public static <T> Single<Result<T>> wrap(Single<T> single) {
+    return single.map(Result::success).onErrorReturn(Result::error);
+  }
+
+  public static <T> Consumer<? super Result<T>> unwrap(
+      Consumer<T> onSuccess, Consumer<Throwable> onError) {
+    return result -> {
+      switch (result.getState()) {
+        case SUCCESS:
+          onSuccess.accept(result.get());
+          break;
+        case ERROR:
+          onError.accept(result.getError());
+          break;
+      }
+    };
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListViewModel.java
@@ -105,9 +105,9 @@ public class RecordListViewModel extends AbstractViewModel {
   }
 
   class RecordSummaryRequest {
-    public Project project;
-    public String featureId;
-    public String formId;
+    public final Project project;
+    public final String featureId;
+    public final String formId;
 
     public RecordSummaryRequest(Project project, String featureId, String formId) {
       this.project = project;

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListViewModel.java
@@ -39,6 +39,7 @@ import java8.util.stream.Collectors;
 import javax.inject.Inject;
 
 // TODO: Roll up into parent viewmodel. Simplify VMs overall.
+// TODO(#71): Simplify VM project, form, and feature access.
 public class RecordListViewModel extends AbstractViewModel {
 
   private static final String TAG = RecordListViewModel.class.getSimpleName();

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListViewModel.java
@@ -20,7 +20,6 @@ import android.util.Log;
 
 import static java8.util.stream.StreamSupport.stream;
 
-import androidx.core.util.Pair;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import com.google.android.gnd.repository.DataRepository;
@@ -32,13 +31,8 @@ import com.google.android.gnd.vo.Project;
 import com.google.android.gnd.vo.Record;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.Flowable;
 import io.reactivex.Single;
-import io.reactivex.processors.BehaviorProcessor;
 import io.reactivex.subjects.PublishSubject;
 import java8.util.Optional;
 import java8.util.stream.Collectors;

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/RecordListViewModel.java
@@ -85,6 +85,7 @@ public class RecordListViewModel extends AbstractViewModel {
    *     provided in the request.
    */
   private Single<List<Record>> fetchRecordSummaries(RecordSummaryRequest request) {
+    // TODO: Only fetch records with current formId.
     return dataRepository
         .getRecordSummaries(request.project.getId(), request.featureId)
         .map(


### PR DESCRIPTION
Fixed leaky subscriptions in the record list view model. 

Note: I've cherry picked in the Result wrapper--what I should have done, was push those changes to issue-24/master separately, but I started down the wrong path by cherry-picking them into the home screen fragment/view model fixes branch, thus leaving me to pick the same cherries over and over in subsequent branches *sigh*. Oh well, lesson learned. 

Hopefully the approach to naming here is an improvement over the initial PRs!

Contributes toward #24 