### PR TITLE
Disable DataClass PMD rule

### DIFF
--- a/config/pmd/pmd-ruleset.xml
+++ b/config/pmd/pmd-ruleset.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-<!--
+<?xml version="1.0"?><!--
   ~ Copyright 2019 Google LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +67,7 @@
     <exclude name="CollapsibleIfStatements" />
     <exclude name="CouplingBetweenObjects" />
     <exclude name="CyclomaticComplexity" />
+    <exclude name="DataClass" />
     <exclude name="ExcessiveImports" />
     <exclude name="ExcessiveParameterList" />
     <exclude name="GodClass" />

--- a/config/pmd/pmd-ruleset.xml
+++ b/config/pmd/pmd-ruleset.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0"?><!--
+<?xml version="1.0"?>
+
+<!--
   ~ Copyright 2019 Google LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
We sometimes want to move converters outside of data classes themselves to allow injection, finer separation of concerns, and easier testing, so suggesting to disable this rule. Wdyt?