### PR TITLE
Offline Imagery: Add tile streams to data store

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -18,6 +18,7 @@ package com.google.android.gnd.persistence.local;
 
 import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Project;
+import com.google.android.gnd.model.basemap.tile.Tile;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.FeatureMutation;
 import com.google.android.gnd.model.observation.Record;
@@ -74,6 +75,12 @@ public interface LocalDataStore {
   Maybe<Record> getRecord(Feature feature, String recordId);
 
   /**
+   * Returns a long-lived stream that emits the full set of tiles on subscribe and continues to
+   * return the full set each time a tile is added/changed/removed.
+   */
+  Flowable<ImmutableSet<Tile>> getTilesOnceAndStream();
+
+  /**
    * Returns all feature and record mutations in the local mutation queue relating to feature with
    * the specified id.
    */
@@ -94,8 +101,8 @@ public interface LocalDataStore {
 
   /**
    * Merges the provided record with pending unsynced local mutations, and inserts it into the local
-   * data store. If a record with the same id already exists, it will be overwritten with the
-   * merged instance.
+   * data store. If a record with the same id already exists, it will be overwritten with the merged
+   * instance.
    */
   Completable mergeRecord(Record record);
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -26,6 +26,7 @@ import androidx.room.Transaction;
 import com.google.android.gnd.GndApplication;
 import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Project;
+import com.google.android.gnd.model.basemap.tile.Tile;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.FeatureMutation;
 import com.google.android.gnd.model.observation.Record;
@@ -105,6 +106,13 @@ public class RoomLocalDataStore implements LocalDataStore {
                 stream(list)
                     .map(record -> RecordEntity.toRecord(feature, record))
                     .collect(toImmutableList()));
+  }
+
+  @Override
+  public Flowable<ImmutableSet<Tile>> getTilesOnceAndStream() {
+    return db.tileDao()
+        .findAll()
+        .map(list -> stream(list).map(TileEntity::toTile).collect(toImmutableSet()));
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/TileDao.java
@@ -5,13 +5,19 @@ import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 
+import java.util.List;
+
 import io.reactivex.Completable;
+import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 
 @Dao
 public interface TileDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     Completable insertOrUpdate(TileEntity tileEntity);
+
+    @Query("SELECT * FROM tile")
+    Flowable<List<TileEntity>> findAll();
 
     @Query("SELECT * FROM tile WHERE id = :id")
     Maybe<TileEntity> findById(String id);


### PR DESCRIPTION
This change adds methods for accessing all tiles from the local data store.
Additionally, I've updated the tile DAO so that we can fetch all tiles
from the DB.