### PR TITLE
[Add feature] Fix force quit on "Add feature"

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/basemapselector/BasemapSelectorFragment.java
@@ -69,6 +69,7 @@ public class BasemapSelectorFragment extends AbstractFragment {
     BasemapSelectorFragBinding binding =
         BasemapSelectorFragBinding.inflate(inflater, container, false);
     binding.setViewModel(viewModel);
+    binding.setLifecycleOwner(this);
     return binding.getRoot();
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -137,6 +137,7 @@ public class HomeScreenFragment extends AbstractFragment
     super.onCreateView(inflater, container, savedInstanceState);
     HomeScreenFragBinding binding = HomeScreenFragBinding.inflate(inflater, container, false);
     binding.featureSheetChrome.setViewModel(viewModel);
+    binding.setLifecycleOwner(this);
     return binding.getRoot();
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -155,7 +155,16 @@ public class HomeScreenViewModel extends AbstractViewModel {
       return;
     }
     Feature feature = state.getFeature();
-    navigator.addObservation(feature.getProject().getId(), feature.getId(), selectedForm.getId());
+    if (feature == null) {
+      Log.e(TAG, "Missing feature");
+      return;
+    }
+    Project project = feature.getProject();
+    if (project == null) {
+      Log.e(TAG, "Missing project");
+      return;
+    }
+    navigator.addObservation(project.getId(), feature.getId(), selectedForm.getId());
   }
 
   public void init() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -56,7 +56,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
   private final SingleLiveEvent<Void> openDrawerRequests;
   private final MutableLiveData<FeatureSheetState> featureSheetState;
   private final MutableLiveData<Integer> addObservationButtonVisibility =
-      new MutableLiveData<>(View.VISIBLE);
+      new MutableLiveData<>(View.GONE);
   @Nullable private Form selectedForm;
 
   @Inject

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/FeatureSheetFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/FeatureSheetFragment.java
@@ -69,6 +69,7 @@ public class FeatureSheetFragment extends AbstractFragment {
       @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     FeatureSheetFragBinding binding = FeatureSheetFragBinding.inflate(inflater, container, false);
     binding.setViewModel(viewModel);
+    binding.setLifecycleOwner(this);
     return binding.getRoot();
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/ObservationListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuresheet/ObservationListAdapter.java
@@ -47,6 +47,8 @@ class ObservationListAdapter extends RecyclerView.Adapter<ObservationListItemVie
     LayoutInflater inflater = LayoutInflater.from(parent.getContext());
     ObservationListItemBinding itemBinding =
         ObservationListItemBinding.inflate(inflater, parent, false);
+    // Note: Before using Android Data Binding for this component, holder must implement
+    // LifecycleOwner and be passed to itemBinding.setLifecycleOwner().
     return new ObservationListItemViewHolder(itemBinding);
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -108,6 +108,7 @@ public class MapContainerFragment extends AbstractFragment {
     MapContainerFragBinding binding = MapContainerFragBinding.inflate(inflater, container, false);
     binding.setViewModel(mapContainerViewModel);
     binding.setHomeScreenViewModel(homeScreenViewModel);
+    binding.setLifecycleOwner(this);
     return binding.getRoot();
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/signin/SignInFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/signin/SignInFragment.java
@@ -42,6 +42,7 @@ public class SignInFragment extends AbstractFragment implements BackPressListene
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     SignInFragBinding binding = SignInFragBinding.inflate(inflater, container, false);
     binding.setViewModel(viewModel);
+    binding.setLifecycleOwner(this);
     return binding.getRoot();
   }
 


### PR DESCRIPTION
Clicking "add feature" sometimes crashed the app because the "add record" was present on the screen but invisible even when the sheet was closed. So when clicking near the "add feature" button, we were actually clicking "add record". This was due to data binding not working since the lifecycle owner was never set. Fixed this for this use case and other binding instances.