### PR TITLE
Fix the height of the bottom sheet scroll view

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -180,8 +180,8 @@ public class HomeScreenFragment extends AbstractFragment
    * Set the height of the bottom sheet so it completely fills the screen when expanded.
    */
   private void setBottomSheetHeight() {
-    CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams)
-      bottomSheetScrollView.getLayoutParams();
+    CoordinatorLayout.LayoutParams params =
+        (CoordinatorLayout.LayoutParams) bottomSheetScrollView.getLayoutParams();
 
     int screenHeight = getScreenHeight(getActivity());
     int statusBarHeight = statusBarScrim.getHeight();

--- a/gnd/src/main/res/layout/feature_sheet_chrome.xml
+++ b/gnd/src/main/res/layout/feature_sheet_chrome.xml
@@ -35,8 +35,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_alignParentTop="true"
-      android:background="@color/colorPrimary"
-      android:translationY="-1000dp">
+      android:background="@color/colorPrimary">
 
       <com.google.android.gnd.ui.common.TwoLineToolbar
         android:id="@+id/toolbar"
@@ -73,6 +72,6 @@
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
       android:alpha="0"
-      android:background="@color/colorBackground" />
+      android:background="@color/colorGrey300" />
   </RelativeLayout>
 </layout>

--- a/gnd/src/main/res/layout/home_screen_frag.xml
+++ b/gnd/src/main/res/layout/home_screen_frag.xml
@@ -61,10 +61,14 @@
             android:id="@+id/feature_sheet_fragment"
             android:name="com.google.android.gnd.ui.home.featuresheet.FeatureSheetFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            tools:layout="@layout/feature_sheet_frag" />
 
         </FrameLayout>
 
+        <!-- feature_sheet_chrome contains the fixed widgets that don't scroll -
+        in this case the Add Observation button the shim to obscure
+        the transparent bottom inset -->
         <include
           android:id="@+id/feature_sheet_chrome"
           layout="@layout/feature_sheet_chrome" />
@@ -101,6 +105,7 @@
       Translucent scrim to make status bar legible when shown overlaid on map or toolbar.
       Workaround for possible bug in Navigation Architecture Components where translucent system
       bars get replaced with solid white background in fragment after navigation.
+      TODO: Is this a bug? If so, what's the bug ID? Has it been fixed?
      -->
     <FrameLayout
       android:id="@+id/status_bar_scrim"

--- a/gnd/src/main/res/layout/observation_list_frag.xml
+++ b/gnd/src/main/res/layout/observation_list_frag.xml
@@ -15,15 +15,15 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<layout>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
   <data>
     <variable
         name="viewModel"
         type="com.google.android.gnd.ui.home.featuresheet.ObservationListViewModel"/>
   </data>
 
-  <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-      android:layout_width="match_parent"
+  <FrameLayout
+    android:layout_width="match_parent"
       android:layout_height="match_parent">
 
     <ProgressBar
@@ -36,8 +36,9 @@
         android:visibility="@{viewModel.loadingSpinnerVisibility}"/>
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/observation_list_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+      android:id="@+id/observation_list_container"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:clipToPadding="false" />
   </FrameLayout>
 </layout>


### PR DESCRIPTION
Screenshot of fixed layout: 

![image](https://user-images.githubusercontent.com/873212/78704989-ae572c00-7904-11ea-8e46-0f1f89be87eb.png)

Change includes: 

- Fix to height of bottom sheet scroll view so that it perfectly fills the screen when expanded
- Fixed a related bug where the `RecyclerView` didn't fill the entire container (it was being clipped to its padding), see screenshot showing issue below. 
- Change navigation bar to a light grey to make the buttons easier to see (previously it was white)
- Added a few comments

![image](https://user-images.githubusercontent.com/873212/78704781-53253980-7904-11ea-86f8-d15c9376e7fa.png)
