### PR TITLE
[Code health] Enforce check to detect hard-coded strings in layouts

### DIFF
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -23,5 +23,6 @@
   <!-- Severity: Error -->
   <issue id="ApplySharedPref" severity="error" />
   <issue id="DuplicateIds" severity="error" />
+  <issue id="HardcodedText" severity="error" />
   <issue id="PxUsage" severity="error" />
 </lint>

--- a/gnd/src/main/res/layout/observation_list_item.xml
+++ b/gnd/src/main/res/layout/observation_list_item.xml
@@ -51,7 +51,7 @@
         android:layout_height="wrap_content"
         android:layout_toEndOf="@id/user_name"
         android:layout_toRightOf="@id/user_name"
-        android:text=" · " />
+        android:text="@string/text_separator" />
 
       <TextView
         android:id="@+id/last_modified_date"
@@ -69,7 +69,7 @@
         android:layout_height="wrap_content"
         android:layout_toEndOf="@id/last_modified_date"
         android:layout_toRightOf="@id/last_modified_date"
-        android:text=" · "
+        android:text="@string/text_separator"
         android:textAppearance="@style/ObservationListText.Separator" />
 
       <TextView

--- a/gnd/src/main/res/layout/sign_in_frag.xml
+++ b/gnd/src/main/res/layout/sign_in_frag.xml
@@ -55,7 +55,7 @@
         android:layout_marginEnd="8dp"
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"
-        android:text="Ground"
+        android:text="@string/app_name"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.501"

--- a/gnd/src/main/res/values/strings-untranslated.xml
+++ b/gnd/src/main/res/values/strings-untranslated.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright 2020 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+
+  <string name="app_name" translatable="false">Ground</string>
+  <string name="text_separator" translatable="false">·</string>
+
+</resources>

--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -16,9 +16,6 @@
 
 <resources>
 
-  <!-- Application name. Do not translate. -->
-  <string name="app_name" translatable="false">Ground</string>
-
   <!-- Message shown while project is loading. -->
   <string name="project_loading_please_wait">Project loading, please wait &#8230;</string>
 


### PR DESCRIPTION
Enable lint check to detect hardcoded texts in xml layouts.

This should help us in future localization tasks.

@gino-m @scolsen I also noticed that some of strings are duplicate (like `add_feature_cancel` and `discard_multiple_choice_changes`). Any particular reason for that? Also, would it be fine to use android's resource for common strings (android.R.string.cancel) ?