### PR TITLE
Fix app crashes on missing default layer style

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -21,7 +21,7 @@ public final class Config {
 
   // Local db settings.
   // TODO(#128): Reset version to 1 before releasing.
-  public static final int DB_VERSION = 42;
+  public static final int DB_VERSION = 43;
   public static final String DB_NAME = "gnd.db";
 
   // Firebase Cloud Firestore settings.

--- a/gnd/src/main/java/com/google/android/gnd/model/layer/Layer.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/layer/Layer.java
@@ -32,7 +32,6 @@ public abstract class Layer {
   @Nullable
   public abstract String getItemLabel();
 
-  @Nullable
   public abstract Style getDefaultStyle();
 
   public abstract Optional<Form> getForm();
@@ -53,7 +52,7 @@ public abstract class Layer {
 
     public abstract Builder setItemLabel(@Nullable String newItemLabel);
 
-    public abstract Builder setDefaultStyle(@Nullable Style newDefaultStyle);
+    public abstract Builder setDefaultStyle(Style newDefaultStyle);
 
     public abstract Builder setForm(Optional<Form> form);
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/LayerEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/LayerEntity.java
@@ -59,7 +59,6 @@ public abstract class LayerEntity {
   public abstract String getItemLabel();
 
   @CopyAnnotations
-  @Nullable
   @ColumnInfo(name = "default_style")
   public abstract Style getDefaultStyle();
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
@@ -20,21 +20,25 @@ import static com.google.android.gnd.util.Localization.getLocalizedMessage;
 
 import android.util.Log;
 import com.google.android.gnd.model.layer.Layer;
+import com.google.android.gnd.model.layer.Style;
 
 /** Converts between Firestore documents and {@link Layer} instances. */
 class LayerConverter {
-
   private static final String TAG = LayerConverter.class.getSimpleName();
+
+  /** Black marker used when default remote data is corrupt or missing. */
+  private static Style DEFAULT_DEFAULT_STYLE = Style.builder().setColor("#000000").build();
 
   static Layer toLayer(String id, LayerNestedObject obj) {
     Layer.Builder layer = Layer.newBuilder();
     layer
         .setId(id)
         .setListHeading(getLocalizedMessage(obj.getListHeading()))
-        .setItemLabel(getLocalizedMessage(obj.getItemLabel()));
-    if (obj.getDefaultStyle() != null) {
-      layer.setDefaultStyle(StyleConverter.toStyle(obj.getDefaultStyle()));
-    }
+        .setItemLabel(getLocalizedMessage(obj.getItemLabel()))
+        .setDefaultStyle(
+            obj.getDefaultStyle() == null
+                ? DEFAULT_DEFAULT_STYLE
+                : StyleConverter.toStyle(obj.getDefaultStyle()));
     if (obj.getForms() != null && !obj.getForms().isEmpty()) {
       if (obj.getForms().size() > 1) {
         Log.w(TAG, "Multiple forms not supported");

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
@@ -27,7 +27,7 @@ class LayerConverter {
   private static final String TAG = LayerConverter.class.getSimpleName();
 
   /** Black marker used when default remote data is corrupt or missing. */
-  private static Style DEFAULT_DEFAULT_STYLE = Style.builder().setColor("#000000").build();
+  private static final Style DEFAULT_DEFAULT_STYLE = Style.builder().setColor("#000000").build();
 
   static Layer toLayer(String id, LayerNestedObject obj) {
     Layer.Builder layer = Layer.newBuilder();

--- a/gnd/src/test/java/com/google/android/gnd/repository/InMemoryCacheTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/InMemoryCacheTest.java
@@ -55,7 +55,7 @@ public class InMemoryCacheTest {
   }
 
   @Test
-  public void getFeatures_EmptyIfNoneAdded() {
+  public void getFeatures_emptyIfNoneAdded() {
     assertThat(inMemoryCache.getFeatures()).isEmpty();
   }
 
@@ -75,7 +75,7 @@ public class InMemoryCacheTest {
   }
 
   @Test
-  public void clear_ClearsFeatures() {
+  public void clear_clearsFeatures() {
     inMemoryCache.putFeature(FAKE_FEATURE);
     inMemoryCache.clear();
 

--- a/gnd/src/test/java/com/google/android/gnd/repository/InMemoryCacheTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/InMemoryCacheTest.java
@@ -24,6 +24,7 @@ import com.google.android.gnd.model.User;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.model.layer.Layer;
+import com.google.android.gnd.model.layer.Style;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,11 +35,15 @@ public class InMemoryCacheTest {
   private static final User FAKE_USER =
       User.builder().setId("id").setDisplayName("name").setEmail("email").build();
 
+  private static final Style FAKE_STYLE = Style.builder().setColor("#000000").build();
+
+  private static final Layer FAKE_LAYER = Layer.newBuilder().setDefaultStyle(FAKE_STYLE).build();
+
   private static final Feature FAKE_FEATURE =
       Feature.newBuilder()
           .setId("foo feature id")
           .setProject(Project.newBuilder().build())
-          .setLayer(Layer.newBuilder().build())
+          .setLayer(FAKE_LAYER)
           .setPoint(Point.newBuilder().setLatitude(0.0).setLongitude(0.0).build())
           .setCreated(AuditInfo.now(FAKE_USER))
           .setLastModified(AuditInfo.now(FAKE_USER))


### PR DESCRIPTION
Fixes #443. Older projects didn't have defaultStyle set for all layers, causing the app to crash.