### PR TITLE
Offline Imagery: Remove offline maps from menu

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -339,10 +339,11 @@ public class HomeScreenFragment extends AbstractFragment
         showProjectSelector();
         closeDrawer();
         break;
-      case R.id.nav_offline_maps:
-        showBasemapSelector();
-        closeDrawer();
-        break;
+      // TODO: Restore once basemap selector related bugs are resolved
+      //case R.id.nav_offline_maps:
+      //  showBasemapSelector();
+      //  closeDrawer();
+      //  break;
       case R.id.nav_sign_out:
         authenticationManager.signOut();
         break;

--- a/gnd/src/main/res/menu/nav_drawer_menu.xml
+++ b/gnd/src/main/res/menu/nav_drawer_menu.xml
@@ -21,10 +21,10 @@
         android:id="@+id/nav_join_project"
         android:icon="@drawable/ic_menu_project"
         android:title="@string/select_project_menu_item"/>
-    <item
+    <!--<item
         android:id="@+id/nav_offline_maps"
         android:icon="@drawable/ic_arrow_drop_down"
-        android:title="@string/offline_maps"/>
+        android:title="@string/offline_maps"/>-->
     <item
         android:id="@+id/nav_sign_out"
         android:icon="@drawable/ic_sign_out"


### PR DESCRIPTION
Temporarily removing offline maps from the nav menu, since the
functionality is disabled.

Not sure what your plans are for this, but in case you just want to completely nix the functionality from this build, this PR temporarily removes the offline maps menu option!