### PR TITLE
[Project selector] Fix reappearing frozen project selector

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -109,6 +109,7 @@ public class HomeScreenFragment extends AbstractFragment
   private MapContainerFragment mapContainerFragment;
   private BottomSheetBehavior<View> bottomSheetBehavior;
   private PublishSubject<Object> showFeatureDialogRequests;
+  private ProjectSelectorDialogFragment projectSelectorDialogFragment;
 
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -137,6 +138,9 @@ public class HomeScreenFragment extends AbstractFragment
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
+
+    projectSelectorDialogFragment = new ProjectSelectorDialogFragment();
+
     HomeScreenFragBinding binding = HomeScreenFragBinding.inflate(inflater, container, false);
     binding.featureSheetChrome.setViewModel(viewModel);
     binding.setLifecycleOwner(this);
@@ -221,8 +225,22 @@ public class HomeScreenFragment extends AbstractFragment
     viewModel.init();
   }
 
+  @Override
+  public void onStop() {
+    super.onStop();
+
+    dismissProjectSelector();
+  }
+
   private void showProjectSelector() {
-    ProjectSelectorDialogFragment.show(getFragmentManager());
+    if (!projectSelectorDialogFragment.isVisible()) {
+      projectSelectorDialogFragment.show(
+          getFragmentManager(), ProjectSelectorDialogFragment.class.getSimpleName());
+    }
+  }
+
+  private void dismissProjectSelector() {
+    projectSelectorDialogFragment.dismiss();
   }
 
   private void showOfflineAreas() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/projectselector/ProjectSelectorDialogFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/projectselector/ProjectSelectorDialogFragment.java
@@ -29,7 +29,6 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.fragment.app.FragmentManager;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import com.google.android.gnd.R;
@@ -54,10 +53,6 @@ public class ProjectSelectorDialogFragment extends AbstractDialogFragment {
 
   private ProjectSelectorViewModel viewModel;
   private ArrayAdapter listAdapter;
-
-  public static void show(FragmentManager fragmentManager) {
-    new ProjectSelectorDialogFragment().show(fragmentManager, TAG);
-  }
 
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -112,7 +107,7 @@ public class ProjectSelectorDialogFragment extends AbstractDialogFragment {
   }
 
   private void onItemSelected(AdapterView<?> parent, View view, int idx, long id) {
-    getDialog().hide();
+    dismiss();
     viewModel.activateProject(idx);
   }
 }


### PR DESCRIPTION
Fixes #313. 

- [x] Call dismiss() on the fragment instead of hide() on the dialog()
- [x] Dismiss the dialog `onStop` of the home screen so it won't be restored on resume
- [x] Don't try to reopen the dialog if it's already showing