### PR TITLE
Configure Timber logging

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -184,6 +184,9 @@ dependencies {
     // Picasso: Image downloading and caching library
     implementation 'com.squareup.picasso:picasso:2.71828'
 
+    // Logging
+    implementation 'com.jakewharton.timber:timber:4.7.1'
+
     // Room
     implementation "androidx.room:room-runtime:$roomVersion"
     annotationProcessor "androidx.room:room-compiler:$roomVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,6 @@ android.enableBuildCache=true
 # Enable simple gradle caching
 org.gradle.caching=true
 # Increase memory allotted to JVM
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# Run annotation processing in a separate task
+android.enableSeparateAnnotationProcessing=true


### PR DESCRIPTION
- Adds timber logging library (https://github.com/JakeWharton/timber)
- Upload warning/error logs to crashlytics for non-debug builds

Next steps:
- Replace Log.* calls with Timber.*
- Enable link check to prevent usages of Log.*