### PR TITLE
[Refactor] Add fieldId to TextResponse

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
@@ -27,10 +27,16 @@ import java8.util.stream.Collectors;
 /** User responses to a select-one (radio) or select-multiple (checkbox) field. */
 public class MultipleChoiceResponse implements Response {
 
+  private final String fieldId;
   private List<String> choices;
 
-  public MultipleChoiceResponse(List<String> choices) {
+  private MultipleChoiceResponse(String fieldId, List<String> choices) {
+    this.fieldId = fieldId;
     this.choices = choices;
+  }
+
+  public String getFieldId() {
+    return fieldId;
   }
 
   public List<String> getChoices() {
@@ -87,7 +93,7 @@ public class MultipleChoiceResponse implements Response {
     if (codes.isEmpty()) {
       return Optional.empty();
     } else {
-      return Optional.of(new MultipleChoiceResponse(codes));
+      return Optional.of(new MultipleChoiceResponse("", codes));
     }
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
@@ -89,11 +89,11 @@ public class MultipleChoiceResponse implements Response {
     return stream(choices).sorted().collect(Collectors.joining(","));
   }
 
-  public static Optional<Response> fromList(List<String> codes) {
+  public static Optional<Response> fromList(String fieldId, List<String> codes) {
     if (codes.isEmpty()) {
       return Optional.empty();
     } else {
-      return Optional.of(new MultipleChoiceResponse("", codes));
+      return Optional.of(new MultipleChoiceResponse(fieldId, codes));
     }
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/TextResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/TextResponse.java
@@ -71,7 +71,7 @@ public class TextResponse implements Response {
     return text;
   }
 
-  public static Optional<Response> fromString(String text) {
-    return text.isEmpty() ? Optional.empty() : Optional.of(new TextResponse("", text));
+  public static Optional<Response> fromString(String fieldId, String text) {
+    return text.isEmpty() ? Optional.empty() : Optional.of(new TextResponse(fieldId, text));
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/TextResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/TextResponse.java
@@ -22,10 +22,16 @@ import java8.util.Optional;
 /** A user provided response to a text {@link Field}. */
 public class TextResponse implements Response {
 
+  private String fieldId;
   private String text;
 
-  public TextResponse(String text) {
+  private TextResponse(String fieldId, String text) {
+    this.fieldId = fieldId;
     this.text = text;
+  }
+
+  public String getFieldId() {
+    return fieldId;
   }
 
   public String getText() {
@@ -66,6 +72,6 @@ public class TextResponse implements Response {
   }
 
   public static Optional<Response> fromString(String text) {
-    return text.isEmpty() ? Optional.empty() : Optional.of(new TextResponse(text));
+    return text.isEmpty() ? Optional.empty() : Optional.of(new TextResponse("", text));
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ResponseDeltasTypeConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ResponseDeltasTypeConverter.java
@@ -67,7 +67,7 @@ public class ResponseDeltasTypeConverter {
         deltas.add(
             ResponseDelta.builder()
                 .setFieldId(fieldId)
-                .setNewResponse(ResponseJsonConverter.toResponse(jsonObject.get(fieldId)))
+                .setNewResponse(ResponseJsonConverter.toResponse(fieldId, jsonObject.get(fieldId)))
                 .build());
       }
     } catch (JSONException e) {

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ResponseJsonConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ResponseJsonConverter.java
@@ -47,9 +47,9 @@ class ResponseJsonConverter {
     return array;
   }
 
-  public static Optional<Response> toResponse(Object obj) {
+  public static Optional<Response> toResponse(String fieldId, Object obj) {
     if (obj instanceof String) {
-      return TextResponse.fromString((String) obj);
+      return TextResponse.fromString(fieldId, (String) obj);
     } else if (obj instanceof JSONArray) {
       return MultipleChoiceResponse.fromList(toList((JSONArray) obj));
     } else {

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ResponseJsonConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ResponseJsonConverter.java
@@ -51,7 +51,7 @@ class ResponseJsonConverter {
     if (obj instanceof String) {
       return TextResponse.fromString(fieldId, (String) obj);
     } else if (obj instanceof JSONArray) {
-      return MultipleChoiceResponse.fromList(toList((JSONArray) obj));
+      return MultipleChoiceResponse.fromList(fieldId, toList((JSONArray) obj));
     } else {
       Log.e(TAG, "Error parsing JSON in db of " + obj.getClass() + ": " + obj);
       return Optional.empty();

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ResponseMapTypeConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/ResponseMapTypeConverter.java
@@ -64,7 +64,7 @@ public class ResponseMapTypeConverter {
       Iterator<String> keys = jsonObject.keys();
       while (keys.hasNext()) {
         String fieldId = keys.next();
-        ResponseJsonConverter.toResponse(jsonObject.get(fieldId))
+        ResponseJsonConverter.toResponse(fieldId, jsonObject.get(fieldId))
             .ifPresent(response -> map.putResponse(fieldId, response));
       }
     } catch (JSONException e) {

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/ObservationDoc.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/ObservationDoc.java
@@ -94,7 +94,7 @@ public class ObservationDoc {
         // } else if (obj instanceof Float) {
         //   responses.put(key, new NumericResponse((Float) obj));
       } else if (obj instanceof List) {
-        MultipleChoiceResponse.fromList((List<String>) obj)
+        MultipleChoiceResponse.fromList(fieldId, (List<String>) obj)
             .ifPresent(r -> responses.putResponse(fieldId, r));
       } else {
         Log.d(TAG, "Unsupported obj in db: " + obj.getClass().getName());

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/ObservationDoc.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/ObservationDoc.java
@@ -88,7 +88,7 @@ public class ObservationDoc {
     for (String fieldId : docResponses.keySet()) {
       Object obj = docResponses.get(fieldId);
       if (obj instanceof String) {
-        TextResponse.fromString(((String) obj).trim())
+        TextResponse.fromString(fieldId, ((String) obj).trim())
             .ifPresent(r -> responses.putResponse(fieldId, r));
         // TODO(#23): Implement number fields, e.g.:
         // } else if (obj instanceof Float) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -176,7 +176,7 @@ public class EditObservationViewModel extends AbstractViewModel {
   public void onTextChanged(Field field, String text) {
     Log.v(TAG, "onTextChanged: " + field.getId());
 
-    onResponseChanged(field, TextResponse.fromString(text));
+    onResponseChanged(field, TextResponse.fromString(field.getId(), text));
   }
 
   public void onResponseChanged(Field field, Optional<Response> newResponse) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/MultiSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/MultiSelectDialogFactory.java
@@ -55,7 +55,7 @@ class MultiSelectDialogFactory {
     dialogBuilder.setTitle(field.getLabel());
     dialogBuilder.setPositiveButton(
         R.string.apply_multiple_choice_changes,
-        (dialog, which) -> responseChangeCallback.accept(state.getSelectedValues(options)));
+        (dialog, which) -> responseChangeCallback.accept(state.getSelectedValues(field, options)));
     dialogBuilder.setNegativeButton(
         R.string.discard_multiple_choice_changes, (dialog, which) -> {});
     return dialogBuilder.create();
@@ -82,14 +82,14 @@ class MultiSelectDialogFactory {
                               ((MultipleChoiceResponse) r).isSelected(options.get(i))));
     }
 
-    private Optional<Response> getSelectedValues(List<Option> options) {
+    private Optional<Response> getSelectedValues(Field field, List<Option> options) {
       ImmutableList.Builder<String> choices = new ImmutableList.Builder<>();
       for (int i = 0; i < options.size(); i++) {
         if (checkedItems[i]) {
           choices.add(options.get(i).getCode());
         }
       }
-      return MultipleChoiceResponse.fromList(choices.build());
+      return MultipleChoiceResponse.fromList(field.getId(), choices.build());
     }
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SingleSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SingleSelectDialogFactory.java
@@ -91,8 +91,8 @@ class SingleSelectDialogFactory {
 
     private Optional<Response> getSelectedValue(Field field, List<Option> options) {
       if (checkedItem >= 0) {
-        return Optional.of(
-            new MultipleChoiceResponse(ImmutableList.of(options.get(checkedItem).getCode())));
+        return MultipleChoiceResponse.fromList(
+            ImmutableList.of(options.get(checkedItem).getCode()));
       } else {
         return Optional.empty();
       }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SingleSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SingleSelectDialogFactory.java
@@ -92,7 +92,7 @@ class SingleSelectDialogFactory {
     private Optional<Response> getSelectedValue(Field field, List<Option> options) {
       if (checkedItem >= 0) {
         return MultipleChoiceResponse.fromList(
-            ImmutableList.of(options.get(checkedItem).getCode()));
+            field.getId(), ImmutableList.of(options.get(checkedItem).getCode()));
       } else {
         return Optional.empty();
       }


### PR DESCRIPTION
Inspired from #328 

There is always a need to bind the field id to the response whenever we are dealing with it (eg. EditObservationFragment / EditObservationViewModel)

Adding this field to the model would remove the extra need keep a Map<String, Response> at all places.

Next steps:

- Cleanup code 