### PR TITLE
Offline Imagery: Add JSON Layer Rendering

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-auth:$project.gmsVersion"
     implementation "com.google.android.gms:play-services-maps:$project.gmsVersion"
     implementation "com.google.android.gms:play-services-location:$project.gmsVersion"
+    implementation "com.google.maps.android:android-maps-utils:0.5+"
 
     // Firebase and related libraries.
     implementation "com.google.firebase:firebase-core:$project.firebaseCoreVersion"

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -335,11 +335,19 @@ public class HomeScreenFragment extends AbstractFragment
         showProjectSelector();
         closeDrawer();
         break;
+      case R.id.nav_download_tiles:
+        showTileDownloadLayer();
+        closeDrawer();
+        break;
       case R.id.nav_sign_out:
         authenticationManager.signOut();
         break;
     }
     return false;
+  }
+
+  private void showTileDownloadLayer() {
+    this.viewModel.getDownloadTileClicks().onNext(new Object());
   }
 
   private class BottomSheetCallback extends BottomSheetBehavior.BottomSheetCallback {

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -47,6 +47,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
   private final LiveData<Persistable<Project>> activeProject;
 
   private final PublishSubject<Feature> addFeatureClicks;
+  private final PublishSubject<Object> downloadTileClicks;
 
   // TODO: Move into MapContainersViewModel
   private final SingleLiveEvent<Point> addFeatureDialogRequests;
@@ -66,6 +67,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
         LiveDataReactiveStreams.fromPublisher(dataRepository.getActiveProjectOnceAndStream());
     this.navigator = navigator;
     this.addFeatureClicks = PublishSubject.create();
+    this.downloadTileClicks = PublishSubject.create();
 
     disposeOnClear(
         addFeatureClicks
@@ -92,6 +94,10 @@ public class HomeScreenViewModel extends AbstractViewModel {
 
   public void openNavDrawer() {
     openDrawerRequests.setValue(null);
+  }
+
+  public PublishSubject<Object> getDownloadTileClicks() {
+    return downloadTileClicks;
   }
 
   public LiveData<Persistable<Project>> getActiveProject() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -138,6 +138,10 @@ public class MapContainerFragment extends AbstractFragment {
     addFeatureBtn.setOnClickListener(
         __ -> homeScreenViewModel.onAddFeatureBtnClick(map.getCenter()));
     enableLocationLockBtn();
+    homeScreenViewModel
+        .getDownloadTileClicks()
+        .as(autoDisposable(this))
+        .subscribe(__ -> map.renderJsonLayer());
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/MapProvider.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/MapProvider.java
@@ -52,6 +52,8 @@ public interface MapProvider {
 
     void moveCamera(Point point, float zoomLevel);
 
+    void renderJsonLayer();
+
     Point getCenter();
 
     float getCurrentZoomLevel();

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapAdapter.java
@@ -21,7 +21,11 @@ import static java8.util.stream.StreamSupport.stream;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.Color;
 import android.util.Log;
+
+import androidx.core.content.ContextCompat;
+
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.UiSettings;
@@ -29,6 +33,7 @@ import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.android.gnd.R;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.model.layer.FeatureType;
@@ -38,6 +43,7 @@ import com.google.android.gnd.ui.map.MapProvider.MapAdapter;
 import com.google.common.collect.ImmutableSet;
 import com.google.maps.android.data.geojson.GeoJsonFeature;
 import com.google.maps.android.data.geojson.GeoJsonLayer;
+import com.google.maps.android.data.geojson.GeoJsonPolygonStyle;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -76,12 +82,14 @@ class GoogleMapsMapAdapter implements MapAdapter {
    * GoogleMap markers themselves are destroyed as well.
    */
   private java.util.Map<String, Marker> markers = new HashMap<>();
+
   private java.util.Set<GeoJsonFeature> selectedJsonFeatures = new HashSet<>();
 
   private final PublishSubject<MapMarker> markerClickSubject = PublishSubject.create();
   private final PublishSubject<Point> dragInteractionSubject = PublishSubject.create();
   private final BehaviorSubject<Point> cameraPositionSubject = BehaviorSubject.create();
-  private final PublishSubject<Set<GeoJsonFeature>> selectedJsonFeaturesSubject = PublishSubject.create();
+  private final PublishSubject<Set<GeoJsonFeature>> selectedJsonFeaturesSubject =
+      PublishSubject.create();
 
   @Nullable private LatLng cameraTargetBeforeDrag;
 
@@ -185,9 +193,19 @@ class GoogleMapsMapAdapter implements MapAdapter {
     GeoJsonFeature geoJsonFeature = (GeoJsonFeature) feature;
 
     if (selectedJsonFeatures.contains(geoJsonFeature)) {
+      GeoJsonPolygonStyle style = new GeoJsonPolygonStyle();
+      style.setStrokeWidth(10);
+      style.setStrokeColor(ContextCompat.getColor(context, R.color.colorTileInactiveStroke));
+      style.setFillColor(ContextCompat.getColor(context, R.color.colorTileInactiveOverlay));
+      geoJsonFeature.setPolygonStyle(style);
       selectedJsonFeatures.remove(geoJsonFeature);
       selectedJsonFeaturesSubject.onNext(selectedJsonFeatures);
     } else {
+      GeoJsonPolygonStyle style = new GeoJsonPolygonStyle();
+      style.setStrokeWidth(3);
+      style.setStrokeColor(ContextCompat.getColor(context, R.color.colorTileActiveStroke));
+      style.setFillColor(ContextCompat.getColor(context, R.color.colorTileActiveOverlay));
+      geoJsonFeature.setPolygonStyle(style);
       selectedJsonFeatures.add(geoJsonFeature);
       selectedJsonFeaturesSubject.onNext(selectedJsonFeatures);
     }

--- a/gnd/src/main/res/menu/nav_drawer_menu.xml
+++ b/gnd/src/main/res/menu/nav_drawer_menu.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2018 Google LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +15,19 @@
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-  <group android:checkableBehavior="single">
-    <item
-        android:id="@+id/nav_join_project"
-        android:icon="@drawable/ic_menu_project"
-        android:title="@string/select_project_menu_item"/>
-    <item
-        android:id="@+id/nav_sign_out"
-        android:icon="@drawable/ic_sign_out"
-        android:title="@string/sign_out"/>
-  </group>
+    <group android:checkableBehavior="single">
+        <item
+            android:id="@+id/nav_join_project"
+            android:icon="@drawable/ic_menu_project"
+            android:title="@string/select_project_menu_item" />
+        <!--TODO: Add an icon for the download menu option -->
+        <item
+            android:id="@+id/nav_download_tiles"
+            android:icon="@drawable/ic_arrow_drop_down"
+            android:title="@string/download_tiles_menu_item" />
+        <item
+            android:id="@+id/nav_sign_out"
+            android:icon="@drawable/ic_sign_out"
+            android:title="@string/sign_out" />
+    </group>
 </menu>

--- a/gnd/src/main/res/values/colors.xml
+++ b/gnd/src/main/res/values/colors.xml
@@ -27,4 +27,8 @@
   <color name="colorGrey800">#424242</color>
   <color name="colorForeground">#212121</color>
   <color name="colorAlert">#d2004d</color>
+  <color name="colorTileActiveOverlay">#2200FFFF</color>
+  <color name="colorTileActiveStroke">#99003333</color>
+  <color name="colorTileInactiveOverlay">#00000000</color>
+  <color name="colorTileInactiveStroke">#000000</color>
 </resources>

--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -16,128 +16,129 @@
 
 <resources>
 
-  <!-- Application name. Do not translate. -->
-  <string name="app_name" translatable="false">Ground</string>
+    <!-- Application name. Do not translate. -->
+    <string name="app_name" translatable="false">Ground</string>
 
-  <!-- Message shown while project is loading. -->
-  <string name="project_loading_please_wait">Project loading, please wait &#8230;</string>
+    <!-- Message shown while project is loading. -->
+    <string name="project_loading_please_wait">Project loading, please wait &#8230;</string>
 
-  <!--
-    ADD/EDIT FEATURE DATA
-  -->
+    <!--
+      ADD/EDIT FEATURE DATA
+    -->
 
-  <!-- Title shown above list of feature types when (+) is clicked on map. -->
-  <string name="add_feature_select_type_dialog_title">What would you like to add?</string>
-  <!-- Text shown to dismiss "Add a feature" dialog -->
-  <string name="add_feature_cancel">Cancel</string>
+    <!-- Title shown above list of feature types when (+) is clicked on map. -->
+    <string name="add_feature_select_type_dialog_title">What would you like to add?</string>
+    <!-- Text shown to dismiss "Add a feature" dialog -->
+    <string name="add_feature_cancel">Cancel</string>
 
-  <!-- Shown in toolbar when adding a new feature and form instance. -->
-  <string name="add_feature_toolbar_title">Add a feature</string>
-  <!-- Shown in toolbar when editing an existing record (form instance). -->
-  <string name="edit_feature_data_toolbar_title">Edit feature data</string>
-  <!-- Shown in toolbar when adding a new record (form instance) to a feature. -->
-  <string name="add_feature_data_toolbar_title">Add feature data</string>
-  <!-- Shown in toolbar to save changes to feature data. -->
-  <string name="save">Save</string>
-  <!-- Shown when leaving edit mode without saving changes. -->
-  <string name="unsaved_changes">Save changes before closing?</string>
-  <string name="save_unsaved_changes">Save</string>
-  <string name="continue_editing">Continue editing</string>
-  <string name="close_without_saving">Close without saving</string>
-  <!-- Shown on save when connection was not available. -->
-  <string name="save_queued">Saved locally, queued for sync.</string>
-  <!-- Shown on save when connection is available (TBD). -->
-  <string name="saved">Changes saved</string>
+    <!-- Shown in toolbar when adding a new feature and form instance. -->
+    <string name="add_feature_toolbar_title">Add a feature</string>
+    <!-- Shown in toolbar when editing an existing record (form instance). -->
+    <string name="edit_feature_data_toolbar_title">Edit feature data</string>
+    <!-- Shown in toolbar when adding a new record (form instance) to a feature. -->
+    <string name="add_feature_data_toolbar_title">Add feature data</string>
+    <!-- Shown in toolbar to save changes to feature data. -->
+    <string name="save">Save</string>
+    <!-- Shown when leaving edit mode without saving changes. -->
+    <string name="unsaved_changes">Save changes before closing?</string>
+    <string name="save_unsaved_changes">Save</string>
+    <string name="continue_editing">Continue editing</string>
+    <string name="close_without_saving">Close without saving</string>
+    <!-- Shown on save when connection was not available. -->
+    <string name="save_queued">Saved locally, queued for sync.</string>
+    <!-- Shown on save when connection is available (TBD). -->
+    <string name="saved">Changes saved</string>
 
-  <!--
-    FEATURE DATA FORMS
-  -->
+    <!--
+      FEATURE DATA FORMS
+    -->
 
-  <!-- Text in multiple-choice popup dialogs that when clicked, applied new selection to form -->
-  <string name="apply_multiple_choice_changes">Apply</string>
-  <!-- Text in multiple-choice popup dialogs that when clicked, discards any changes made. -->
-  <string name="discard_multiple_choice_changes">Cancel</string>
-  <!-- Shown below fields that are required but left empty (TBD). -->
-  <string name="required_field">This field is required</string>
+    <!-- Text in multiple-choice popup dialogs that when clicked, applied new selection to form -->
+    <string name="apply_multiple_choice_changes">Apply</string>
+    <!-- Text in multiple-choice popup dialogs that when clicked, discards any changes made. -->
+    <string name="discard_multiple_choice_changes">Cancel</string>
+    <!-- Shown below fields that are required but left empty (TBD). -->
+    <string name="required_field">This field is required</string>
 
-  <!--
-    VIEW FEATURE DATA
-  -->
+    <!--
+      VIEW FEATURE DATA
+    -->
 
-  <!-- Shown in record overflow menu to open popup dialog to edit feature metadata. -->
-  <string name="edit_record">Edit record</string>
-  <!-- Shown in record overflow menu to delete a record. -->
-  <string name="delete_record">Delete record</string>
-  <!-- Confirmation shown when deleting a record (TBD). -->
-  <string name="delete_record_confirmation">
+    <!-- Shown in record overflow menu to open popup dialog to edit feature metadata. -->
+    <string name="edit_record">Edit record</string>
+    <!-- Shown in record overflow menu to delete a record. -->
+    <string name="delete_record">Delete record</string>
+    <!-- Confirmation shown when deleting a record (TBD). -->
+    <string name="delete_record_confirmation">
     This will permanently delete the selected record. This cannot be undone. Are you sure?
   </string>
-  <!--
-    Shown above saved records (forms) that have been submitted. %1$s placeholder will already be
-    translated, and it will contain the "time ago" that the record was received by the server
-    (e.g., "Submitted 2 min ago").
-   -->
-  <string name="submitted_status">Submitted %1$s</string>
-  <!--
-    Shown above saved records (forms) that have been submitted and subsequently modified. %1$s
-    placeholder will already be translated, and it will contain the "time ago" that the changes were
-    last received by the server (e.g., "Updated 1 min ago").
-   -->
-  <string name="updated_status">Updated %1$s</string>
+    <!--
+      Shown above saved records (forms) that have been submitted. %1$s placeholder will already be
+      translated, and it will contain the "time ago" that the record was received by the server
+      (e.g., "Submitted 2 min ago").
+     -->
+    <string name="submitted_status">Submitted %1$s</string>
+    <!--
+      Shown above saved records (forms) that have been submitted and subsequently modified. %1$s
+      placeholder will already be translated, and it will contain the "time ago" that the changes were
+      last received by the server (e.g., "Updated 1 min ago").
+     -->
+    <string name="updated_status">Updated %1$s</string>
 
-  <!--
-    IN BOTH ADD/EDIT AND VIEW FEATURE SCREENS
-  -->
+    <!--
+      IN BOTH ADD/EDIT AND VIEW FEATURE SCREENS
+    -->
 
-  <!-- Shown in toolbar overflow menu to enter "move" mode to reposition a feature. -->
-  <string name="move_feature">Move feature</string>
-  <!-- Shown in toolbar overflow menu to open popup dialog to edit feature metadata. -->
-  <string name="edit_feature_id_and_caption">Edit ID &amp; caption</string>
-  <!-- Shown in edit id/caption popup (TBD) above feature ID. -->
-  <string name="feature_id">ID</string>
-  <!-- Shown in edit id/caption popup (TBD) above feature caption. -->
-  <string name="feature_caption">Caption</string>
-  <!-- Shown in toolbar overflow menu to delete a feature and all related data. -->
-  <string name="delete_feature">Delete feature</string>
-  <!-- Shown in toolbar overflow menu to delete a feature and all related data. -->
-  <string name="delete_feature_confirmation">
+    <!-- Shown in toolbar overflow menu to enter "move" mode to reposition a feature. -->
+    <string name="move_feature">Move feature</string>
+    <!-- Shown in toolbar overflow menu to open popup dialog to edit feature metadata. -->
+    <string name="edit_feature_id_and_caption">Edit ID &amp; caption</string>
+    <!-- Shown in edit id/caption popup (TBD) above feature ID. -->
+    <string name="feature_id">ID</string>
+    <!-- Shown in edit id/caption popup (TBD) above feature caption. -->
+    <string name="feature_caption">Caption</string>
+    <!-- Shown in toolbar overflow menu to delete a feature and all related data. -->
+    <string name="delete_feature">Delete feature</string>
+    <!-- Shown in toolbar overflow menu to delete a feature and all related data. -->
+    <string name="delete_feature_confirmation">
     This will delete the currently selected feature and all related data. This cannot be undone.
     Are you sure?
   </string>
 
-  <!--
-    LOCATION (GPS/CELL/WIFI) UPDATE ERROR MESSAGES
-  -->
+    <!--
+      LOCATION (GPS/CELL/WIFI) UPDATE ERROR MESSAGES
+    -->
 
-  <!-- Shown when user has refused to grant app fine grained location permission. -->
-  <string name="no_fine_location_permissions">Cannot show current location without
+    <!-- Shown when user has refused to grant app fine grained location permission. -->
+    <string name="no_fine_location_permissions">Cannot show current location without
     permission</string>
-  <!-- Shown when an unknown error occurs obtaining fine grained location permission. -->
-  <string name="location_updates_unknown_error">Failed to enable location updates</string>
-  <!-- Shown when user has refused to enable location services in settings.-->
-  <string name="location_disabled_in_settings">Please enable location in system settings</string>
-  <!-- Shown when an unknown error occurs while obtaining location updates.-->
-  <string name="location_updates_request_failed">Failed to enable location updates</string>
+    <!-- Shown when an unknown error occurs obtaining fine grained location permission. -->
+    <string name="location_updates_unknown_error">Failed to enable location updates</string>
+    <!-- Shown when user has refused to enable location services in settings.-->
+    <string name="location_disabled_in_settings">Please enable location in system settings</string>
+    <!-- Shown when an unknown error occurs while obtaining location updates.-->
+    <string name="location_updates_request_failed">Failed to enable location updates</string>
 
-  <!-- Shown when saving a form that contains missing or invalid data -->
-  <string name="invalid_data_warning">The form contains incomplete or invalid data. Please check
+    <!-- Shown when saving a form that contains missing or invalid data -->
+    <string name="invalid_data_warning">The form contains incomplete or invalid data. Please check
   your responses and try again.</string>
-  <string name="invalid_data_confirm">OK</string>
+    <string name="invalid_data_confirm">OK</string>
 
-  <string name="join_project_dialog_title">Join project</string>
-  <string name="add_record_button_label">Add record</string>
-  <string name="view_record_details">View record details</string>
-  <string name="map_view">Map view</string>
-  <string name="project_load_error">Project could not be loaded</string>
-  <string name="project_list_load_error">Project list not available</string>
-  <string name="unexpected_error">An unexpected error has occurred</string>
-  <string name="edit_record_button_label">Edit</string>
-  <string name="save_record_button_label">Save</string>
-  <string name="saving">Saving&#8230;</string>
-  <string name="no_changes_to_save">No changes to save</string>
-  <string name="select_project_menu_item">Select project</string>
-  <string name="google_api_install_failed">Google Play Services installation failed</string>
-  <string name="sign_in_unsuccessful">Sign in unsuccessful</string>
-  <string name="sign_out">Sign out</string>
+    <string name="join_project_dialog_title">Join project</string>
+    <string name="add_record_button_label">Add record</string>
+    <string name="view_record_details">View record details</string>
+    <string name="map_view">Map view</string>
+    <string name="project_load_error">Project could not be loaded</string>
+    <string name="project_list_load_error">Project list not available</string>
+    <string name="unexpected_error">An unexpected error has occurred</string>
+    <string name="edit_record_button_label">Edit</string>
+    <string name="save_record_button_label">Save</string>
+    <string name="saving">Saving&#8230;</string>
+    <string name="no_changes_to_save">No changes to save</string>
+    <string name="select_project_menu_item">Select project</string>
+    <string name="google_api_install_failed">Google Play Services installation failed</string>
+    <string name="sign_in_unsuccessful">Sign in unsuccessful</string>
+    <string name="sign_out">Sign out</string>
+    <string name="download_tiles_menu_item">Download Tiles</string>
 
 </resources>


### PR DESCRIPTION
This PR introduces JSON layer rendering on the map. Users can select a new primary nave menu option, "Download Tiles" which, when selected, activates a JSON layer on the map that gives users a visual field to use to select tiles. 

Once this looks okay, we can move on to passing the tile selections off to the appropriate VM and subsequently the download worker, providing the user with an indication of available storage space, highlight which tiles are already downloaded on the device, etc.

This change also includes some preliminary setup for passing on a set of selected tiles from the MapAdapter, but we don't do anything with theses as of yet.

I'm not 100% confident about how I've hooked up the UI menu option to the rendering logic, but it seemed to be the cleanest way to do it considering the way the VMs and reactive streams were already set up. 