### PR TITLE
[Refactor] Bind Firestore instance in module and inject using Dagger

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -19,7 +19,12 @@ package com.google.android.gnd;
 /** Project configurations. */
 public final class Config {
 
+  // Local db settings
   // TODO(#128): Reset version to 1 before releasing.
   public static final int DB_VERSION = 32;
   public static final String DB_NAME = "gnd.db";
+
+  // Firebase firestore settings
+  public static final boolean FIRESTORE_PERSISTANCE_ENABLED = false;
+  public static final boolean FIRESTORE_LOGGING_ENABLED = true;
 }

--- a/gnd/src/main/java/com/google/android/gnd/GndApplicationModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/GndApplicationModule.java
@@ -43,6 +43,8 @@ import com.google.android.gnd.persistence.remote.firestore.FirestoreDataStore;
 import com.google.android.gnd.persistence.remote.firestore.FirestoreUuidGenerator;
 import com.google.android.gnd.persistence.uuid.OfflineUuidGenerator;
 import com.google.android.gnd.ui.common.ViewModelModule;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreSettings;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -99,6 +101,22 @@ abstract class GndApplicationModule {
     return application
         .getApplicationContext()
         .getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+  }
+
+  @Provides
+  static FirebaseFirestoreSettings firebaseFirestoreSettings() {
+    return new FirebaseFirestoreSettings.Builder()
+        .setPersistenceEnabled(Config.FIRESTORE_PERSISTANCE_ENABLED)
+        .build();
+  }
+
+  @Provides
+  @Singleton
+  static FirebaseFirestore firebaseFirestore(FirebaseFirestoreSettings settings) {
+    FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+    firestore.setFirestoreSettings(settings);
+    FirebaseFirestore.setLoggingEnabled(Config.FIRESTORE_LOGGING_ENABLED);
+    return firestore;
   }
 
   @Provides

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
@@ -28,7 +28,6 @@ import com.google.android.gnd.Config;
  * <p>A separate data model is used to represent data stored locally to prevent leaking db-level
  * design details into main API * and to allow us to guarantee backwards compatibility.
  */
-// TODO: Make injectable via Dagger.
 @Database(
     entities = {
       FeatureEntity.class,

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/FirestoreDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/FirestoreDataStore.java
@@ -31,8 +31,6 @@ import com.google.android.gnd.rx.RxTask;
 import com.google.android.gnd.system.AuthenticationManager.User;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.FirebaseFirestoreSettings;
 import com.google.firebase.firestore.WriteBatch;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
@@ -46,22 +44,12 @@ import javax.inject.Singleton;
 @Singleton
 public class FirestoreDataStore implements RemoteDataStore {
 
-  // TODO(#57): Set to false to disable Firebase-managed offline persistence once local db sync
-  // is implemented for project config and users.
-  private static final FirebaseFirestoreSettings FIRESTORE_SETTINGS =
-      new FirebaseFirestoreSettings.Builder().setPersistenceEnabled(false).build();
   static final String ID_COLLECTION = "/ids";
-  private final GndFirestore db;
+
+  @Inject GndFirestore db;
 
   @Inject
-  FirestoreDataStore() {
-    // TODO: Run on I/O thread, return asynchronously.
-    // TODO: Bind the Firestore instance in a module and inject it here.
-    FirebaseFirestore firestore = FirebaseFirestore.getInstance();
-    firestore.setFirestoreSettings(FIRESTORE_SETTINGS);
-    FirebaseFirestore.setLoggingEnabled(true);
-    db = new GndFirestore(firestore);
-  }
+  FirestoreDataStore() {}
 
   static Timestamps toTimestamps(@Nullable Date created, @Nullable Date modified) {
     Timestamps.Builder timestamps = Timestamps.newBuilder();

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/GndFirestore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/GndFirestore.java
@@ -45,8 +45,11 @@ import io.reactivex.Single;
 import java.util.Collections;
 import java.util.List;
 import java8.util.function.Function;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /** Object representation of Ground Firestore database. */
+@Singleton
 public class GndFirestore extends AbstractFluentFirestore {
   private static final String TAG = GndFirestore.class.getSimpleName();
 
@@ -54,6 +57,7 @@ public class GndFirestore extends AbstractFluentFirestore {
   private static final String FEATURES = "features";
   private static final String RECORDS = "records";
 
+  @Inject
   GndFirestore(FirebaseFirestore db) {
     super(db);
   }


### PR DESCRIPTION
Things done:
 - Add binding for Firestore instance in module.
 - Move settings to `Config`
 - Inject `GndFirestore` into `FirestoreDataStore`

Testing: 
 - Manually verified the changes by running on emulator.

Advantages:
 - Moving `FirebaseFirestore` instance call to a module would allow us to use mocks in tests.
 - Code cleanup