### PR TITLE
Offline Imagery: Update File Download Worker

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/inject/GndWorkerFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/inject/GndWorkerFactory.java
@@ -55,7 +55,7 @@ public class GndWorkerFactory extends WorkerFactory {
     if (workerClassName.equals(LocalMutationSyncWorker.class.getName())) {
       return new LocalMutationSyncWorker(appContext, params, localDataStore, remoteDataStore);
     } else if (workerClassName.equals(FileDownloadWorker.class.getName())) {
-      return new FileDownloadWorker(appContext, params);
+      return new FileDownloadWorker(appContext, params, localDataStore);
     } else {
       throw new IllegalArgumentException("Unknown worker class " + workerClassName);
     }

--- a/gnd/src/main/java/com/google/android/gnd/model/basemap/tile/Tile.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/basemap/tile/Tile.java
@@ -24,6 +24,9 @@ public abstract class Tile {
   public static String pathFromId(String tileId) {
     // Tile ids are stored as x-y-z. Paths must be z-x-y.mbtiles.
     // TODO: Convert tile ids to paths in a less restrictive and less hacky manner.
+    // TODO: Move this method to a more appropriate home? We need to perform (and possibly will no
+    // matter where the tiles are stored) translation between the tile ID and the file path of the
+    // corresponding tile source in remote storage/wherever we pull the source tile from.
     String[] fields = tileId.replaceAll("[()]", "").split(", ");
     String filename = fields[2] + "-" + fields[0] + "-" + fields[1];
 

--- a/gnd/src/main/java/com/google/android/gnd/model/basemap/tile/Tile.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/basemap/tile/Tile.java
@@ -4,25 +4,42 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class Tile {
-    public enum State {
-        PENDING,
-        IN_PROGRESS,
-        DOWNLOADED,
-        FAILED
-    }
+  public enum State {
+    PENDING,
+    IN_PROGRESS,
+    DOWNLOADED,
+    FAILED
+  }
 
-    public abstract String getId();
-    public abstract String getPath();
-    public abstract State getState();
+  public abstract String getId();
 
-    public static Builder newBuilder() {return new AutoValue_Tile.Builder();}
+  public abstract String getPath();
 
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract Builder setId(String id);
-        public abstract Builder setPath(String path);
-        public abstract Builder setState(State state);
+  public abstract State getState();
 
-        public abstract Tile build();
-    }
+  public static Builder newBuilder() {
+    return new AutoValue_Tile.Builder();
+  }
+
+  public static String pathFromId(String tileId) {
+    // Tile ids are stored as x-y-z. Paths must be z-x-y.mbtiles.
+    // TODO: Convert tile ids to paths in a less restrictive and less hacky manner.
+    String[] fields = tileId.replaceAll("[()]", "").split(", ");
+    String filename = fields[2] + "-" + fields[0] + "-" + fields[1];
+
+    return filename + ".mbtiles";
+  }
+
+  public abstract Builder toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setId(String id);
+
+    public abstract Builder setPath(String path);
+
+    public abstract Builder setState(State state);
+
+    public abstract Tile build();
+  }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -112,8 +112,6 @@ public interface LocalDataStore {
    */
   Completable insertOrUpdateTile(Tile tile);
 
-  /**
-   * Returns the tile with the specified id from the local data store, if found.
-   */
+  /** Returns the tile with the specified id from the local data store, if found. */
   Maybe<Tile> getTile(String tileId);
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -105,4 +105,15 @@ public interface LocalDataStore {
    * instance.
    */
   Completable mergeRecord(Record record);
+
+  /**
+   * Attempts to update a tile in the local data store. If the tile doesn't exist, inserts the tile
+   * into the local data store.
+   */
+  Completable insertOrUpdateTile(Tile tile);
+
+  /**
+   * Returns the tile with the specified id from the local data store, if found.
+   */
+  Maybe<Tile> getTile(String tileId);
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -215,4 +215,14 @@ public class RoomLocalDataStore implements LocalDataStore {
   private Completable enqueue(RecordMutation mutation) {
     return db.recordMutationDao().insert(RecordMutationEntity.fromMutation(mutation));
   }
+
+  @Override
+  public Completable insertOrUpdateTile(Tile tile) {
+    return db.tileDao().insertOrUpdate(TileEntity.fromTile(tile));
+  }
+
+  @Override
+  public Maybe<Tile> getTile(String tileId) {
+    return db.tileDao().findById(tileId).map(TileEntity::toTile);
+  }
 }

--- a/gnd/src/main/java/com/google/android/gnd/workers/FileDownloadWorkManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/workers/FileDownloadWorkManager.java
@@ -29,7 +29,7 @@ import io.reactivex.Completable;
 /** Enqueues file download work to be done in the background. */
 public class FileDownloadWorkManager {
   private static final Constraints CONSTRAINTS =
-          new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
+      new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
 
   private final Provider<WorkManager> workManagerProvider;
 
@@ -58,9 +58,8 @@ public class FileDownloadWorkManager {
 
   private OneTimeWorkRequest buildWorkerRequest(String tileId) {
     return new OneTimeWorkRequest.Builder(FileDownloadWorker.class)
-            .setConstraints(CONSTRAINTS)
-            .setInputData(FileDownloadWorker.createInputData(tileId))
-            .build();
+        .setConstraints(CONSTRAINTS)
+        .setInputData(FileDownloadWorker.createInputData(tileId))
+        .build();
   }
 }
-

--- a/gnd/src/main/java/com/google/android/gnd/workers/FileDownloadWorker.java
+++ b/gnd/src/main/java/com/google/android/gnd/workers/FileDownloadWorker.java
@@ -50,14 +50,14 @@ public class FileDownloadWorker extends Worker {
   private static final String TILE_ID = "tile_id";
   private static final int BUFFER_SIZE = 4096;
   private static final String URL_BASE_PATH =
-          "https://storage.googleapis.com/ground-offline-imagery-demo/mbtiles/l8/7/";
+      "https://storage.googleapis.com/ground-offline-imagery-demo/mbtiles/l8/7/";
 
   private final Context context;
   private final LocalDataStore localDataStore;
   private final String tileId;
 
   public FileDownloadWorker(
-          @NonNull Context context, @NonNull WorkerParameters params, LocalDataStore localDataStore) {
+      @NonNull Context context, @NonNull WorkerParameters params, LocalDataStore localDataStore) {
     super(context, params);
     this.context = context;
     this.localDataStore = localDataStore;
@@ -71,6 +71,7 @@ public class FileDownloadWorker extends Worker {
 
   /**
    * Returns a url from which a tile can be downloaded.
+   *
    * @param tile
    * @return tile url
    * @throws MalformedURLException
@@ -80,18 +81,19 @@ public class FileDownloadWorker extends Worker {
   }
 
   /**
-   * Given a tile, downloads a tile source file and saves it to the device's app storage.
-   * Optional HTTP request header properties may be provided.
+   * Given a tile, downloads a tile source file and saves it to the device's app storage. Optional
+   * HTTP request header properties may be provided.
+   *
    * @param tile
    * @param requestProperties optional properties to add to the HTTP request.
    * @return
    */
-  private Result downloadTileFile(Tile tile, Optional<HashMap<String,String>> requestProperties) {
+  private Result downloadTileFile(Tile tile, Optional<HashMap<String, String>> requestProperties) {
     try {
       URL url = tileUrl(tile);
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
-      if(requestProperties.isPresent()) {
+      if (requestProperties.isPresent()) {
         for (Map.Entry<String, String> property : requestProperties.get().entrySet()) {
           connection.setRequestProperty(property.getKey(), property.getValue());
         }
@@ -112,8 +114,8 @@ public class FileDownloadWorker extends Worker {
       fos.close();
 
       localDataStore
-              .insertOrUpdateTile(tile.toBuilder().setState(Tile.State.DOWNLOADED).build())
-              .blockingAwait();
+          .insertOrUpdateTile(tile.toBuilder().setState(Tile.State.DOWNLOADED).build())
+          .blockingAwait();
 
       return Result.success();
 
@@ -121,8 +123,8 @@ public class FileDownloadWorker extends Worker {
       Log.d(TAG, "Failed to download and write file.", e);
 
       localDataStore
-              .insertOrUpdateTile(tile.toBuilder().setState(Tile.State.FAILED).build())
-              .blockingAwait();
+          .insertOrUpdateTile(tile.toBuilder().setState(Tile.State.FAILED).build())
+          .blockingAwait();
 
       return Result.failure();
     }
@@ -130,21 +132,25 @@ public class FileDownloadWorker extends Worker {
 
   /**
    * Update a tile's state in the database and initiate a download of the tile source file.
+   *
    * @param tile
-   * @return {@code Result.success()} if the tile source is download successfully, otherwise {@code Result.failure()}.
+   * @return {@code Result.success()} if the tile source is download successfully, otherwise {@code
+   *     Result.failure()}.
    */
   private Result downloadTile(Tile tile) {
     localDataStore
-            .insertOrUpdateTile(tile.toBuilder().setState(Tile.State.IN_PROGRESS).build())
-            .blockingAwait();
+        .insertOrUpdateTile(tile.toBuilder().setState(Tile.State.IN_PROGRESS).build())
+        .blockingAwait();
 
     return downloadTileFile(tile, Optional.empty());
   }
 
   /**
    * Resumes downloading the source for a tile marked as {@code Tile.State.IN_PROGRESS}.
+   *
    * @param tile
-   * @return {@code Result.success()} if the tile source is download successfully, otherwise {@code Result.failure()}.
+   * @return {@code Result.success()} if the tile source is download successfully, otherwise {@code
+   *     Result.failure()}.
    */
   private Result resumeTileDownload(Tile tile) {
     File existingTileFile = new File(context.getFilesDir(), tile.getPath());
@@ -157,8 +163,9 @@ public class FileDownloadWorker extends Worker {
 
   /**
    * Verifies that a tile marked as {@code Tile.State.DOWNLOADED} in the local database still exists
-   * in the app's storage.
-   * If the tile's source file isn't present, initiates a download of source file.
+   * in the app's storage. If the tile's source file isn't present, initiates a download of source
+   * file.
+   *
    * @param tile
    * @return
    */
@@ -174,8 +181,8 @@ public class FileDownloadWorker extends Worker {
 
   /**
    * Given a tile identifier, downloads a tile source file and saves it to the app's file storage.
-   * If the tile source file already exists on the device, this method returns
-   * {@code Result.success()} and does not re-download the file.
+   * If the tile source file already exists on the device, this method returns {@code
+   * Result.success()} and does not re-download the file.
    */
   @NonNull
   @Override
@@ -186,11 +193,11 @@ public class FileDownloadWorker extends Worker {
     // When there is no tile in the db, the maybe completes and returns null.
     if (tile == null) {
       tile =
-              Tile.newBuilder()
-                      .setId(tileId)
-                      .setState(Tile.State.PENDING)
-                      .setPath(Tile.pathFromId(tileId))
-                      .build();
+          Tile.newBuilder()
+              .setId(tileId)
+              .setState(Tile.State.PENDING)
+              .setPath(Tile.pathFromId(tileId))
+              .build();
     }
 
     switch (tile.getState()) {


### PR DESCRIPTION
I've made necessary updates to ensure the file download worker can manage the entirety of the tile downloading and db writing/mgmt flow. 

After this change is in, we only need to pass tile IDs to the worker from the view model, rather than have to worry about managing tiles. 