### PR TITLE
UI: Rename "record" to "observation"

### DIFF
--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -65,12 +65,12 @@
   -->
 
   <!-- Shown in record overflow menu to open popup dialog to edit feature metadata. -->
-  <string name="edit_record">Edit record</string>
+  <string name="edit_record">Edit observation</string>
   <!-- Shown in record overflow menu to delete a record. -->
-  <string name="delete_record">Delete record</string>
+  <string name="delete_record">Delete observation</string>
   <!-- Confirmation shown when deleting a record (TBD). -->
   <string name="delete_record_confirmation">
-    This will permanently delete the selected record. This cannot be undone. Are you sure?
+    This will permanently delete the selected observation. This cannot be undone. Are you sure?
   </string>
   <!--
     Shown above saved records (forms) that have been submitted. %1$s placeholder will already be
@@ -125,8 +125,8 @@
   <string name="invalid_data_confirm">OK</string>
 
   <string name="join_project_dialog_title">Join project</string>
-  <string name="add_record_button_label">Add record</string>
-  <string name="view_record_details">View record details</string>
+  <string name="add_record_button_label">Add observation</string>
+  <string name="view_record_details">View observation details</string>
   <string name="map_view">Map view</string>
   <string name="project_load_error">Project could not be loaded</string>
   <string name="project_list_load_error">Project list not available</string>


### PR DESCRIPTION
This change renames UI instances of the string record to observation, in
keeping with our adopted terminology.

Closes #121 