### PR TITLE
[Code health] Add gradle task checkCode  

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ to the base repository using a pull request.
 1. Run code health checks locally and fix any errors.
 
    1. Using Command-line:
-      1. `$ ./gradlew checkstyle lintDebug pmd`
+      1. `$ ./gradlew checkCode`
     
    1. Using Android Studio
       1. Expand `gradle` side-tab (top-right corner in Android Studio IDE).
       1. Click on `Execute gradle task` button (the one with gradle logo)
-      1. Type `checkstyle lintDebug pmd` and press OK
+      1. Type `checkCode` and press OK
       
 1. Add your changes to the staging area:
     

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,10 @@ allprojects {
     }
 }
 
+task checkCode(type: GradleBuild) {
+    tasks = ['pmd', 'checkstyle', 'lintDebug', 'spotbugs']
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -69,7 +69,7 @@ steps:
   # Build debug APK and run checkstyle checks
   - name: 'gcr.io/$PROJECT_ID/android:28'
     id: build
-    args: ['./gradlew', 'assembleDebug', 'checkstyle', 'lintDebug', 'pmd']
+    args: ['./gradlew', 'assembleDebug', 'checkCode']
     env:
       - 'TERM=dumb'
       - 'JAVA_TOOL_OPTIONS="-Xmx3g"'


### PR DESCRIPTION
Running `checkCode` executes all 4 plugins (lint, pmd, checkstyle, spotbugs)

To be merged after #226