### PR TITLE
[Code health] Enable excluded checks for spotbugs

### DIFF
--- a/config/spotbugs/spotbugs-filter.xml
+++ b/config/spotbugs/spotbugs-filter.xml
@@ -28,6 +28,21 @@
     <Class name="~.*\.Manifest\$.*" />
   </Match>
 
+  <!-- Auto-generated data binding classes -->
+  <Match>
+    <Class name="~.*databinding.*Binding.*" />
+  </Match>
+
+  <!-- Auto-generated ButterKnife classes -->
+  <Match>
+    <Class name="~.*_ViewBinding$*" />
+  </Match>
+
+  <!-- Auto-generated room classes -->
+  <Match>
+    <Class name="~.*_Impl\$*.*" />
+  </Match>
+
   <!-- Internationalization -->
   <Match>
     <Bug pattern="DM_DEFAULT_ENCODING" />
@@ -40,82 +55,16 @@
   <Match>
     <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE" />
   </Match>
-  <Match>
-    <Bug pattern="DE_MIGHT_IGNORE" />
-  </Match>
-  <Match>
-    <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS" />
-  </Match>
-  <Match>
-    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE" />
-  </Match>
-  <Match>
-    <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
-  </Match>
-  <Match>
-    <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE" />
-  </Match>
-  <Match>
-    <Bug pattern="OS_OPEN_STREAM_EXCEPTION_PATH" />
-  </Match>
-  <Match>
-    <Bug pattern="SE_NO_SERIALVERSIONID" />
-  </Match>
-  <Match>
-    <Bug pattern="RR_NOT_CHECKED" />
-  </Match>
-
-  <!-- Correctness -->
-  <Match>
-    <Bug pattern="NP_NULL_ON_SOME_PATH" />
-  </Match>
-  <Match>
-    <Bug pattern="NP_NULL_ON_SOME_PATH_EXCEPTION" />
-  </Match>
-  <Match>
-    <Bug pattern="NP_NULL_PARAM_DEREF" />
-  </Match>
-  <Match>
-    <Bug pattern="RV_RETURN_VALUE_IGNORED" />
-  </Match>
-
-  <!-- Malicious code vulnerability -->
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP" />
-  </Match>
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP2" />
-  </Match>
-  <Match>
-    <Bug pattern="MS_CANNOT_BE_FINAL" />
-  </Match>
-
-  <!-- Multithreaded correctness -->
-  <Match>
-    <Bug pattern="IS2_INCONSISTENT_SYNC" />
-  </Match>
-  <Match>
-    <Bug pattern="LI_LAZY_INIT_STATIC" />
-  </Match>
 
   <!-- Performance Warnings -->
   <Match>
     <Bug pattern="WMI_WRONG_MAP_ITERATOR" />
   </Match>
   <Match>
-    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
-  </Match>
-  <Match>
-    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS" />
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />
   </Match>
 
   <!-- Dodgy code Warnings -->
-  <Match>
-    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
-  </Match>
-  <Match>
-    <Bug pattern="DLS_DEAD_LOCAL_STORE" />
-  </Match>
   <Match>
     <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE" />
   </Match>
@@ -123,45 +72,12 @@
     <Bug pattern="UCF_USELESS_CONTROL_FLOW" />
   </Match>
   <Match>
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
-  </Match>
-  <Match>
     <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD" />
-  </Match>
-  <Match>
-    <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
-  </Match>
-  <Match>
-    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
   </Match>
   <Match>
     <Bug pattern="SF_SWITCH_NO_DEFAULT" />
   </Match>
   <Match>
-    <Bug pattern="SF_SWITCH_FALLTHROUGH" />
-  </Match>
-  <Match>
-    <Bug pattern="BC_UNCONFIRMED_CAST_OF_RETURN_VALUE" />
-  </Match>
-  <Match>
-    <Bug pattern="BC_UNCONFIRMED_CAST" />
-  </Match>
-  <Match>
     <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
-  </Match>
-  <Match>
-    <Bug pattern="REC_CATCH_EXCEPTION" />
-  </Match>
-  <Match>
-    <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
-  </Match>
-  <Match>
-    <Bug pattern="Warnings_STYLE" />
-  </Match>
-  <Match>
-    <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
-  </Match>
-  <Match>
-    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Most of the issues detected by spotbugs were in the auto-generated classes. 

Filtering them out allows us to enable those checks for our source code.