### PR TITLE
[Refactor] Move common methods to BaseDao and refactor DAOs

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/BaseDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/BaseDao.java
@@ -16,10 +16,12 @@
 
 package com.google.android.gnd.persistence.local.room;
 
+import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.Update;
 import io.reactivex.Completable;
 import io.reactivex.Single;
+import java.util.List;
 
 /**
  * Base interface for DAOs that implement operations on a specific entity type.
@@ -27,15 +29,20 @@ import io.reactivex.Single;
  * @param <E> the type of entity that is persisted by sub-interfaces.
  */
 public interface BaseDao<E> {
+
   @Insert
   Completable insert(E entity);
 
   @Update
   Single<Integer> update(E entity);
 
-  /**
-   * Try to update the specified entity, and if it doesn't yet exist, create it.
-   */
+  @Update
+  Completable updateAll(List<E> entities);
+
+  @Delete
+  Completable delete(E entity);
+
+  /** Try to update the specified entity, and if it doesn't yet exist, create it. */
   default Completable insertOrUpdate(E entity) {
     return update(entity).filter(n -> n == 0).flatMapCompletable(__ -> insert(entity));
   }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/FeatureMutationDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/FeatureMutationDao.java
@@ -17,9 +17,7 @@
 package com.google.android.gnd.persistence.local.room;
 
 import androidx.room.Dao;
-import androidx.room.Insert;
 import androidx.room.Query;
-import androidx.room.Update;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import java.util.List;
@@ -28,12 +26,7 @@ import java.util.List;
  * Provides low-level read/write operations of {@link FeatureMutationEntity} to/from the local db.
  */
 @Dao
-public interface FeatureMutationDao {
-  @Insert
-  Completable insert(FeatureMutationEntity entity);
-
-  @Update
-  Completable updateAll(List<FeatureMutationEntity> entities);
+public interface FeatureMutationDao extends BaseDao<FeatureMutationEntity> {
 
   @Query("DELETE FROM feature_mutation WHERE id IN (:ids)")
   Completable deleteAll(List<Long> ids);

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/FieldDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/FieldDao.java
@@ -19,6 +19,4 @@ package com.google.android.gnd.persistence.local.room;
 import androidx.room.Dao;
 
 @Dao
-public interface FieldDao extends BaseDao<FieldEntity> {
-
-}
+public interface FieldDao extends BaseDao<FieldEntity> {}

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ProjectDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ProjectDao.java
@@ -17,19 +17,14 @@
 package com.google.android.gnd.persistence.local.room;
 
 import androidx.room.Dao;
-import androidx.room.Delete;
 import androidx.room.Query;
 import androidx.room.Transaction;
-import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 import java.util.List;
 
 @Dao
 public interface ProjectDao extends BaseDao<ProjectEntity> {
-
-  @Delete
-  Completable deleteProject(ProjectEntity projectEntity);
 
   @Transaction
   @Query("SELECT * FROM project")

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RecordMutationDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RecordMutationDao.java
@@ -17,21 +17,14 @@
 package com.google.android.gnd.persistence.local.room;
 
 import androidx.room.Dao;
-import androidx.room.Insert;
 import androidx.room.Query;
-import androidx.room.Update;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import java.util.List;
 
 /** Data access object for database operations related to {@link RecordMutationEntity}. */
 @Dao
-public interface RecordMutationDao {
-  @Insert
-  Completable insert(RecordMutationEntity entity);
-
-  @Update
-  Completable updateAll(List<RecordMutationEntity> entities);
+public interface RecordMutationDao extends BaseDao<RecordMutationEntity> {
 
   @Query("DELETE FROM record_mutation WHERE id IN (:ids)")
   Completable deleteAll(List<Long> ids);

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -159,7 +159,7 @@ public class RoomLocalDataStore implements LocalDataStore {
   @Override
   public Completable removeProject(Project project) {
     return projectDao
-        .deleteProject(ProjectEntity.fromProject(project))
+        .delete(ProjectEntity.fromProject(project))
         .subscribeOn(Schedulers.io());
   }
 


### PR DESCRIPTION
Moves commonly used update and delete methods to BaseDao. Also, all DAOs now extend BaseDao