### PR TITLE
Offline Imagery: Extent map adapter

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
@@ -15,8 +15,8 @@ import com.google.android.gnd.R;
 import com.google.android.gnd.databinding.BasemapSelectorFragBinding;
 import com.google.android.gnd.inject.ActivityScoped;
 import com.google.android.gnd.ui.common.AbstractFragment;
+import com.google.android.gnd.ui.map.ExtentSelector;
 import com.google.android.gnd.ui.map.MapProvider;
-import com.google.android.gnd.ui.map.MapProvider.MapAdapter;
 
 import javax.inject.Inject;
 
@@ -44,12 +44,12 @@ public class BasemapSelectorFragment extends AbstractFragment {
     super.onCreate(savedInstanceState);
     viewModel = getViewModel(BasemapSelectorViewModel.class);
     mainViewModel = getViewModel(MainViewModel.class);
-    Single<MapAdapter> mapAdapter = mapProvider.getMapAdapter();
+    Single<ExtentSelector> mapAdapter = mapProvider.getExtentSelector();
     mapAdapter.as(autoDisposable(this)).subscribe(this::onMapReady);
   }
 
-  private void onMapReady(MapAdapter map) {
-    map.renderJsonLayer();
+  private void onMapReady(ExtentSelector map) {
+    map.renderExtentSelectionLayer();
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/Extent.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/Extent.java
@@ -1,0 +1,51 @@
+package com.google.android.gnd.ui.map;
+
+import androidx.annotation.Nullable;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class Extent {
+  public enum State {
+    SELECTED,
+    UNSELECTED
+  }
+
+  public abstract String getId();
+
+  public abstract State getState();
+
+  public static Builder newBuilder() {
+    return new AutoValue_Extent.Builder();
+  }
+
+  public abstract Builder toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setId(String id);
+
+    public abstract Builder setState(State state);
+
+    public abstract Extent build();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (obj == this) {
+      return true;
+    }
+
+    if (!(obj instanceof Extent)) {
+      return false;
+    }
+
+    Extent extent = (Extent) obj;
+
+    if (extent.getId().equals(this.getId())) {
+      return true;
+    }
+
+    return super.equals(obj);
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/Extent.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/Extent.java
@@ -7,6 +7,9 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class Extent {
+  // TODO: Find a more appropriate name for this enum.
+  // State is confusing in this case since it suggests the class also maintains the state of the
+  // extent's corresponding tile--that's not the case.
   public enum State {
     DOWNLOADED,
     PENDING_DOWNLOAD,
@@ -24,19 +27,23 @@ public abstract class Extent {
 
   public abstract Builder toBuilder();
 
-  public static Extent fromTile(Tile tile) {
-    switch (tile.getState()) {
+  private static State toExtentState(Tile.State state) {
+    switch (state) {
       case IN_PROGRESS:
-        return Extent.newBuilder().setId(tile.getId()).setState(State.PENDING_DOWNLOAD).build();
+        return State.PENDING_DOWNLOAD;
       case DOWNLOADED:
-        return Extent.newBuilder().setId(tile.getId()).setState(State.DOWNLOADED).build();
-      case FAILED:
-        return Extent.newBuilder().setId(tile.getId()).setState(State.NONE).build();
+        return State.DOWNLOADED;
       case PENDING:
-        return Extent.newBuilder().setId(tile.getId()).setState(State.PENDING_DOWNLOAD).build();
+        return State.PENDING_DOWNLOAD;
+      case FAILED:
+        return State.NONE;
       default:
-        return Extent.newBuilder().setId(tile.getId()).setState(State.NONE).build();
+        return State.NONE;
     }
+  }
+
+  public static Extent fromTile(Tile tile) {
+    return Extent.newBuilder().setId(tile.getId()).setState(toExtentState(tile.getState())).build();
   }
 
   @AutoValue.Builder
@@ -48,6 +55,7 @@ public abstract class Extent {
     public abstract Extent build();
   }
 
+  // TODO: Remove this override, it's extraneous.
   @Override
   public boolean equals(@Nullable Object obj) {
     if (obj == this) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/Extent.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/Extent.java
@@ -2,6 +2,7 @@ package com.google.android.gnd.ui.map;
 
 import androidx.annotation.Nullable;
 
+import com.google.android.gnd.model.basemap.tile.Tile;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
@@ -22,6 +23,21 @@ public abstract class Extent {
   }
 
   public abstract Builder toBuilder();
+
+  public static Extent fromTile(Tile tile) {
+    switch (tile.getState()) {
+      case IN_PROGRESS:
+        return Extent.newBuilder().setId(tile.getId()).setState(State.PENDING_DOWNLOAD).build();
+      case DOWNLOADED:
+        return Extent.newBuilder().setId(tile.getId()).setState(State.DOWNLOADED).build();
+      case FAILED:
+        return Extent.newBuilder().setId(tile.getId()).setState(State.NONE).build();
+      case PENDING:
+        return Extent.newBuilder().setId(tile.getId()).setState(State.PENDING_DOWNLOAD).build();
+      default:
+        return Extent.newBuilder().setId(tile.getId()).setState(State.NONE).build();
+    }
+  }
 
   @AutoValue.Builder
   public abstract static class Builder {

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/Extent.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/Extent.java
@@ -7,8 +7,10 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class Extent {
   public enum State {
-    SELECTED,
-    UNSELECTED
+    DOWNLOADED,
+    PENDING_DOWNLOAD,
+    PENDING_REMOVAL,
+    NONE
   }
 
   public abstract String getId();

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/ExtentSelector.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/ExtentSelector.java
@@ -9,10 +9,13 @@ import com.google.common.collect.ImmutableSet;
 
 import io.reactivex.Observable;
 
+// TODO: After G4G, revisit this design/object hierarchy--an additional interface may not be
+// necessary.
 public interface ExtentSelector extends MapProvider.MapAdapter {
 
   Observable<Extent> getExtentSelections();
 
+  // TODO: Simplify this? Instead of consuming a set of extents, can we update extents individually?
   void updateExtentSelections(ImmutableSet<Extent> extents);
 
   void renderExtentSelectionLayer();

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/ExtentSelector.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/ExtentSelector.java
@@ -1,0 +1,28 @@
+package com.google.android.gnd.ui.map;
+
+import android.util.Pair;
+
+import androidx.annotation.Nullable;
+
+import com.google.android.gnd.model.feature.Feature;
+import com.google.common.collect.ImmutableSet;
+
+import io.reactivex.Observable;
+
+public interface ExtentSelector extends MapProvider.MapAdapter {
+
+  Observable<Extent> getExtentSelections();
+
+  void updateExtentSelections(ImmutableSet<Extent> extents);
+
+  void renderExtentSelectionLayer();
+
+  // By default, we assume extent selectors don't care about markers.
+  default Observable<MapMarker> getMarkerClicks() {
+    return Observable.empty();
+  }
+
+  default void updateMarkers(ImmutableSet<Feature> features) {
+    // Do nothing.
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/MapProvider.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/MapProvider.java
@@ -32,6 +32,8 @@ public interface MapProvider {
 
   Single<MapAdapter> getMapAdapter();
 
+  Single<ExtentSelector> getExtentSelector();
+
   /**
    * Interface defining map interactions and events. This a separate class from {@link MapProvider}
    * so that it can be returned asynchronously by {@link MapProvider#getMapAdapter()} if necessary.
@@ -60,7 +62,5 @@ public interface MapProvider {
     void enableCurrentLocationIndicator();
 
     void updateMarkers(ImmutableSet<Feature> features);
-
-    void renderJsonLayer();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/gms/BasemapSelectorMapAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/gms/BasemapSelectorMapAdapter.java
@@ -77,6 +77,8 @@ public class BasemapSelectorMapAdapter implements ExtentSelector {
       BufferedReader buf = new BufferedReader(new InputStreamReader(is));
       String line = buf.readLine();
       StringBuilder sb = new StringBuilder();
+
+      // TODO: Use a higher-level API to read the contents of the JSON file.
       while (line != null) {
         sb.append(line).append("\n");
         line = buf.readLine();
@@ -118,6 +120,7 @@ public class BasemapSelectorMapAdapter implements ExtentSelector {
     GeoJsonFeature geoJsonFeature = (GeoJsonFeature) feature;
     Extent extent = availableExtents.get(geoJsonFeature.getId());
 
+    // TODO: Refactor repetitive extent building.
     switch (extent.getState()) {
       case DOWNLOADED:
         updateExtentSelectionState(

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/gms/BasemapSelectorMapAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/gms/BasemapSelectorMapAdapter.java
@@ -1,0 +1,203 @@
+package com.google.android.gnd.ui.map.gms;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.UiSettings;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gnd.model.feature.Point;
+import com.google.android.gnd.ui.map.Extent;
+import com.google.android.gnd.ui.map.ExtentSelector;
+import com.google.common.collect.ImmutableSet;
+import com.google.maps.android.data.Feature;
+import com.google.maps.android.data.geojson.GeoJsonFeature;
+import com.google.maps.android.data.geojson.GeoJsonLayer;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+
+import io.reactivex.Observable;
+import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.PublishSubject;
+
+import static com.google.android.gms.maps.GoogleMap.OnCameraMoveStartedListener.REASON_DEVELOPER_ANIMATION;
+import static java8.util.stream.StreamSupport.stream;
+
+public class BasemapSelectorMapAdapter implements ExtentSelector {
+
+  private static final String TAG = GoogleMapsMapAdapter.class.getSimpleName();
+  private static final String GEO_JSON_FILE = "gnd-geojson.geojson";
+  private final GoogleMap map;
+  private final Context context;
+
+  private final PublishSubject<Point> dragInteractionSubject = PublishSubject.create();
+  private final BehaviorSubject<Point> cameraPositionSubject = BehaviorSubject.create();
+  private final PublishSubject<Extent> extentsSubject = PublishSubject.create();
+
+  @Nullable private LatLng cameraTargetBeforeDrag;
+  private GeoJsonLayer extentSelectionLayer;
+  private HashMap<String, Extent> availableExtents;
+
+  public BasemapSelectorMapAdapter(GoogleMap map, Context context) {
+    this.map = map;
+    this.context = context;
+    map.setMapType(GoogleMap.MAP_TYPE_HYBRID);
+    UiSettings uiSettings = map.getUiSettings();
+    uiSettings.setRotateGesturesEnabled(false);
+    uiSettings.setTiltGesturesEnabled(false);
+    uiSettings.setMyLocationButtonEnabled(false);
+    uiSettings.setMapToolbarEnabled(false);
+    uiSettings.setCompassEnabled(false);
+    uiSettings.setIndoorLevelPickerEnabled(false);
+    map.setOnCameraIdleListener(this::onCameraIdle);
+    map.setOnCameraMoveStartedListener(this::onCameraMoveStarted);
+    map.setOnCameraMoveListener(this::onCameraMove);
+    onCameraMove();
+  }
+
+  @Override
+  public void renderExtentSelectionLayer() {
+    File file = new File(context.getFilesDir(), GEO_JSON_FILE);
+
+    try {
+      InputStream is = new FileInputStream(file);
+      BufferedReader buf = new BufferedReader(new InputStreamReader(is));
+      String line = buf.readLine();
+      StringBuilder sb = new StringBuilder();
+      while (line != null) {
+        sb.append(line).append("\n");
+        line = buf.readLine();
+      }
+
+      JSONObject geoJson = new JSONObject(sb.toString());
+      this.extentSelectionLayer = new GeoJsonLayer(map, geoJson);
+      extentSelectionLayer.addLayerToMap();
+      extentSelectionLayer.setOnFeatureClickListener(this::onExtentSelection);
+
+      Iterable<GeoJsonFeature> jsonFeatures = this.extentSelectionLayer.getFeatures();
+
+      for (GeoJsonFeature feature : jsonFeatures) {
+        availableExtents.put(feature.getId(),
+            Extent.newBuilder().setId(feature.getId()).setState(Extent.State.UNSELECTED).build());
+      }
+
+      Log.d(TAG, "Extent selection layer successfully loaded");
+
+    } catch (IOException | JSONException e) {
+      Log.e(TAG, "Unable to load extent selection layer", e);
+    }
+  }
+
+  @Override
+  public void updateExtentSelections(ImmutableSet<Extent> extents) {
+    stream(extents.asList())
+        .filter(extent -> availableExtents.containsKey(extent))
+        .forEach(this::updateExtentSelectionState);
+  }
+
+  private void updateExtentSelectionState(Extent extent) {
+    availableExtents.put(extent.getId(), extent);
+    extentsSubject.onNext(extent);
+  }
+
+  private void onExtentSelection(Feature feature) {
+    GeoJsonFeature geoJsonFeature = (GeoJsonFeature) feature;
+    Extent extent = availableExtents.get(geoJsonFeature.getId());
+
+    switch (extent.getState()) {
+      case SELECTED:
+        updateExtentSelectionState(extent.toBuilder().setState(Extent.State.UNSELECTED).build());
+        break;
+      case UNSELECTED:
+        updateExtentSelectionState(extent.toBuilder().setState(Extent.State.SELECTED).build());
+        break;
+    }
+  }
+
+  @Override
+  public Observable<Extent> getExtentSelections() {
+    return Observable.empty();
+  }
+
+  @Override
+  public Observable<Point> getDragInteractions() {
+    return dragInteractionSubject;
+  }
+
+  @Override
+  public Observable<Point> getCameraPosition() {
+    return cameraPositionSubject;
+  }
+
+  @Override
+  public void enable() {
+    map.getUiSettings().setAllGesturesEnabled(true);
+  }
+
+  @Override
+  public void disable() {
+    map.getUiSettings().setAllGesturesEnabled(false);
+  }
+
+  @Override
+  public void moveCamera(Point point) {
+    map.moveCamera(CameraUpdateFactory.newLatLng(point.toLatLng()));
+  }
+
+  @Override
+  public void moveCamera(Point point, float zoomLevel) {
+    map.moveCamera(CameraUpdateFactory.newLatLngZoom(point.toLatLng(), zoomLevel));
+  }
+
+  @Override
+  public Point getCenter() {
+    return Point.fromLatLng(map.getCameraPosition().target);
+  }
+
+  @Override
+  public float getCurrentZoomLevel() {
+    return map.getCameraPosition().zoom;
+  }
+
+  @Override
+  @SuppressLint("MissingPermission")
+  public void enableCurrentLocationIndicator() {
+    if (!map.isMyLocationEnabled()) {
+      map.setMyLocationEnabled(true);
+    }
+  }
+
+  private void onCameraIdle() {
+    cameraTargetBeforeDrag = null;
+  }
+
+  private void onCameraMoveStarted(int reason) {
+    if (reason == REASON_DEVELOPER_ANIMATION) {
+      // MapAdapter was panned by the app, not the user.
+      return;
+    }
+    cameraTargetBeforeDrag = map.getCameraPosition().target;
+  }
+
+  private void onCameraMove() {
+    LatLng cameraTarget = map.getCameraPosition().target;
+    Point target = Point.fromLatLng(cameraTarget);
+    cameraPositionSubject.onNext(target);
+    if (cameraTargetBeforeDrag != null && !cameraTarget.equals(cameraTargetBeforeDrag)) {
+      dragInteractionSubject.onNext(target);
+    }
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/gms/BasemapSelectorMapAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/gms/BasemapSelectorMapAdapter.java
@@ -90,8 +90,9 @@ public class BasemapSelectorMapAdapter implements ExtentSelector {
       Iterable<GeoJsonFeature> jsonFeatures = this.extentSelectionLayer.getFeatures();
 
       for (GeoJsonFeature feature : jsonFeatures) {
-        availableExtents.put(feature.getId(),
-            Extent.newBuilder().setId(feature.getId()).setState(Extent.State.UNSELECTED).build());
+        availableExtents.put(
+            feature.getId(),
+            Extent.newBuilder().setId(feature.getId()).setState(Extent.State.NONE).build());
       }
 
       Log.d(TAG, "Extent selection layer successfully loaded");
@@ -118,11 +119,19 @@ public class BasemapSelectorMapAdapter implements ExtentSelector {
     Extent extent = availableExtents.get(geoJsonFeature.getId());
 
     switch (extent.getState()) {
-      case SELECTED:
-        updateExtentSelectionState(extent.toBuilder().setState(Extent.State.UNSELECTED).build());
+      case DOWNLOADED:
+        updateExtentSelectionState(
+            extent.toBuilder().setState(Extent.State.PENDING_REMOVAL).build());
         break;
-      case UNSELECTED:
-        updateExtentSelectionState(extent.toBuilder().setState(Extent.State.SELECTED).build());
+      case PENDING_DOWNLOAD:
+        updateExtentSelectionState(extent.toBuilder().setState(Extent.State.NONE).build());
+        break;
+      case PENDING_REMOVAL:
+        updateExtentSelectionState(extent.toBuilder().setState(Extent.State.DOWNLOADED).build());
+        break;
+      case NONE:
+        updateExtentSelectionState(
+            extent.toBuilder().setState(Extent.State.PENDING_DOWNLOAD).build());
         break;
     }
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapProvider.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapProvider.java
@@ -18,6 +18,8 @@ package com.google.android.gnd.ui.map.gms;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
+import com.google.android.gnd.ui.map.ExtentSelector;
 import com.google.android.gnd.ui.map.MapProvider;
 import io.reactivex.Single;
 import io.reactivex.subjects.SingleSubject;
@@ -27,6 +29,7 @@ public class GoogleMapsMapProvider implements MapProvider {
 
   @Nullable private GoogleMapsFragment fragment;
   @Nullable private SingleSubject<MapAdapter> map = SingleSubject.create();
+  @Nullable private SingleSubject<ExtentSelector> extentMap = SingleSubject.create();
 
   @Override
   public void restore(Fragment fragment) {
@@ -44,7 +47,8 @@ public class GoogleMapsMapProvider implements MapProvider {
   private void createMapAsync() {
     ((GoogleMapsFragment) getFragment())
         .getMapAsync(
-            googleMap -> map.onSuccess(new GoogleMapsMapAdapter(googleMap, fragment.getContext())));
+            googleMap -> {map.onSuccess(new GoogleMapsMapAdapter(googleMap, fragment.getContext()));
+            extentMap.onSuccess(new BasemapSelectorMapAdapter(googleMap, fragment.getContext()));});
   }
 
   @Override
@@ -58,5 +62,10 @@ public class GoogleMapsMapProvider implements MapProvider {
   @Override
   public Single<MapAdapter> getMapAdapter() {
     return map;
+  }
+
+  @Override
+  public Single<ExtentSelector> getExtentSelector() {
+    return extentMap;
   }
 }


### PR DESCRIPTION
I've added an extent map adapter to differentiate between maps that support extent selections and those that don't. It implements (more or less) all the methods we'll need to handle extent selections for the offline imagery functionality. 

Additionally, I've added an Extent value class that should keep our implementation flexible, (for instance, we can easily augment the class with tile styling information to be applied on extent selection).

More PRS coming your way soon ;)