### PR TITLE
Use Apache Commons in GeoJsonParser; Fix GeoJsonExtent

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -209,7 +209,7 @@ dependencies {
     implementation "com.uber.autodispose:autodispose-android:$project.autoDisposeVersion"
     implementation "com.uber.autodispose:autodispose-android-archcomponents:$project.autoDisposeVersion"
 
-    // Apache commons IO
+    // Apache Commons IO
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation "commons-io:commons-io:$project.apacheCommonsVersion"
 }

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -23,6 +23,7 @@ apply from: '../config/pmd/pmd.gradle'
 apply from: '../config/spotbugs/spotbugs.gradle'
 
 project.ext {
+    apacheCommonsVersion = "2.6"
     autoDisposeVersion = "1.2.0"
     autoValueVersion = "1.6.3"
     butterKnifeVersion = "10.2.0"
@@ -207,6 +208,10 @@ dependencies {
 
     implementation "com.uber.autodispose:autodispose-android:$project.autoDisposeVersion"
     implementation "com.uber.autodispose:autodispose-android-archcomponents:$project.autoDisposeVersion"
+
+    // Apache commons IO
+    // https://mvnrepository.com/artifact/commons-io/commons-io
+    implementation "commons-io:commons-io:$project.apacheCommonsVersion"
 }
 
 apply plugin: 'androidx.navigation.safeargs'

--- a/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonExtent.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonExtent.java
@@ -35,8 +35,14 @@ class GeoJsonExtent {
       return ImmutableList.of();
     }
 
-    JSONArray sw = geometry.getVertices().map(j -> j.optJSONArray(0)).orElse(null);
-    JSONArray ne = geometry.getVertices().map(j -> j.optJSONArray(2)).orElse(null);
+    JSONArray g = geometry.getVertices().map(j -> j.optJSONArray(0)).orElse(null);
+
+    if (g == null) {
+      return ImmutableList.of();
+    }
+
+    JSONArray sw = g.optJSONArray(0);
+    JSONArray ne = g.optJSONArray(2);
 
     if (sw == null || ne == null) {
       return ImmutableList.of();

--- a/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonParser.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonParser.java
@@ -41,6 +41,7 @@ public class GeoJsonParser {
   private static final String TAG = GeoJsonParser.class.getSimpleName();
   private final OfflineUuidGenerator uuidGenerator;
   private static final String FEATURES_KEY = "features";
+  private static final String JSON_SOURCE_CHARSET = "UTF-8";
 
   @Inject
   GeoJsonParser(OfflineUuidGenerator uuidGenerator) {
@@ -53,7 +54,7 @@ public class GeoJsonParser {
    */
   public ImmutableList<Tile> intersectingTiles(LatLngBounds bounds, File file) {
     try {
-      String fileContents = FileUtils.readFileToString(file, Charset.forName("UTF-8"));
+      String fileContents = FileUtils.readFileToString(file, Charset.forName(JSON_SOURCE_CHARSET));
       // TODO: Separate parsing and intersection checks, make asyc (single, completable).
       JSONObject geoJson = new JSONObject(fileContents);
       // TODO: Make features constant.


### PR DESCRIPTION
**N.B.**: Includes changes from pr #390 (wait until that's submitted)

- Fix an error in handling of coordinate values in GeoJsonExtent (coordinates were nested more deeply in an array in the source than I anticipated)
- Use Apache Commons to read in Json data.﻿
