### PR TITLE
Map Container: Remove extra subscription

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -145,8 +145,6 @@ public class MapContainerFragment extends AbstractFragment {
   public void onActivityCreated(@Nullable Bundle savedInstanceState) {
     super.onActivityCreated(savedInstanceState);
     mainViewModel.getWindowInsets().observe(this, this::onApplyWindowInsets);
-    // TODO(#24): Fix leaky subscriptions!
-    mapProvider.getMapAdapter().as(autoDisposable(this)).subscribe(this::onMapReady);
   }
 
   private void onFeatureSheetStateChange(FeatureSheetState state, MapAdapter map) {


### PR DESCRIPTION
Last teeny bit needed to close out issue #24!

After resolving this leaky subscription originally, I missed a leftover subscription to the mapAdapter. I've now removed it, taking care of the last #24 TODO.