### PR TITLE
[Code-health] Add task for dependency check to Cloud Build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ allprojects {
 }
 
 task checkCode(type: GradleBuild) {
-    tasks = ['checkstyle', 'lintDebug', 'pmd', 'spotbugs']
+    tasks = ['checkstyle', 'lintDebug', 'pmd', 'spotbugs', 'dependencyUpdates']
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,8 @@ buildscript {
     }
 }
 
-// Lets us check which deps are out of date with:
-// ./gradlew dependencyUpdates -Drevision=release
 plugins {
-    id "com.github.ben-manes.versions" version "0.20.0"
+    id "com.github.ben-manes.versions" version "0.28.0"
     id 'com.github.spotbugs' version '1.6.4'
 }
 
@@ -72,4 +70,13 @@ task clean(type: Delete) {
 apply plugin: "com.pascalwelsch.gitversioner"
 gitVersioner {
     baseBranch "master"
+}
+
+// To check which dependencies are out of date:
+// ./gradlew dependencyUpdates
+tasks.dependencyUpdates {
+    checkConstraints = true
+    gradleReleaseChannel = "current"
+    outputFormatter = "json,plain"
+    outputDir = "gnd/build/reports/dependencyUpdates"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ gitVersioner {
     baseBranch "master"
 }
 
+// TODO: Create total code health svg badge using report json and add to github
 // To check which dependencies are out of date:
 // ./gradlew dependencyUpdates
 tasks.dependencyUpdates {

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -219,7 +219,3 @@ apply plugin: 'androidx.navigation.safeargs'
 // This must be last to avoid dependency collisions.
 // https://developers.google.com/android/guides/google-services-plugin#introduction
 apply plugin: 'com.google.gms.google-services'
-
-task checkCode(type: GradleBuild) {
-    dependsOn 'checkstyle', 'lintDebug', 'pmd', 'spotbugs'
-}


### PR DESCRIPTION
- Config task updateDependency
- Set output dir to /gnd/build/reports/ so that the reports are uploaded to GCS
- Add TODO for future task