### PR TITLE
Reformat PR template for reading as unformatted markdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,20 @@
-**Instructions:**
-1. Set the PR description to a short title of the form "\[Feature name\] Fixed/Added/Refactored...".
-1. Add a reference to a related issue (Closes #number, Fixes #number). If one does not already exist,
-   [create one](../../issues/new/choose).
-1. Add high-level summary of the changes proposed in the pull request. Prefix items with `- [x]` to add a checkbox.
-1. Add steps to verify behavior where appropriate.
-1. Paste a screenshot or GIF (optional) illustrating the proposed change.
-1. @mentions of the person or team responsible for reviewing proposed changes.
-1. Delete these instructions and below example.
+Instructions:
 
-**Example:**
+1. Set the PR description to a short title of the form "Fixed/Added/Refactored...".
+2. Add a reference to a related issue (Closes #number, Fixes #number). If one does not already exist,
+   [create one](../../issues/new/choose). Be sure to add steps to verify bug/feature.
+3. Add high-level summary of the changes proposed in the pull request. Prefix items with `- [x]` to add a checkbox.
+4. Paste a screenshot or GIF (optional) illustrating the proposed change.
+5. If known, @mentions the person or team responsible for reviewing proposed changes.
+6. Delete these instructions and the example below.
 
-> Title: "\[Observation list\] Sorted observations by date"
-> - [x] Refactor ObservationViewModel allow modification of sort order.
-> - [x] Sort results when returned from ObservationRepository.
-> \[Screenshot\]
->
-> Fixes #000.
->
-> @gino-m PTAL?
+Example:
+
+Title: "Sort observation list by date"
+- [x] Refactor ObservationViewModel allow modification of sort order.
+- [x] Sort results when returned from ObservationRepository.
+[Screenshot](image.gif)
+
+Fixes #000.
+
+@... PTAL?


### PR DESCRIPTION
The PR editor opens in  "Write" mode, so developers don't see the text as Markdown formatted when writing the PR desc. Reformatted to reflect this.