### PR TITLE
[Photos Support] Upload photos to firebase storage

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -176,7 +176,7 @@ dependencies {
     // Guava
     implementation "com.google.guava:guava:$project.guavaVersion"
 
-    // Picasso
+    // Picasso: Image downloading and caching library
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Room

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -176,6 +176,9 @@ dependencies {
     // Guava
     implementation "com.google.guava:guava:$project.guavaVersion"
 
+    // Picasso
+    implementation 'com.squareup.picasso:picasso:2.71828'
+
     // Room
     implementation "androidx.room:room-runtime:$roomVersion"
     annotationProcessor "androidx.room:room-compiler:$roomVersion"

--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -27,6 +27,4 @@ public final class Config {
   // Firebase Cloud Firestore settings.
   public static final boolean FIRESTORE_PERSISTENCE_ENABLED = false;
   public static final boolean FIRESTORE_LOGGING_ENABLED = true;
-  public static final String FIREBASE_PROJECT_ID = "gnddemo1";
-  public static final String FIRESTORE_CLOUD_STORAGE_BUCKET = "gnddemo1.appspot.com";
 }

--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -27,4 +27,6 @@ public final class Config {
   // Firebase Cloud Firestore settings.
   public static final boolean FIRESTORE_PERSISTENCE_ENABLED = false;
   public static final boolean FIRESTORE_LOGGING_ENABLED = true;
+  public static final String FIREBASE_PROJECT_ID = "gnddemo1";
+  public static final String FIRESTORE_CLOUD_STORAGE_BUCKET = "gnddemo1.appspot.com";
 }

--- a/gnd/src/main/java/com/google/android/gnd/GndApplicationModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/GndApplicationModule.java
@@ -46,6 +46,8 @@ import com.google.android.gnd.persistence.uuid.OfflineUuidGenerator;
 import com.google.android.gnd.ui.common.ViewModelModule;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -118,6 +120,13 @@ abstract class GndApplicationModule {
     firestore.setFirestoreSettings(settings);
     FirebaseFirestore.setLoggingEnabled(Config.FIRESTORE_LOGGING_ENABLED);
     return firestore;
+  }
+
+  /** Returns a reference to the default Storage bucket. */
+  @Provides
+  @Singleton
+  static StorageReference baseFirestoreReference() {
+    return FirebaseStorage.getInstance().getReference();
   }
 
   @Provides

--- a/gnd/src/main/java/com/google/android/gnd/GndApplicationModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/GndApplicationModule.java
@@ -125,7 +125,7 @@ abstract class GndApplicationModule {
   /** Returns a reference to the default Storage bucket. */
   @Provides
   @Singleton
-  static StorageReference baseFirestoreReference() {
+  static StorageReference firebaseStorageReference() {
     return FirebaseStorage.getInstance().getReference();
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
@@ -18,7 +18,6 @@ package com.google.android.gnd.persistence.remote;
 
 import android.net.Uri;
 import android.util.Log;
-import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
 import io.reactivex.Maybe;
@@ -35,18 +34,16 @@ public class FirestoreStorageManager {
 
   private static final String TAG = FirestoreStorageManager.class.getName();
   private static final String MEDIA_ROOT_DIR = "uploaded_media";
+  private final StorageReference storageReference;
 
   @Inject
-  FirestoreStorageManager() {}
-
-  /** Returns a reference to the default Storage bucket. */
-  private StorageReference getBaseReference() {
-    return FirebaseStorage.getInstance().getReference();
+  FirestoreStorageManager(StorageReference storageReference) {
+    this.storageReference = storageReference;
   }
 
   /** Returns a reference to the root media dir. */
   private StorageReference getRootMediaDir() {
-    return getBaseReference().child(MEDIA_ROOT_DIR);
+    return storageReference.child(MEDIA_ROOT_DIR);
   }
 
   /**
@@ -61,7 +58,7 @@ public class FirestoreStorageManager {
   public Maybe<Uri> getDownloadUrl(String path) {
     return Maybe.create(
         emitter ->
-            getBaseReference()
+            storageReference
                 .child(path)
                 .getDownloadUrl()
                 .addOnSuccessListener(emitter::onSuccess)

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
@@ -66,11 +66,11 @@ public class FirestoreStorageManager {
   }
 
   /** Upload file to Firebase Storage. */
-  public String uploadMediaFromFile(File file, String fileName) {
-    StorageReference reference = createReference(fileName);
+  public String uploadMediaFromFile(File file, String destinationPath) {
+    StorageReference reference = createReference(destinationPath);
     UploadTask task = reference.putFile(Uri.fromFile(file));
 
-    uploadMediaToFirebaseStorage(task, fileName);
+    uploadMediaToFirebaseStorage(task, destinationPath);
     fetchDownloadUrl(reference, task);
     return reference.getPath();
   }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
@@ -61,7 +61,7 @@ public class FirestoreStorageManager {
    * @param fileName Name of the uploaded media
    */
   private StorageReference createReference(String fileName) {
-    return getRootMediaDir().child(fileName + '-' + getFilenameSuffix());
+    return getRootMediaDir().child(fileName);
   }
 
   /** Converts current timestamp to a string to be used a suffix for uploading media. */

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
@@ -19,14 +19,12 @@ package com.google.android.gnd.persistence.remote;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.util.Log;
+import com.google.android.gnd.Config;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
 import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -39,8 +37,6 @@ public class FirestoreStorageManager {
 
   private static final String TAG = FirestoreStorageManager.class.getName();
   private static final String MEDIA_ROOT_DIR = "uploaded_media";
-  private final SimpleDateFormat dateFormat =
-      new SimpleDateFormat("yyyyMMddHHmmss", Locale.getDefault());
 
   @Inject
   FirestoreStorageManager() {}
@@ -64,18 +60,21 @@ public class FirestoreStorageManager {
     return getRootMediaDir().child(fileName);
   }
 
-  /** Converts current timestamp to a string to be used a suffix for uploading media. */
-  private String getFilenameSuffix() {
-    return dateFormat.format(new Date());
-  }
-
   /** Upload file to Firebase Storage. */
-  public void uploadMediaFromFile(File file, String fileName) {
+  public String uploadMediaFromFile(File file, String fileName) {
     StorageReference reference = createReference(fileName);
     UploadTask task = reference.putFile(Uri.fromFile(file));
 
     uploadMediaToFirebaseStorage(task, fileName);
     fetchDownloadUrl(reference, task);
+    return finalDownloadLocation(reference.getPath());
+  }
+
+  private String finalDownloadLocation(String path) {
+    return "https://firebasestorage.googleapis.com/v0/b/"
+        + Config.FIRESTORE_CLOUD_STORAGE_BUCKET
+        + "/o/"
+        + path.substring(1).replaceAll("/", "%2F");
   }
 
   /** Upload bitmap to Firebase Storage. */

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/FirestoreStorageManager.java
@@ -16,15 +16,12 @@
 
 package com.google.android.gnd.persistence.remote;
 
-import android.graphics.Bitmap;
 import android.net.Uri;
 import android.util.Log;
-import com.google.android.gnd.Config;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
 import io.reactivex.Maybe;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Objects;
 import javax.inject.Inject;
@@ -79,26 +76,6 @@ public class FirestoreStorageManager {
     uploadMediaToFirebaseStorage(task, fileName);
     fetchDownloadUrl(reference, task);
     return reference.getPath();
-  }
-
-  public String finalDownloadLocation(String path) {
-    return "https://firebasestorage.googleapis.com/v0/b/"
-        + Config.FIRESTORE_CLOUD_STORAGE_BUCKET
-        + "/o/"
-        + path.substring(1).replaceAll("/", "%2F");
-  }
-
-  /** Upload bitmap to Firebase Storage. */
-  public void uploadMediaFromBitmap(Bitmap bitmap, String fileName) {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, baos);
-    byte[] data = baos.toByteArray();
-
-    StorageReference reference = createReference(fileName);
-    UploadTask task = reference.putBytes(data);
-
-    uploadMediaToFirebaseStorage(task, fileName);
-    fetchDownloadUrl(reference, task);
   }
 
   private void uploadMediaToFirebaseStorage(UploadTask uploadTask, String fileName) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -52,6 +52,7 @@ import com.google.android.gnd.ui.editobservation.PhotoDialogFragment.AddPhotoLis
 import com.google.android.gnd.ui.util.FileUtil;
 import com.squareup.picasso.Picasso;
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import java.io.File;
 import java8.util.Optional;
 import javax.inject.Inject;
 
@@ -200,23 +201,30 @@ public class EditObservationFragment extends AbstractFragment
             });
   }
 
-  private void updateBitmap(ImageView imageView, String path) {
-    // TODO: Image doesn't load into the imageview
+  /**
+   * Load thumbnail preview from the provided destination path.
+   *
+   * <p>If the image is not uploaded yet, then parse the filename from path and load the file from
+   * local storage.
+   *
+   * @param imageView Placeholder for photo field
+   * @param destinationPath Destination path of the uploaded image
+   */
+  private void updateBitmap(ImageView imageView, String destinationPath) {
+    // TODO: (BUG) Image doesn't load into the imageview
     viewModel
-        .getFirestoreDownloadUrl(path)
+        .getFirestoreDownloadUrl(destinationPath)
         .observeOn(AndroidSchedulers.mainThread())
         .doOnSuccess(
             uri -> {
-              // Load the file from firestore storage
+              // Load the file from Firestore Storage
               Picasso.get().load(uri).into(imageView);
             })
         .doOnError(
             throwable -> {
               // Load file locally
-              String[] splits = path.split("/");
-              Picasso.get()
-                  .load(fileUtil.getFileFromFilename(splits[splits.length - 1]))
-                  .into(imageView);
+              File file = viewModel.getLocalFileFromDestinationPath(destinationPath);
+              Picasso.get().load(file).into(imageView);
             })
         .as(autoDisposable(this))
         .subscribe();

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -21,6 +21,7 @@ import static java8.util.stream.StreamSupport.stream;
 
 import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.net.Uri;
 import android.util.Log;
 import android.view.View;
 import androidx.databinding.ObservableArrayMap;
@@ -50,6 +51,7 @@ import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.android.gnd.ui.util.FileUtil;
 import com.google.common.collect.ImmutableList;
 import io.reactivex.Completable;
+import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.processors.BehaviorProcessor;
@@ -111,6 +113,10 @@ public class EditObservationViewModel extends AbstractViewModel {
 
   /** Outcome of user clicking "Save". */
   private final LiveData<Event<SaveResult>> saveResults;
+
+  public Maybe<Uri> getFirestoreDownloadUrl(String path) {
+    return firestoreStorageManager.getDownloadUrl(path);
+  }
 
   /** Possible outcomes of user clicking "Save". */
   enum SaveResult {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -56,6 +56,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.processors.BehaviorProcessor;
 import io.reactivex.processors.PublishProcessor;
+import java.io.File;
 import java.util.Date;
 import java8.util.Optional;
 import javax.annotation.Nullable;
@@ -113,6 +114,8 @@ public class EditObservationViewModel extends AbstractViewModel {
 
   /** Outcome of user clicking "Save". */
   private final LiveData<Event<SaveResult>> saveResults;
+
+  private EditObservationFragmentArgs args;
 
   public Maybe<Uri> getFirestoreDownloadUrl(String path) {
     return firestoreStorageManager.getDownloadUrl(path);
@@ -178,6 +181,7 @@ public class EditObservationViewModel extends AbstractViewModel {
   }
 
   public void initialize(EditObservationFragmentArgs args) {
+    this.args = args;
     viewArgs.onNext(args);
   }
 
@@ -255,13 +259,23 @@ public class EditObservationViewModel extends AbstractViewModel {
             file -> {
               // If offline, Firebase will automatically upload the image when the network
               // connectivity is  re-established.
-              return firestoreStorageManager.uploadMediaFromFile(file, file.getName());
+              String remotePath = getRemoteImageDir() + file.getName();
+              return firestoreStorageManager.uploadMediaFromFile(file, remotePath);
             })
         .doOnNext(
             url -> {
               // update observable response map
               onTextChanged(form.getValue().getField(fieldId).get(), url);
             });
+  }
+
+  private String getRemoteImageDir() {
+    return args.getProjectId()
+        + File.separator
+        + args.getFormId()
+        + File.separator
+        + args.getFeatureId()
+        + File.separator;
   }
 
   public void onSaveClick() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -277,14 +277,14 @@ public class EditObservationViewModel extends AbstractViewModel {
    * path.
    */
   File getLocalFileFromDestinationPath(String destinationPath) throws FileNotFoundException {
-    String[] splits = destinationPath.split(File.separator);
+    String[] splits = destinationPath.split("/");
     return fileUtil.getFile(splits[splits.length - 1]);
   }
 
   /**
    * Generates destination path for saving the image to Firestore Storage.
    *
-   * <p>/uploaded_media/<project_id>/<form_id>/<feature_id>/filename.jpg
+   * <p>/uploaded_media/{project_id}/{form_id}/{feature_id}/{filename.jpg}
    */
   private String getRemoteImagePath(String filename) {
     return new StringJoiner(File.separator)

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -245,12 +245,14 @@ public class EditObservationViewModel extends AbstractViewModel {
   private Observable<File> saveBitmapAndUpdateResponse(Observable<Bitmap> source, String fieldId) {
     return source
         .map(bitmap -> fileUtil.saveBitmap(bitmap, fieldId + ".jpg"))
-        .doOnNext(
-            file -> {
-              // upload to firestore
-              firestoreStorageManager.uploadMediaFromFile(file, file.getName());
-            })
-        .doOnNext(file -> onTextChanged(form.getValue().getField(fieldId).get(), file.getPath()));
+        .doOnNext(file -> {
+          // upload to firestore
+          firestoreStorageManager.uploadMediaFromFile(file, file.getName());
+        })
+        .doOnNext(file -> {
+          // update observable response map
+          onTextChanged(form.getValue().getField(fieldId).get(), file.getPath());
+        });
   }
 
   public void onSaveClick() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/util/FileUtil.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/util/FileUtil.java
@@ -18,9 +18,7 @@ package com.google.android.gnd.ui.util;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.util.Log;
-import androidx.annotation.Nullable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -59,16 +57,5 @@ public class FileUtil {
       throw new FileNotFoundException("File not found: " + filename);
     }
     return file;
-  }
-
-  /** Load bitmap from a file path. */
-  @Nullable
-  public static Bitmap createBitmapFromPath(String path) {
-    File file = new File(path);
-    if (!file.exists()) {
-      Log.e(TAG, "File not found: " + path);
-      return null;
-    }
-    return BitmapFactory.decodeFile(path);
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/util/FileUtil.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/util/FileUtil.java
@@ -22,6 +22,7 @@ import android.graphics.BitmapFactory;
 import android.util.Log;
 import androidx.annotation.Nullable;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import javax.inject.Inject;
@@ -49,6 +50,14 @@ public class FileUtil {
     }
 
     Log.d(TAG, "Photo saved : " + file.getPath());
+    return file;
+  }
+
+  public File getFileFromFilename(String filename) throws FileNotFoundException {
+    File file = new File(context.getFilesDir(), filename);
+    if (!file.exists()) {
+      throw new FileNotFoundException("File not found: " + filename);
+    }
     return file;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/util/FileUtil.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/util/FileUtil.java
@@ -51,7 +51,7 @@ public class FileUtil {
     return file;
   }
 
-  public File getFileFromFilename(String filename) throws FileNotFoundException {
+  public File getFile(String filename) throws FileNotFoundException {
     File file = new File(context.getFilesDir(), filename);
     if (!file.exists()) {
       throw new FileNotFoundException("File not found: " + filename);


### PR DESCRIPTION
Towards #310 

- Uploads selected photo to firestore storage 
- If offline, the sdk handles the re-uploading when the network is available
- files are uploaded using the UUID. So, they can be stored in the db without actually having to upload the photo first
- Adds picasso to load the uploaded photo using Uri (Bug: The bitmap isn't getting loaded into the ImageView, added a TODO for that)