### PR TITLE
[Code health] Spotbugs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ to the base repository using a pull request.
 1. Run code health checks locally and fix any errors.
 
    1. Using Command-line:
-      1. `$ ./gradlew checkstyle lintDebug pmd`
+      1. `$ ./gradlew checkstyle lintDebug pmd spotbugs`
     
    1. Using Android Studio
       1. Expand `gradle` side-tab (top-right corner in Android Studio IDE).
       1. Click on `Execute gradle task` button (the one with gradle logo)
-      1. Type `checkstyle lintDebug pmd` and press OK
+      1. Type `checkstyle lintDebug pmd spotbugs` and press OK
       
 1. Add your changes to the staging area:
     

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ buildscript {
 // ./gradlew dependencyUpdates -Drevision=release
 plugins {
     id "com.github.ben-manes.versions" version "0.20.0"
+    id 'com.github.spotbugs' version '1.6.4'
 }
 
 allprojects {

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -69,7 +69,7 @@ steps:
   # Build debug APK and run checkstyle checks
   - name: 'gcr.io/$PROJECT_ID/android:28'
     id: build
-    args: ['./gradlew', 'assembleDebug', 'checkstyle', 'lintDebug', 'pmd']
+    args: ['./gradlew', 'assembleDebug', 'checkstyle', 'lintDebug', 'pmd', 'spotbugs']
     env:
       - 'TERM=dumb'
       - 'JAVA_TOOL_OPTIONS="-Xmx3g"'

--- a/config/spotbugs/spotbugs-filter.xml
+++ b/config/spotbugs/spotbugs-filter.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- Excludes classes or bugs from the spotbugs check -->
+<FindBugsFilter>
+
+  <!-- Auto-generated resources classes -->
+  <Match>
+    <Class name="~.*\.R\$.*" />
+  </Match>
+
+  <!-- Auto-generated manifest classes -->
+  <Match>
+    <Class name="~.*\.Manifest\$.*" />
+  </Match>
+
+  <!-- Internationalization -->
+  <Match>
+    <Bug pattern="DM_DEFAULT_ENCODING" />
+  </Match>
+
+  <!-- Bad practice -->
+  <Match>
+    <Bug pattern="OS_OPEN_STREAM" />
+  </Match>
+  <Match>
+    <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE" />
+  </Match>
+  <Match>
+    <Bug pattern="DE_MIGHT_IGNORE" />
+  </Match>
+  <Match>
+    <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS" />
+  </Match>
+  <Match>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE" />
+  </Match>
+  <Match>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
+  </Match>
+  <Match>
+    <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE" />
+  </Match>
+  <Match>
+    <Bug pattern="OS_OPEN_STREAM_EXCEPTION_PATH" />
+  </Match>
+  <Match>
+    <Bug pattern="SE_NO_SERIALVERSIONID" />
+  </Match>
+  <Match>
+    <Bug pattern="RR_NOT_CHECKED" />
+  </Match>
+
+  <!-- Correctness -->
+  <Match>
+    <Bug pattern="NP_NULL_ON_SOME_PATH" />
+  </Match>
+  <Match>
+    <Bug pattern="NP_NULL_ON_SOME_PATH_EXCEPTION" />
+  </Match>
+  <Match>
+    <Bug pattern="NP_NULL_PARAM_DEREF" />
+  </Match>
+  <Match>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED" />
+  </Match>
+
+  <!-- Malicious code vulnerability -->
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP" />
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2" />
+  </Match>
+  <Match>
+    <Bug pattern="MS_CANNOT_BE_FINAL" />
+  </Match>
+
+  <!-- Multithreaded correctness -->
+  <Match>
+    <Bug pattern="IS2_INCONSISTENT_SYNC" />
+  </Match>
+  <Match>
+    <Bug pattern="LI_LAZY_INIT_STATIC" />
+  </Match>
+
+  <!-- Performance Warnings -->
+  <Match>
+    <Bug pattern="WMI_WRONG_MAP_ITERATOR" />
+  </Match>
+  <Match>
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+  </Match>
+  <Match>
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS" />
+  </Match>
+
+  <!-- Dodgy code Warnings -->
+  <Match>
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
+  </Match>
+  <Match>
+    <Bug pattern="DLS_DEAD_LOCAL_STORE" />
+  </Match>
+  <Match>
+    <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE" />
+  </Match>
+  <Match>
+    <Bug pattern="UCF_USELESS_CONTROL_FLOW" />
+  </Match>
+  <Match>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+  </Match>
+  <Match>
+    <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD" />
+  </Match>
+  <Match>
+    <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
+  </Match>
+  <Match>
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+  </Match>
+  <Match>
+    <Bug pattern="SF_SWITCH_NO_DEFAULT" />
+  </Match>
+  <Match>
+    <Bug pattern="SF_SWITCH_FALLTHROUGH" />
+  </Match>
+  <Match>
+    <Bug pattern="BC_UNCONFIRMED_CAST_OF_RETURN_VALUE" />
+  </Match>
+  <Match>
+    <Bug pattern="BC_UNCONFIRMED_CAST" />
+  </Match>
+  <Match>
+    <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
+  </Match>
+  <Match>
+    <Bug pattern="REC_CATCH_EXCEPTION" />
+  </Match>
+  <Match>
+    <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+  </Match>
+  <Match>
+    <Bug pattern="Warnings_STYLE" />
+  </Match>
+  <Match>
+    <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
+  </Match>
+  <Match>
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />
+  </Match>
+</FindBugsFilter>

--- a/config/spotbugs/spotbugs.gradle
+++ b/config/spotbugs/spotbugs.gradle
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spotbugs plugin configuration for code styling checks.
+ *
+ * It finds bugs in Java programs. It looks for instances of “bug patterns” — code instances that
+ * are likely to be errors.
+ * GitHub link: https://github.com/spotbugs/spotbugs
+ *
+ * Runs automatically with every build on GoogleCloudBuild.
+ *
+ * For manual run,
+ * $ ./gradlew spotbugs
+ *
+ * Report (only html format. Both can't be generated) are stored under: gnd/build/reports/spotbugs/
+ */
+
+import com.github.spotbugs.SpotBugsTask
+
+buildscript {
+    repositories {
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+        classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.4'
+    }
+}
+
+apply plugin: 'com.github.spotbugs'
+
+spotbugs {
+    toolVersion = '4.0.0-beta4'
+}
+
+def configDir = "${project.rootDir}/config/spotbugs"
+def reportsDir = "${project.buildDir}/reports"
+
+tasks.register("spotbugs", SpotBugsTask) {
+    ignoreFailures false // Fail early
+    effort = 'max'
+
+    reportLevel = 'low'
+
+    excludeFilter = new File("$configDir/spotbugs-filter.xml")
+    classes = fileTree("build/intermediates/javac/")
+
+    source = 'src'
+
+    classpath = files()
+    pluginClasspath = project.configurations.spotbugsPlugins
+    spotbugsClasspath = buildscript.configurations.classpath
+
+    setMaxHeapSize('256m')
+
+    reports {
+        html {
+            enabled true
+            setDestination new File("$reportsDir/spotbugs/spotbugs.html")
+        }
+        xml {
+            enabled false
+            setDestination new File("$reportsDir/spotbugs/spotbugs.xml")
+        }
+    }
+}

--- a/config/spotbugs/spotbugs.gradle
+++ b/config/spotbugs/spotbugs.gradle
@@ -26,7 +26,7 @@
  * For manual run,
  * $ ./gradlew spotbugs
  *
- * Report (only html format. Both can't be generated) are stored under: gnd/build/reports/spotbugs/
+ * HTML report is stored under: gnd/build/reports/spotbugs/
  */
 
 import com.github.spotbugs.SpotBugsTask

--- a/config/spotbugs/spotbugs.gradle
+++ b/config/spotbugs/spotbugs.gradle
@@ -15,7 +15,7 @@
  */
 
 /**
- * Spotbugs plugin configuration for code styling checks.
+ * Spotbugs plugin configuration.
  *
  * It finds bugs in Java programs. It looks for instances of “bug patterns” — code instances that
  * are likely to be errors.

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.google.firebase.firebase-perf'
 apply from: '../config/checkstyle/checkstyle.gradle'
 apply from: '../config/lint/lint.gradle'
 apply from: '../config/pmd/pmd.gradle'
+apply from: '../config/spotbugs/spotbugs.gradle'
 
 project.ext {
     autoDisposeVersion = "1.2.0"


### PR DESCRIPTION
Add [spotbugs](https://github.com/spotbugs/spotbugs) plugin for finding common bugs in Java classes. This can also be run manually like other plugins in the IDE or command-line.

- [x] Added to cloud build

- [x] Updated README

