### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $ keytool -list -v \
 
     https://console.firebase.google.com/
 
-2. Save config file for Android app to gnd/google-services.json:
+2. Save config file for Android app to gnd/debug/google-services.json:
 
     https://support.google.com/firebase/answer/7015592
 


### PR DESCRIPTION
Fixes #210 

The way the plugin searches for the `google-services.json` file is from in to out.
So, first buildType `debug` and then in `gnd` dir.

So, if the json file is found in `debug` or `release` dir, then the empty json file is ignored.

Tested with success.