### PR TITLE
Fix minor lint warnings

### DIFF
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -15,7 +15,12 @@
   ~ limitations under the License.
   -->
 <lint>
-  <issue id="InvalidPackage" severity="ignore" />
-  <issue id="MissingTranslation" severity="ignore" />
+  <!-- Severity: Warning -->
+  <issue id="DuplicateStrings" severity="warning" />
+  <issue id="InvalidPackage" severity="warning" />
+  <issue id="MissingTranslation" severity="warning" />
+
+  <!-- Severity: Error -->
+  <issue id="DuplicateIds" severity="error" />
   <issue id="PxUsage" severity="error" />
 </lint>

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -17,4 +17,5 @@
 <lint>
   <issue id="InvalidPackage" severity="ignore" />
   <issue id="MissingTranslation" severity="ignore" />
+  <issue id="PxUsage" severity="error" />
 </lint>

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -21,6 +21,7 @@
   <issue id="MissingTranslation" severity="warning" />
 
   <!-- Severity: Error -->
+  <issue id="ApplySharedPref" severity="error" />
   <issue id="DuplicateIds" severity="error" />
   <issue id="PxUsage" severity="error" />
 </lint>

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalValueStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalValueStore.java
@@ -46,11 +46,17 @@ public class LocalValueStore {
 
   /** Set the id of the last project successfully activated by the user. */
   public void setLastActiveProjectId(@NonNull String id) {
-    preferences.edit().putString(ACTIVE_PROJECT_ID_KEY, id).commit();
+    preferences
+      .edit()
+      .putString(ACTIVE_PROJECT_ID_KEY, id)
+      .apply();
   }
 
   /** Removes the last active project id in the local value store. */
   public void clearLastActiveProjectId() {
-    preferences.edit().remove(ACTIVE_PROJECT_ID_KEY).commit();
+    preferences
+      .edit()
+      .remove(ACTIVE_PROJECT_ID_KEY)
+      .apply();
   }
 }

--- a/gnd/src/main/res/layout/record_list_frag.xml
+++ b/gnd/src/main/res/layout/record_list_frag.xml
@@ -31,7 +31,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center|top"
-        android:paddingTop="150px"
+        android:paddingTop="150dp"
         android:visibility="@{viewModel.loadingSpinnerVisibility}"/>
 
     <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
Related to #217 

Changing the severity to error forces the cloud build to fail. Warnings don't cause failure but do get reported in the html.