### PR TITLE
Add helper for debugging Single events

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/rx/RxDebug.java
+++ b/gnd/src/main/java/com/google/android/gnd/rx/RxDebug.java
@@ -52,6 +52,7 @@ public abstract class RxDebug {
             .doOnComplete(t::onComplete)
             .doOnError(t::onError);
   }
+
   /**
    * Returns a converter for use with {@link Single#as} that logs all events that occur on the
    * source stream.

--- a/gnd/src/main/java/com/google/android/gnd/rx/RxDebug.java
+++ b/gnd/src/main/java/com/google/android/gnd/rx/RxDebug.java
@@ -24,6 +24,8 @@ import io.reactivex.Flowable;
 import io.reactivex.FlowableConverter;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeConverter;
+import io.reactivex.Single;
+import io.reactivex.SingleConverter;
 import io.reactivex.disposables.Disposable;
 import org.reactivestreams.Subscription;
 
@@ -49,6 +51,14 @@ public abstract class RxDebug {
             .doOnSuccess(t::onSuccess)
             .doOnComplete(t::onComplete)
             .doOnError(t::onError);
+  }
+  /**
+   * Returns a converter for use with {@link Single#as} that logs all events that occur on the
+   * source stream.
+   */
+  public static <T> SingleConverter<T, Single<T>> tracedSingle(String tag, String streamName) {
+    Tracer t = new Tracer(tag, streamName);
+    return m -> m.doOnSubscribe(t::onSubscribe).doOnSuccess(t::onSuccess).doOnError(t::onError);
   }
 
   /**


### PR DESCRIPTION
Useful when debugging Single streams. These helpers are not actually used in code production code, only during development.