### PR TITLE
Stop running checkCode on install

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -216,8 +216,3 @@ apply plugin: 'com.google.gms.google-services'
 task checkCode(type: GradleBuild) {
     dependsOn 'checkstyle', 'lintDebug', 'pmd', 'spotbugs'
 }
-
-// Run code quality checks before installing apk to device
-afterEvaluate {
-    installDebug.dependsOn checkCode
-}


### PR DESCRIPTION
Auto running locally has been causing several issues so disabling for now. @shobhitagarwal1612 FYI. See also conversation on #342 and in https://gitter.im/ground-platform/ground-contributors. 