### PR TITLE
Mapbox: Setup initial mapbox db classes

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -30,6 +30,7 @@ project.ext {
     junitVersion = "4.12"
     lifecycleVersion = "2.0.0-beta01"
     navigationVersion = "1.0.0-alpha05"
+    roomVersion = "2.1.0-rc01"
     rxAndroidVersion = "2.1.1"
     rxBindingVersion = "2.1.1"
     rxFirebaseVersion = "1.5.0"
@@ -149,6 +150,10 @@ dependencies {
 
     // Guava
     implementation "com.google.guava:guava:$project.guavaVersion"
+
+    //Room
+    implementation "androidx.room:room-runtime:$project.roomVersion"
+    implementation "androidx.room:room-rxjava2:$project.roomVersion"
 
     // Testing
     testImplementation "junit:junit:$project.junitVersion"

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/MapboxDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/MapboxDatabase.java
@@ -1,0 +1,17 @@
+package com.google.android.gnd.mapbox;
+
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
+
+import com.google.android.gnd.mapbox.entity.Grid;
+import com.google.android.gnd.mapbox.entity.GridData;
+import com.google.android.gnd.mapbox.entity.Metadata;
+import com.google.android.gnd.mapbox.entity.Tile;
+
+@Database(
+    version = 1,
+    entities = {Metadata.class, Tile.class, Grid.class, GridData.class})
+abstract class MapboxDatabase extends RoomDatabase {
+  // TODO: Implement a Database for mbtiles.
+  // Grid and GridData are optional tables.
+}

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/dao/GridDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/dao/GridDao.java
@@ -1,0 +1,8 @@
+package com.google.android.gnd.mapbox.dao;
+
+import androidx.room.Dao;
+
+@Dao
+public interface GridDao {
+  // TODO: Implement Grid DAO
+}

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/dao/GridDataDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/dao/GridDataDao.java
@@ -1,0 +1,8 @@
+package com.google.android.gnd.mapbox.dao;
+
+import androidx.room.Dao;
+
+@Dao
+public interface GridDataDao {
+  // TODO: Implement GridData DAO
+}

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/dao/MetadataDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/dao/MetadataDao.java
@@ -1,0 +1,21 @@
+package com.google.android.gnd.mapbox.dao;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+
+import com.google.android.gnd.mapbox.entity.Metadata;
+
+import io.reactivex.Maybe;
+
+@Dao
+public interface MetadataDao {
+  // TODO: Figure out whether or not we even need insert methods.
+  // Presumably we might, in order to load up the data specified in an mbtiles file, but we may
+  // be able to do this automatically using a room db constructor.
+  @Insert
+  public void insertMetadata(Metadata metadata);
+
+  @Query("SELECT * FROM metadata WHERE name=:metadataName")
+  public Maybe<Metadata> getMetadata(String metadataName);
+}

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/dao/TileDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/dao/TileDao.java
@@ -1,0 +1,19 @@
+package com.google.android.gnd.mapbox.dao;
+
+import androidx.room.Dao;
+import androidx.room.Query;
+
+import com.google.android.gnd.mapbox.entity.Tile;
+
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+
+@Dao
+public interface TileDao {
+  @Query(
+      "SELECT * FROM tiles WHERE zoom_level=:zoom_level AND tile_column=:tile_column AND tile_row=:tile_row LIMIT 1")
+  public Maybe<Tile> getTile(int zoom_level, int tile_column, int tile_row);
+
+  @Query("SELECT * FROM tiles WHERE zoom_level=:zoom_level")
+  public Flowable<Tile> getTilesAtZoomLevel(int zoom_level);
+}

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/entity/Grid.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/entity/Grid.java
@@ -1,0 +1,25 @@
+package com.google.android.gnd.mapbox.entity;
+
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+@Entity(tableName = "grids")
+public class Grid {
+  @PrimaryKey
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int zoom_level;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int tile_column;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int tile_row;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
+  public int grid;
+
+  public Grid() {
+    // no-arg constructor
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/entity/GridData.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/entity/GridData.java
@@ -1,0 +1,28 @@
+package com.google.android.gnd.mapbox.entity;
+
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+@Entity(tableName = "grid_data")
+public class GridData {
+  @PrimaryKey
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int zoom_level;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int tile_column;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int tile_row;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.TEXT)
+  public String key_name;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.TEXT)
+  public String key_json;
+
+  public GridData() {
+    // no-arg constructor
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/entity/Metadata.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/entity/Metadata.java
@@ -1,0 +1,20 @@
+package com.google.android.gnd.mapbox.entity;
+
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+import androidx.room.util.TableInfo;
+
+@Entity(tableName = "metadata")
+public class Metadata {
+  @PrimaryKey
+  @ColumnInfo(typeAffinity = ColumnInfo.TEXT)
+  public String name;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.TEXT)
+  public String value;
+
+  public Metadata() {
+    // no-arg constructor
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/mapbox/entity/Tile.java
+++ b/gnd/src/main/java/com/google/android/gnd/mapbox/entity/Tile.java
@@ -1,0 +1,33 @@
+package com.google.android.gnd.mapbox.entity;
+
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
+
+@Entity(
+    tableName = "tiles",
+    indices = {
+      @Index(
+          value = {"zoom_level", "tile_column", "tile_row"},
+          name = "tile_index",
+          unique = true)
+    })
+public class Tile {
+  @PrimaryKey
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int zoom_level;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int tile_column;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.INTEGER)
+  public int tile_row;
+
+  @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
+  public int tile_data;
+
+  public Tile() {
+    // no-arg constructor
+  }
+}


### PR DESCRIPTION
This is a fairly small change. Just trying to stick with the trunk based model.

Counts toward #10 

This change introduces the scaffolding for a room database that
implements the mbtiles schema. Eventually, we'll read downloaded mbtiles
files and load them into the application by spinning up a room db based
on their contents.

This change also modifies the gradle build file to add room and
room:rx-java as dependencies.