### PR TITLE
[Home screen] Fix map type button margin

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -137,8 +137,8 @@ public class MapContainerFragment extends AbstractFragment {
     }
 
     mapContainerViewModel
-      .getShowMapTypeSelectorRequests()
-      .observe(getViewLifecycleOwner(), __ -> showMapTypeSelectorDialog());
+        .getShowMapTypeSelectorRequests()
+        .observe(getViewLifecycleOwner(), __ -> showMapTypeSelectorDialog());
   }
 
   private void onMapReady(MapAdapter map) {
@@ -245,7 +245,7 @@ public class MapContainerFragment extends AbstractFragment {
   private void onApplyWindowInsets(WindowInsetsCompat windowInsets) {
     ViewCompat.onApplyWindowInsets(mapProvider.getFragment().getView(), windowInsets);
     hamburgerBtn.setTranslationY(windowInsets.getSystemWindowInsetTop());
-    mapBtnLayout.setTranslationY(-windowInsets.getSystemWindowInsetBottom());
+    mapBtnLayout.setTranslationY(windowInsets.getSystemWindowInsetTop());
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -246,10 +246,7 @@ public class MapContainerFragment extends AbstractFragment {
     ViewCompat.onApplyWindowInsets(mapProvider.getFragment().getView(), windowInsets);
     hamburgerBtn.setTranslationY(windowInsets.getSystemWindowInsetTop());
     mapBtnLayout.setPadding(
-        mapBtnLayout.getPaddingLeft(),
-        windowInsets.getSystemWindowInsetTop(),
-        mapBtnLayout.getPaddingRight(),
-        windowInsets.getSystemWindowInsetBottom());
+        0, windowInsets.getSystemWindowInsetTop(), 0, windowInsets.getSystemWindowInsetBottom());
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -245,7 +245,11 @@ public class MapContainerFragment extends AbstractFragment {
   private void onApplyWindowInsets(WindowInsetsCompat windowInsets) {
     ViewCompat.onApplyWindowInsets(mapProvider.getFragment().getView(), windowInsets);
     hamburgerBtn.setTranslationY(windowInsets.getSystemWindowInsetTop());
-    mapBtnLayout.setTranslationY(windowInsets.getSystemWindowInsetTop());
+    mapBtnLayout.setPadding(
+        mapBtnLayout.getPaddingLeft(),
+        windowInsets.getSystemWindowInsetTop(),
+        mapBtnLayout.getPaddingRight(),
+        windowInsets.getSystemWindowInsetBottom());
   }
 
   @Override

--- a/gnd/src/main/res/layout/map_container_frag.xml
+++ b/gnd/src/main/res/layout/map_container_frag.xml
@@ -64,8 +64,7 @@
       android:layout_height="match_parent"
       android:layout_gravity="end"
       android:layout_marginEnd="@dimen/map_btn_margin_right"
-      android:layout_marginRight="@dimen/map_btn_margin_right"
-      android:layout_marginBottom="@dimen/map_btn_margin_bottom">
+      android:layout_marginRight="@dimen/map_btn_margin_right">
 
       <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/map_type_btn"

--- a/gnd/src/main/res/layout/map_container_frag.xml
+++ b/gnd/src/main/res/layout/map_container_frag.xml
@@ -71,7 +71,6 @@
         android:id="@+id/map_type_btn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
         android:onClick="@{() -> viewModel.onMapTypeButtonClicked()}"
         android:tint="@color/colorGrey500"
         app:backgroundTint="@color/colorBackground"

--- a/gnd/src/main/res/layout/map_container_frag.xml
+++ b/gnd/src/main/res/layout/map_container_frag.xml
@@ -62,9 +62,7 @@
       android:id="@+id/map_btn_layout"
       android:layout_width="wrap_content"
       android:layout_height="match_parent"
-      android:layout_gravity="end"
-      android:layout_marginEnd="@dimen/map_btn_margin_right"
-      android:layout_marginRight="@dimen/map_btn_margin_right">
+      android:layout_gravity="end">
 
       <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/map_type_btn"

--- a/gnd/src/main/res/values/dimens.xml
+++ b/gnd/src/main/res/values/dimens.xml
@@ -50,7 +50,7 @@
     <dimen name="observation_menu_btn_right">2dp</dimen>
     <dimen name="map_btn_spacing">8dp</dimen>
     <dimen name="map_btn_margin_right">8dp</dimen>
-    <dimen name="map_btn_margin_bottom">64dp</dimen>
+    <dimen name="map_btn_margin_bottom">8dp</dimen>
     <dimen name="toolbar_button_margin_top">8dp</dimen>
     <dimen name="toolbar_button_margin_right">12dp</dimen>
     <dimen name="chip_button_margin_bottom">16dp</dimen>

--- a/gnd/src/main/res/values/dimens.xml
+++ b/gnd/src/main/res/values/dimens.xml
@@ -50,7 +50,7 @@
     <dimen name="observation_menu_btn_right">2dp</dimen>
     <dimen name="map_btn_spacing">8dp</dimen>
     <dimen name="map_btn_margin_right">8dp</dimen>
-    <dimen name="map_btn_margin_bottom">8dp</dimen>
+    <dimen name="map_btn_margin_bottom">64dp</dimen>
     <dimen name="toolbar_button_margin_top">8dp</dimen>
     <dimen name="toolbar_button_margin_right">12dp</dimen>
     <dimen name="chip_button_margin_bottom">16dp</dimen>


### PR DESCRIPTION
Closes #422, Closes #426

 - Instead of moving the button layout in y-direction, we are now setting the top/bottom padding equal to the inset size for accurate positioning
 - removed extra left / right margin (2nd screenshot, comparing with google maps)

![image](https://user-images.githubusercontent.com/8918023/78914523-23af3200-7aa8-11ea-8cf0-c66d5b43744e.png)

![image](https://user-images.githubusercontent.com/8918023/78915395-76d5b480-7aa9-11ea-8c93-7024f1d63ef6.png)
