### PR TITLE
[CI] Suppress failure if reports were not generated

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -93,7 +93,11 @@ steps:
   # Save all reports to GCS
   - id: Save artifacts to GCS
     name: 'gcr.io/cloud-builders/gsutil'
-    args: ['cp','-r','gnd/build/reports','gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID/reports']
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+      - cp -r gnd/build/reports gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID/reports || echo "Reports not generated"
 
   # Update status badge and fail build if errors were found in "build" step
   - id: Bubble build result


### PR DESCRIPTION
Do not kill the build if reports were not generated for any reason. (`assembleDebug` might fail).