### PR TITLE
Offline Imagery: Add basemap selector UI

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/MainActivityModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/MainActivityModule.java
@@ -19,6 +19,8 @@ package com.google.android.gnd;
 import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.gnd.inject.ActivityScoped;
 import com.google.android.gnd.inject.FragmentScoped;
+import com.google.android.gnd.ui.basemapselector.BasemapSelectorFragment;
+import com.google.android.gnd.ui.basemapselector.BasemapSelectorModule;
 import com.google.android.gnd.ui.editrecord.EditRecordFragment;
 import com.google.android.gnd.ui.editrecord.EditRecordModule;
 import com.google.android.gnd.ui.home.AddFeatureDialogFragment;
@@ -89,4 +91,8 @@ public abstract class MainActivityModule {
   @FragmentScoped
   @ContributesAndroidInjector(modules = EditRecordModule.class)
   abstract EditRecordFragment editRecordFragmentInjector();
+
+  @FragmentScoped
+  @ContributesAndroidInjector(modules = BasemapSelectorModule.class)
+  abstract BasemapSelectorFragment basemapSelectorFragmentInjector();
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
@@ -24,8 +24,8 @@ import io.reactivex.Single;
 
 /**
  * Allows the user to select specific areas on a map for offline display. Users can toggle sections of
- * the to add remove imagery. Upon selection, basemap tiles are queued for download. When deselected,
- * they are removed from the device.
+ * the map to add or remove imagery. Upon selection, basemap tiles are queued for download. When 
+ * deselected, they are removed from the device.
  */
 @ActivityScoped
 public class BasemapSelectorFragment extends AbstractFragment {

--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
@@ -22,6 +22,11 @@ import javax.inject.Inject;
 
 import io.reactivex.Single;
 
+/**
+ * This fragment represents a basemap selector for the application's offline imagery functionality.
+ * The fragment is presented as an immersive experience in which users can select portions of a
+ * basemap for offline viewing. Upon selection, basemap tiles are saved to the device.
+ */
 @ActivityScoped
 public class BasemapSelectorFragment extends AbstractFragment {
 
@@ -63,7 +68,6 @@ public class BasemapSelectorFragment extends AbstractFragment {
   public void onActivityCreated(@Nullable Bundle savedInstanceState) {
     super.onActivityCreated(savedInstanceState);
     mainViewModel.getWindowInsets().observe(this, this::onApplyWindowInsets);
-    // viewModel.getWindowInsets().observe(this, this::onApplyWindowInsets);
   }
 
   private void onApplyWindowInsets(WindowInsetsCompat windowInsets) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
@@ -1,0 +1,74 @@
+package com.google.android.gnd.ui.basemapselector;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import com.google.android.gnd.MainViewModel;
+import com.google.android.gnd.R;
+import com.google.android.gnd.databinding.BasemapSelectorFragBinding;
+import com.google.android.gnd.inject.ActivityScoped;
+import com.google.android.gnd.ui.common.AbstractFragment;
+import com.google.android.gnd.ui.map.MapProvider;
+import com.google.android.gnd.ui.map.MapProvider.MapAdapter;
+
+import javax.inject.Inject;
+
+import io.reactivex.Single;
+
+@ActivityScoped
+public class BasemapSelectorFragment extends AbstractFragment {
+
+  private static final String TAG = BasemapSelectorFragment.class.getName();
+  private static final String MAP_FRAGMENT_KEY = MapProvider.class.getName() + "#fragment";
+  private BasemapSelectorViewModel viewModel;
+  private MainViewModel mainViewModel;
+
+  @Inject MapProvider mapProvider;
+
+  @Override
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    viewModel = getViewModel(BasemapSelectorViewModel.class);
+    mainViewModel = getViewModel(MainViewModel.class);
+    Single<MapAdapter> mapAdapter = mapProvider.getMapAdapter();
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    BasemapSelectorFragBinding binding =
+        BasemapSelectorFragBinding.inflate(inflater, container, false);
+    binding.setViewModel(viewModel);
+    return binding.getRoot();
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    if (savedInstanceState == null) {
+      replaceFragment(R.id.map, mapProvider.getFragment());
+    } else {
+      mapProvider.restore(restoreChildFragment(savedInstanceState, MAP_FRAGMENT_KEY));
+    }
+  }
+
+  @Override
+  public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+    super.onActivityCreated(savedInstanceState);
+    mainViewModel.getWindowInsets().observe(this, this::onApplyWindowInsets);
+    // viewModel.getWindowInsets().observe(this, this::onApplyWindowInsets);
+  }
+
+  private void onApplyWindowInsets(WindowInsetsCompat windowInsets) {
+    ViewCompat.onApplyWindowInsets(mapProvider.getFragment().getView(), windowInsets);
+    // TODO: Once we add control UI elements, translate them based on the inset to avoid collision
+    //  with the android navbar.
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
@@ -23,9 +23,9 @@ import javax.inject.Inject;
 import io.reactivex.Single;
 
 /**
- * This fragment represents a basemap selector for the application's offline imagery functionality.
- * The fragment is presented as an immersive experience in which users can select portions of a
- * basemap for offline viewing. Upon selection, basemap tiles are saved to the device.
+ * Allows the user to select specific areas on a map for offline display. Users can toggle sections of
+ * the to add remove imagery. Upon selection, basemap tiles are queued for download. When deselected,
+ * they are removed from the device.
  */
 @ActivityScoped
 public class BasemapSelectorFragment extends AbstractFragment {

--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorModule.java
@@ -1,0 +1,16 @@
+package com.google.android.gnd.ui.basemapselector;
+
+import androidx.fragment.app.Fragment;
+
+import com.google.android.gnd.inject.FragmentScoped;
+
+import dagger.Binds;
+import dagger.Module;
+
+@Module
+public abstract class BasemapSelectorModule {
+
+  @Binds
+  @FragmentScoped
+  abstract Fragment fragment(BasemapSelectorFragment fragment);
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorViewModel.java
@@ -4,6 +4,13 @@ import androidx.lifecycle.ViewModel;
 
 import javax.inject.Inject;
 
+/**
+ * This view model is responsible for managing state for the {@link BasemapSelectorFragment}.
+ * Together, they constitute a basemap selector that users can interact with to select portions of a
+ * basemap for offline viewing. Among other things, this view model is responsible for receiving
+ * requests to download basemap files and for scheduling those requests with an {@link
+ * com.google.android.gnd.workers.FileDownloadWorker}.
+ */
 public class BasemapSelectorViewModel extends ViewModel {
   @Inject
   BasemapSelectorViewModel() {}

--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorViewModel.java
@@ -1,0 +1,12 @@
+package com.google.android.gnd.ui.basemapselector;
+
+import androidx.lifecycle.ViewModel;
+
+import javax.inject.Inject;
+
+public class BasemapSelectorViewModel extends ViewModel {
+  @Inject
+  BasemapSelectorViewModel() {}
+
+  // TODO: Implement view model.
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/common/Navigator.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/common/Navigator.java
@@ -70,6 +70,14 @@ public class Navigator {
   }
 
   /**
+   * Navigates from a {@link com.google.android.gnd.ui.home.HomeScreenFragment} to a {@link
+   * com.google.android.gnd.ui.basemapselector.BasemapSelectorFragment}.
+   */
+  public void showBasemapSelector() {
+    navigate(HomeScreenFragmentDirections.showBasemapSelector());
+  }
+
+  /**
    * Navigates from the {@link com.google.android.gnd.ui.home.HomeScreenFragment} to a {@link
    * com.google.android.gnd.ui.editrecord.EditRecordFragment} initialized with a new empty record
    * using the specified form.

--- a/gnd/src/main/java/com/google/android/gnd/ui/common/ViewModelModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/common/ViewModelModule.java
@@ -19,6 +19,7 @@ package com.google.android.gnd.ui.common;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 import com.google.android.gnd.MainViewModel;
+import com.google.android.gnd.ui.basemapselector.BasemapSelectorViewModel;
 import com.google.android.gnd.ui.editrecord.EditRecordViewModel;
 import com.google.android.gnd.ui.home.HomeScreenViewModel;
 import com.google.android.gnd.ui.home.featuresheet.FeatureSheetViewModel;
@@ -37,6 +38,11 @@ public abstract class ViewModelModule {
   @IntoMap
   @ViewModelKey(MapContainerViewModel.class)
   abstract ViewModel bindMapContainerViewModel(MapContainerViewModel viewModel);
+
+  @Binds
+  @IntoMap
+  @ViewModelKey(BasemapSelectorViewModel.class)
+  abstract ViewModel bindBasemapSelectorViewModel(BasemapSelectorViewModel viewModel);
 
   @Binds
   @IntoMap

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -224,6 +224,10 @@ public class HomeScreenFragment extends AbstractFragment
     ProjectSelectorDialogFragment.show(getFragmentManager());
   }
 
+  private void showBasemapSelector() {
+    viewModel.showBasemapSelector();
+  }
+
   private void onApplyWindowInsets(WindowInsetsCompat insets) {
     statusBarScrim.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
     toolbarWrapper.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
@@ -333,6 +337,10 @@ public class HomeScreenFragment extends AbstractFragment
     switch (item.getItemId()) {
       case R.id.nav_join_project:
         showProjectSelector();
+        closeDrawer();
+        break;
+      case R.id.nav_offline_maps:
+        showBasemapSelector();
         closeDrawer();
         break;
       case R.id.nav_sign_out:

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -146,6 +146,10 @@ public class HomeScreenViewModel extends AbstractViewModel {
     navigator.addRecord(feature.getProject().getId(), feature.getId(), selectedForm.getId());
   }
 
+  public void showBasemapSelector() {
+    navigator.showBasemapSelector();
+  }
+
   /**
    * Reactivates the last active project, emitting true once loaded, or false if no project was
    * previously activated.

--- a/gnd/src/main/res/layout/basemap_selector_frag.xml
+++ b/gnd/src/main/res/layout/basemap_selector_frag.xml
@@ -1,0 +1,32 @@
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.google.android.gnd.ui.basemapselector.BasemapSelectorViewModel" />
+    </data>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <RelativeLayout
+            android:id="@+id/map_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="top"
+            android:gravity="center"
+            app:layout_behavior="com.google.android.gnd.ui.home.mapcontainer.MapLayoutBehavior">
+
+            <!-- Featureholder for map implementation -->
+            <FrameLayout
+                android:id="@+id/map"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <!--TODO: Add controls for returning Home and downloading selected tiles.-->
+        </RelativeLayout>
+    </FrameLayout>
+</layout>

--- a/gnd/src/main/res/layout/basemap_selector_frag.xml
+++ b/gnd/src/main/res/layout/basemap_selector_frag.xml
@@ -2,7 +2,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-
         <variable
             name="viewModel"
             type="com.google.android.gnd.ui.basemapselector.BasemapSelectorViewModel" />
@@ -20,7 +19,6 @@
             android:gravity="center"
             app:layout_behavior="com.google.android.gnd.ui.home.mapcontainer.MapLayoutBehavior">
 
-            <!-- Featureholder for map implementation -->
             <FrameLayout
                 android:id="@+id/map"
                 android:layout_width="match_parent"

--- a/gnd/src/main/res/menu/nav_drawer_menu.xml
+++ b/gnd/src/main/res/menu/nav_drawer_menu.xml
@@ -22,6 +22,10 @@
         android:icon="@drawable/ic_menu_project"
         android:title="@string/select_project_menu_item"/>
     <item
+        android:id="@+id/nav_offline_maps"
+        android:icon="@drawable/ic_arrow_drop_down"
+        android:title="@string/offline_maps"/>
+    <item
         android:id="@+id/nav_sign_out"
         android:icon="@drawable/ic_sign_out"
         android:title="@string/sign_out"/>

--- a/gnd/src/main/res/navigation/nav_graph.xml
+++ b/gnd/src/main/res/navigation/nav_graph.xml
@@ -67,7 +67,21 @@
         android:defaultValue="NEW_RECORD"
         android:name="recordId"/>
     </action>
+    <action
+        android:id="@+id/showBasemapSelector"
+        app:destination="@id/basemap_selector_fragment"
+        />
   </fragment>
+
+  <fragment
+    android:id="@+id/basemap_selector_fragment"
+    android:label="Offline Maps"
+    android:name="com.google.android.gnd.ui.basemapselector.BasemapSelectorFragment"
+    tools:layout="@layout/basemap_selector_frag">
+    <action
+        android:id="@+id/backToHomeScreen"
+        app:destination="@id/home_screen_fragment"
+      /></fragment>
 
   <fragment
     android:id="@+id/record_details_fragment"

--- a/gnd/src/main/res/navigation/nav_graph.xml
+++ b/gnd/src/main/res/navigation/nav_graph.xml
@@ -75,7 +75,7 @@
 
   <fragment
     android:id="@+id/basemap_selector_fragment"
-    android:label="Offline Maps"
+    android:label="@string/offline_maps"
     android:name="com.google.android.gnd.ui.basemapselector.BasemapSelectorFragment"
     tools:layout="@layout/basemap_selector_frag">
     <action

--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -139,5 +139,6 @@
   <string name="google_api_install_failed">Google Play Services installation failed</string>
   <string name="sign_in_unsuccessful">Sign in unsuccessful</string>
   <string name="sign_out">Sign out</string>
+  <string name="offline_maps">Offline Maps</string>
 
 </resources>

--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -139,6 +139,6 @@
   <string name="google_api_install_failed">Google Play Services installation failed</string>
   <string name="sign_in_unsuccessful">Sign in unsuccessful</string>
   <string name="sign_out">Sign out</string>
-  <string name="offline_maps">Offline Maps</string>
+  <string name="offline_maps">Offline maps</string>
 
 </resources>


### PR DESCRIPTION
This change adds a fragment, view model, layout, and other components
to support a distinct UI for selecting offline imagery. Keeping this UI
separate ensures we can manage the feature independently, as well as
gives users a better experience (the basemap selection map doesn't
render markers, as these are noisy in the context).

This particular commit doesn't implement any interesting functionality.
It is effectively just a shell for the basemap selection UI. As a
minimal first step, we do render the map in this commit.

This UI is in the nav graph, so users can utilize the android navigation
back arrow to return to the main home screen.