### PR TITLE
Offline-Imagery: Add Tile classes to the local db.

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/model/basemap/tile/Tile.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/basemap/tile/Tile.java
@@ -1,13 +1,12 @@
-package com.google.android.gnd.model.tile;
+package com.google.android.gnd.model.basemap.tile;
 
 import com.google.auto.value.AutoValue;
-
-import java.net.URL;
 
 @AutoValue
 public abstract class Tile {
     public enum State {
         PENDING,
+        IN_PROGRESS,
         DOWNLOADED,
         FAILED
     }

--- a/gnd/src/main/java/com/google/android/gnd/model/tile/Tile.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/tile/Tile.java
@@ -1,0 +1,29 @@
+package com.google.android.gnd.model.tile;
+
+import com.google.auto.value.AutoValue;
+
+import java.net.URL;
+
+@AutoValue
+public abstract class Tile {
+    public enum State {
+        PENDING,
+        DOWNLOADED,
+        FAILED
+    }
+
+    public abstract String getId();
+    public abstract String getPath();
+    public abstract State getState();
+
+    public static Builder newBuilder() {return new AutoValue_Tile.Builder();}
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder setId(String id);
+        public abstract Builder setPath(String path);
+        public abstract Builder setState(State state);
+
+        public abstract Tile build();
+    }
+}

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
@@ -33,7 +33,8 @@ import androidx.room.TypeConverters;
       FeatureEntity.class,
       FeatureMutationEntity.class,
       RecordEntity.class,
-      RecordMutationEntity.class
+      RecordMutationEntity.class,
+      TileEntity.class
     },
     // TODO(#128): Reset version to 1 before releasing.
     version = 13,
@@ -42,7 +43,8 @@ import androidx.room.TypeConverters;
   MutationEntityType.class,
   EntityState.class,
   ResponseDeltasTypeConverter.class,
