### PR TITLE
Location lock priority and related tweaks

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     implementation "net.sourceforge.streamsupport:streamsupport-cfuture:" +
         "$project.streamSupportVersion"
 
-    // For dynamic tab bar style.
+    // Google Play Services.
     implementation "com.google.android.gms:play-services-auth:$project.gmsVersion"
     implementation "com.google.android.gms:play-services-maps:$project.gmsVersion"
     implementation "com.google.android.gms:play-services-location:$project.gmsVersion"

--- a/gnd/src/main/java/com/google/android/gnd/GndApplication.java
+++ b/gnd/src/main/java/com/google/android/gnd/GndApplication.java
@@ -49,13 +49,14 @@ public class GndApplication extends DaggerApplication {
   public void onCreate() {
     if (BuildConfig.DEBUG) {
       Log.d(TAG, "DEBUG build config active; enabling debug tooling");
-      setStrictMode();
 
-      /*
-       * Debug bridge for Android applications. Enables network and database debugging for the app
-       * accessible under chrome://inspect in Chrome desktop browser.
-       */
+      // Debug bridge for Android applications. Enables network and database debugging for the app
+      // accessible under chrome://inspect in Chrome desktop browser. Must be done before calling
+      // setStrictMode().
       Stetho.initializeWithDefaults(this);
+
+      // Log failures when trying to do work in the UI thread.
+      setStrictMode();
     }
 
     super.onCreate();

--- a/gnd/src/main/java/com/google/android/gnd/system/LocationManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/LocationManager.java
@@ -44,7 +44,7 @@ public class LocationManager {
   private static final long FASTEST_INTERVAL = 250;
   private static final LocationRequest FINE_LOCATION_UPDATES_REQUEST =
       new LocationRequest()
-          .setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY)
+          .setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY)
           .setInterval(UPDATE_INTERVAL)
           .setFastestInterval(FASTEST_INTERVAL);
 

--- a/gnd/src/main/java/com/google/android/gnd/system/LocationManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/LocationManager.java
@@ -41,7 +41,7 @@ import javax.inject.Inject;
 public class LocationManager {
   private static final String TAG = LocationManager.class.getSimpleName();
   private static final long UPDATE_INTERVAL = 1000 /* 1 sec */;
-  private static final long FASTEST_INTERVAL = 250;
+  private static final long FASTEST_INTERVAL = 250; /* 250 ms */
   private static final LocationRequest FINE_LOCATION_UPDATES_REQUEST =
       new LocationRequest()
           .setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY)


### PR DESCRIPTION
Reducing location lock priority to conserve battery. The user can always increase priority through settings. Discovering while debugging #307. 