-  ResponseMapTypeConverter.class
+  ResponseMapTypeConverter.class,
+  TileEntityState.class
 })
 public abstract class LocalDatabase extends RoomDatabase {
 
@@ -53,4 +55,6 @@ public abstract class LocalDatabase extends RoomDatabase {
   public abstract RecordDao recordDao();
 
   public abstract RecordMutationDao recordMutationDao();
+
+  public abstract TileDao tileDao();
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
@@ -37,7 +37,7 @@ import androidx.room.TypeConverters;
       TileEntity.class
     },
     // TODO(#128): Reset version to 1 before releasing.
-    version = 13,
+    version = 14,
     exportSchema = false)
 @TypeConverters({
   MutationEntityType.class,

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileDao.java
@@ -1,0 +1,21 @@
+package com.google.android.gnd.persistence.local.room;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+
+@Dao
+public interface TileDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    Completable insertOrUpdate(TileEntity tileEntity);
+
+    @Query("SELECT * FROM tile WHERE id = :id")
+    Maybe<TileEntity> findById(String id);
+
+    @Query("SELECT * FROM tile WHERE path = :path")
+    Maybe<TileEntity> findByPath(String path);
+}

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileEntity.java
@@ -1,0 +1,93 @@
+package com.google.android.gnd.persistence.local.room;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+import com.google.android.gnd.model.tile.Tile;
+import com.google.auto.value.AutoValue;
+import com.google.auto.value.AutoValue.CopyAnnotations;
+
+@AutoValue
+@Entity(tableName = "tile")
+public abstract class TileEntity {
+    @CopyAnnotations
+    @NonNull
+    @PrimaryKey
+    @ColumnInfo(name = "id")
+    public abstract String getId();
+
+    @CopyAnnotations
+    @NonNull
+    @ColumnInfo(name = "path")
+    public abstract String getPath();
+
+    @CopyAnnotations
+    @NonNull
+    @ColumnInfo(name = "state")
+    public abstract TileEntityState getState();
+
+    public static Tile toTile(TileEntity tileEntity) {
+        Tile.Builder tile =
+                Tile.newBuilder()
+                        .setId(tileEntity.getId())
+                        .setPath(tileEntity.getPath())
+                        .setState(toTileState(tileEntity.getState()));
+        return tile.build();
+    }
+
+    private static Tile.State toTileState(TileEntityState state) {
+        switch (state) {
+            case PENDING:
+                return Tile.State.PENDING;
+            case DOWNLOADED:
+                return Tile.State.DOWNLOADED;
+            case FAILED:
+                return Tile.State.FAILED;
+            default:
+                return Tile.State.PENDING;
+        }
+    }
+
+    public static TileEntity fromTile(Tile tile) {
+        TileEntity.Builder entity =
+                TileEntity.builder()
+                        .setId(tile.getId())
+                        .setPath(tile.getPath())
+                        .setState(toEntityState(tile.getState()));
+        return entity.build();
+    }
+
+    private static TileEntityState toEntityState(Tile.State state) {
+        switch (state) {
+            case PENDING:
+                return TileEntityState.PENDING;
+            case FAILED:
+                return TileEntityState.FAILED;
+            case DOWNLOADED:
+                return TileEntityState.DOWNLOADED;
+            default:
+                return TileEntityState.UNKNOWN;
+        }
+    }
+
+    public static TileEntity create(String id, String url, String path, TileEntityState state) {
+        return builder().setId(id).setState(state).setPath(path).build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_TileEntity.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder setId(String newId);
+
+        public abstract Builder setPath(String newPath);
+
+        public abstract Builder setState(TileEntityState newState);
+
+        public abstract TileEntity build();
+    }
+}

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileEntity.java
@@ -5,89 +5,94 @@ import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
 
-import com.google.android.gnd.model.tile.Tile;
+import com.google.android.gnd.model.basemap.tile.Tile;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.AutoValue.CopyAnnotations;
 
 @AutoValue
 @Entity(tableName = "tile")
 public abstract class TileEntity {
-    @CopyAnnotations
-    @NonNull
-    @PrimaryKey
-    @ColumnInfo(name = "id")
-    public abstract String getId();
+  @CopyAnnotations
+  @NonNull
+  @PrimaryKey
+  @ColumnInfo(name = "id")
+  public abstract String getId();
 
-    @CopyAnnotations
-    @NonNull
-    @ColumnInfo(name = "path")
-    public abstract String getPath();
+  @CopyAnnotations
+  @NonNull
+  @ColumnInfo(name = "path")
+  public abstract String getPath();
 
-    @CopyAnnotations
-    @NonNull
-    @ColumnInfo(name = "state")
-    public abstract TileEntityState getState();
+  @CopyAnnotations
+  @NonNull
+  @ColumnInfo(name = "state")
+  public abstract TileEntityState getState();
 
-    public static Tile toTile(TileEntity tileEntity) {
-        Tile.Builder tile =
-                Tile.newBuilder()
-                        .setId(tileEntity.getId())
-                        .setPath(tileEntity.getPath())
-                        .setState(toTileState(tileEntity.getState()));
-        return tile.build();
+  public static Tile toTile(TileEntity tileEntity) {
+    Tile.Builder tile =
+        Tile.newBuilder()
+            .setId(tileEntity.getId())
+            .setPath(tileEntity.getPath())
+            .setState(toTileState(tileEntity.getState()));
+    return tile.build();
+  }
+
+  private static Tile.State toTileState(TileEntityState state) {
+    switch (state) {
+      case PENDING:
+        return Tile.State.PENDING;
+      case IN_PROGRESS:
+        return Tile.State.IN_PROGRESS;
+      case DOWNLOADED:
+        return Tile.State.DOWNLOADED;
+      case FAILED:
+        return Tile.State.FAILED;
+      default:
+        throw new IllegalArgumentException("Unknown tile state: " + state);
     }
+  }
 
-    private static Tile.State toTileState(TileEntityState state) {
-        switch (state) {
-            case PENDING:
-                return Tile.State.PENDING;
-            case DOWNLOADED:
-                return Tile.State.DOWNLOADED;
-            case FAILED:
-                return Tile.State.FAILED;
-            default:
-                return Tile.State.PENDING;
-        }
+  public static TileEntity fromTile(Tile tile) {
+    TileEntity.Builder entity =
+        TileEntity.builder()
+            .setId(tile.getId())
+            .setPath(tile.getPath())
+            .setState(toEntityState(tile.getState()));
+    return entity.build();
+  }
+
+  private static TileEntityState toEntityState(Tile.State state) {
+    switch (state) {
+      case PENDING:
+        return TileEntityState.PENDING;
+      case IN_PROGRESS:
+        return TileEntityState.IN_PROGRESS;
+      case FAILED:
+        return TileEntityState.FAILED;
+      case DOWNLOADED:
+        return TileEntityState.DOWNLOADED;
+      default:
+        return TileEntityState.UNKNOWN;
     }
+  }
 
-    public static TileEntity fromTile(Tile tile) {
-        TileEntity.Builder entity =
-                TileEntity.builder()
-                        .setId(tile.getId())
-                        .setPath(tile.getPath())
-                        .setState(toEntityState(tile.getState()));
-        return entity.build();
-    }
+  public static TileEntity create(String id, String path, TileEntityState state) {
+    return builder().setId(id).setState(state).setPath(path).build();
+  }
 
-    private static TileEntityState toEntityState(Tile.State state) {
-        switch (state) {
-            case PENDING:
-                return TileEntityState.PENDING;
-            case FAILED:
-                return TileEntityState.FAILED;
-            case DOWNLOADED:
-                return TileEntityState.DOWNLOADED;
-            default:
-                return TileEntityState.UNKNOWN;
-        }
-    }
+  public static Builder builder() {
+    return new AutoValue_TileEntity.Builder();
+  }
 
-    public static TileEntity create(String id, String url, String path, TileEntityState state) {
-        return builder().setId(id).setState(state).setPath(path).build();
-    }
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setId(String newId);
 
-    public static Builder builder() {
-        return new AutoValue_TileEntity.Builder();
-    }
+    public abstract Builder setPath(String newPath);
 
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract Builder setId(String newId);
+    public abstract Builder setState(TileEntityState newState);
 
-        public abstract Builder setPath(String newPath);
-
-        public abstract Builder setState(TileEntityState newState);
-
-        public abstract TileEntity build();
-    }
+    public abstract TileEntity build();
+  }
 }
+

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileEntityState.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileEntityState.java
@@ -1,0 +1,33 @@
+package com.google.android.gnd.persistence.local.room;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.room.TypeConverter;
+
+public enum TileEntityState implements IntEnum {
+    UNKNOWN(0),
+    PENDING(1),
+    DOWNLOADED(2),
+    FAILED(3);
+
+    private final int intValue;
+
+    TileEntityState(int intValue) {
+        this.intValue = intValue;
+    }
+
+    public int intValue() {
+        return intValue;
+    }
+
+    @TypeConverter
+    public static int toInt(@Nullable TileEntityState value) {
+        return IntEnum.toInt(value, UNKNOWN);
+    }
+
+    @NonNull
+    @TypeConverter
+    public static TileEntityState fromInt(int intValue) {
+        return IntEnum.fromInt(values(), intValue, UNKNOWN);
+    }
+}

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileEntityState.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileEntityState.java
@@ -5,29 +5,31 @@ import androidx.annotation.Nullable;
 import androidx.room.TypeConverter;
 
 public enum TileEntityState implements IntEnum {
-    UNKNOWN(0),
-    PENDING(1),
-    DOWNLOADED(2),
-    FAILED(3);
+  UNKNOWN(0),
+  PENDING(1),
+  IN_PROGRESS(2),
+  DOWNLOADED(3),
+  FAILED(4);
 
-    private final int intValue;
+  private final int intValue;
 
-    TileEntityState(int intValue) {
-        this.intValue = intValue;
-    }
+  TileEntityState(int intValue) {
+    this.intValue = intValue;
+  }
 
-    public int intValue() {
-        return intValue;
-    }
+  public int intValue() {
+    return intValue;
+  }
 
-    @TypeConverter
-    public static int toInt(@Nullable TileEntityState value) {
-        return IntEnum.toInt(value, UNKNOWN);
-    }
+  @TypeConverter
+  public static int toInt(@Nullable TileEntityState value) {
+    return IntEnum.toInt(value, UNKNOWN);
+  }
 
-    @NonNull
-    @TypeConverter
-    public static TileEntityState fromInt(int intValue) {
-        return IntEnum.fromInt(values(), intValue, UNKNOWN);
-    }
+  @NonNull
+  @TypeConverter
+  public static TileEntityState fromInt(int intValue) {
+    return IntEnum.fromInt(values(), intValue, UNKNOWN);
+  }
 }
+


### PR DESCRIPTION
In order to represent what tiles users have available for offline viewing, we'll make use of the local data store. We store tile state along with the id of the json feature the tile is associated with and the path at which the tile data is stored. This should allow us to keep track of what tiles are on the device, as well as resume failed or interrupted downloads.