### PR TITLE
Added Support for Listing Downloaded Offline Areas

### DIFF
--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -79,6 +79,9 @@ android {
     dataBinding {
         enabled = true
     }
+    viewBinding {
+        enabled = true
+    }
 }
 
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -145,4 +145,6 @@ public interface LocalDataStore {
    * the area into the local data store.
    */
   Completable insertOrUpdateOfflineArea(OfflineArea area);
+
+  Single<ImmutableList<OfflineArea>> getOfflineAreas();
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -146,5 +146,5 @@ public interface LocalDataStore {
    */
   Completable insertOrUpdateOfflineArea(OfflineArea area);
 
-  Flowable<ImmutableList<OfflineArea>> getOfflineAreas();
+  Flowable<ImmutableList<OfflineArea>> getOfflineAreasOnceAndStream();
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -146,5 +146,5 @@ public interface LocalDataStore {
    */
   Completable insertOrUpdateOfflineArea(OfflineArea area);
 
-  Single<ImmutableList<OfflineArea>> getOfflineAreas();
+  Flowable<ImmutableList<OfflineArea>> getOfflineAreas();
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -484,7 +484,7 @@ public class RoomLocalDataStore implements LocalDataStore {
   }
 
   @Override
-  public Single<ImmutableList<OfflineArea>> getOfflineAreas() {
+  public Flowable<ImmutableList<OfflineArea>> getOfflineAreas() {
     return offlineAreaDao
         .findAll()
         .map(areas -> stream(areas).map(OfflineAreaEntity::toArea).collect(toImmutableList()))

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -482,4 +482,12 @@ public class RoomLocalDataStore implements LocalDataStore {
         .insertOrUpdate(OfflineAreaEntity.fromArea(area))
         .subscribeOn(schedulers.io());
   }
+
+  @Override
+  public Single<ImmutableList<OfflineArea>> getOfflineAreas() {
+    return offlineAreaDao
+        .findAll()
+        .map(areas -> stream(areas).map(OfflineAreaEntity::toArea).collect(toImmutableList()))
+        .subscribeOn(schedulers.io());
+  }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -484,7 +484,7 @@ public class RoomLocalDataStore implements LocalDataStore {
   }
 
   @Override
-  public Flowable<ImmutableList<OfflineArea>> getOfflineAreas() {
+  public Flowable<ImmutableList<OfflineArea>> getOfflineAreasOnceAndStream() {
     return offlineAreaDao
         .findAll()
         .map(areas -> stream(areas).map(OfflineAreaEntity::toArea).collect(toImmutableList()))

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/OfflineAreaDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/OfflineAreaDao.java
@@ -19,15 +19,15 @@ package com.google.android.gnd.persistence.local.room.dao;
 import androidx.room.Dao;
 import androidx.room.Query;
 import com.google.android.gnd.persistence.local.room.entity.OfflineAreaEntity;
-import io.reactivex.Flowable;
 import io.reactivex.Maybe;
+import io.reactivex.Single;
 import java.util.List;
 
 /** Provides read/write operations for writing {@link OfflineAreaEntity} to the local db. */
 @Dao
 public interface OfflineAreaDao extends BaseDao<OfflineAreaEntity> {
   @Query("SELECT * FROM offline_area")
-  Flowable<List<OfflineAreaEntity>> findAll();
+  Single<List<OfflineAreaEntity>> findAll();
 
   @Query("SELECT * FROM offline_area WHERE id = :id")
   Maybe<OfflineAreaEntity> findById(String id);

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/OfflineAreaDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/OfflineAreaDao.java
@@ -19,15 +19,15 @@ package com.google.android.gnd.persistence.local.room.dao;
 import androidx.room.Dao;
 import androidx.room.Query;
 import com.google.android.gnd.persistence.local.room.entity.OfflineAreaEntity;
+import io.reactivex.Flowable;
 import io.reactivex.Maybe;
-import io.reactivex.Single;
 import java.util.List;
 
 /** Provides read/write operations for writing {@link OfflineAreaEntity} to the local db. */
 @Dao
 public interface OfflineAreaDao extends BaseDao<OfflineAreaEntity> {
   @Query("SELECT * FROM offline_area")
-  Single<List<OfflineAreaEntity>> findAll();
+  Flowable<List<OfflineAreaEntity>> findAll();
 
   @Query("SELECT * FROM offline_area WHERE id = :id")
   Maybe<OfflineAreaEntity> findById(String id);

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OfflineAreaEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OfflineAreaEntity.java
@@ -60,7 +60,7 @@ public abstract class OfflineAreaEntity {
   public static OfflineArea toArea(OfflineAreaEntity offlineAreaEntity) {
     LatLng northEast = new LatLng(offlineAreaEntity.getNorth(), offlineAreaEntity.getEast());
     LatLng southWest = new LatLng(offlineAreaEntity.getSouth(), offlineAreaEntity.getWest());
-    LatLngBounds bounds = new LatLngBounds(northEast, southWest);
+    LatLngBounds bounds = new LatLngBounds(southWest, northEast);
 
     return OfflineArea.newBuilder()
         .setId(offlineAreaEntity.getId())

--- a/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
+++ b/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
@@ -32,7 +32,7 @@ import com.google.android.gnd.ui.util.FileUtil;
 import com.google.android.gnd.workers.TileDownloadWorkManager;
 import com.google.common.collect.ImmutableList;
 import io.reactivex.Completable;
-import io.reactivex.Single;
+import io.reactivex.Flowable;
 import java.io.File;
 import java.io.IOException;
 import javax.inject.Inject;
@@ -96,7 +96,7 @@ public class OfflineAreaRepository {
         .andThen(enqueueTileDownloads(offlineArea));
   }
 
-  public Single<ImmutableList<OfflineArea>> getOfflineAreas() {
+  public Flowable<ImmutableList<OfflineArea>> getOfflineAreas() {
     return localDataStore.getOfflineAreas();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
+++ b/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
@@ -32,6 +32,7 @@ import com.google.android.gnd.ui.util.FileUtil;
 import com.google.android.gnd.workers.TileDownloadWorkManager;
 import com.google.common.collect.ImmutableList;
 import io.reactivex.Completable;
+import io.reactivex.Single;
 import java.io.File;
 import java.io.IOException;
 import javax.inject.Inject;
@@ -93,5 +94,9 @@ public class OfflineAreaRepository {
         .insertOrUpdateOfflineArea(offlineArea)
         .doOnError(__ -> Timber.e("failed to add/update offline area in the database"))
         .andThen(enqueueTileDownloads(offlineArea));
+  }
+
+  public Single<ImmutableList<OfflineArea>> getOfflineAreas() {
+    return localDataStore.getOfflineAreas();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
+++ b/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
@@ -96,7 +96,7 @@ public class OfflineAreaRepository {
         .andThen(enqueueTileDownloads(offlineArea));
   }
 
-  public Flowable<ImmutableList<OfflineArea>> getOfflineAreas() {
-    return localDataStore.getOfflineAreas();
+  public Flowable<ImmutableList<OfflineArea>> getOfflineAreasOnceAndStream() {
+    return localDataStore.getOfflineAreasOnceAndStream();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
@@ -36,8 +36,8 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
     }
   }
 
-  OfflineAreaListAdapter(ImmutableList<OfflineArea> areas) {
-    offlineAreas = areas;
+  OfflineAreaListAdapter() {
+    offlineAreas = ImmutableList.of();
   }
 
   @NotNull
@@ -59,5 +59,10 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
   @Override
   public int getItemCount() {
     return offlineAreas.size();
+  }
+
+  void update(ImmutableList<OfflineArea> offlineAreas) {
+    this.offlineAreas = offlineAreas;
+    notifyDataSetChanged();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
@@ -53,7 +53,7 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
 
   @Override
   public void onBindViewHolder(ViewHolder viewHolder, int position) {
-    viewHolder.binding.offlineAreaName.setText(offlineAreas.iterator().next().getId());
+    viewHolder.binding.offlineAreaName.setText(offlineAreas.get(position).getId());
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
@@ -18,11 +18,11 @@ package com.google.android.gnd.ui.offlinearea;
 
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.gnd.databinding.OfflineAreasListItemBinding;
 import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.common.collect.ImmutableList;
-import org.jetbrains.annotations.NotNull;
 
 class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter.ViewHolder> {
   private ImmutableList<OfflineArea> offlineAreas;
@@ -30,9 +30,9 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
   public static class ViewHolder extends RecyclerView.ViewHolder {
     public OfflineAreasListItemBinding binding;
 
-    ViewHolder(OfflineAreasListItemBinding b) {
-      super(b.getRoot());
-      binding = b;
+    ViewHolder(OfflineAreasListItemBinding binding) {
+      super(binding.getRoot());
+      this.binding = binding;
     }
   }
 
@@ -40,15 +40,15 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
     offlineAreas = ImmutableList.of();
   }
 
-  @NotNull
+  @NonNull
   @Override
   public OfflineAreaListAdapter.ViewHolder onCreateViewHolder(
-      @NotNull ViewGroup parent, int viewType) {
-    OfflineAreasListItemBinding o =
+      @NonNull ViewGroup parent, int viewType) {
+    OfflineAreasListItemBinding offlineAreasListItemBinding =
         OfflineAreasListItemBinding.inflate(
             LayoutInflater.from(parent.getContext()), parent, false);
 
-    return new ViewHolder(o);
+    return new ViewHolder(offlineAreasListItemBinding);
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gnd.ui.offlinearea;
+
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.android.gnd.databinding.OfflineAreasListItemBinding;
+import com.google.android.gnd.model.basemap.OfflineArea;
+import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.NotNull;
+
+class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter.ViewHolder> {
+  private ImmutableList<OfflineArea> offlineAreas;
+
+  public static class ViewHolder extends RecyclerView.ViewHolder {
+    public OfflineAreasListItemBinding binding;
+
+    ViewHolder(OfflineAreasListItemBinding b) {
+      super(b.getRoot());
+      binding = b;
+    }
+  }
+
+  OfflineAreaListAdapter(ImmutableList<OfflineArea> areas) {
+    offlineAreas = areas;
+  }
+
+  @NotNull
+  @Override
+  public OfflineAreaListAdapter.ViewHolder onCreateViewHolder(
+      @NotNull ViewGroup parent, int viewType) {
+    OfflineAreasListItemBinding o =
+        OfflineAreasListItemBinding.inflate(
+            LayoutInflater.from(parent.getContext()), parent, false);
+
+    return new ViewHolder(o);
+  }
+
+  @Override
+  public void onBindViewHolder(ViewHolder viewHolder, int position) {
+    viewHolder.binding.offlineAreaName.setText(offlineAreas.iterator().next().getId());
+  }
+
+  @Override
+  public int getItemCount() {
+    return offlineAreas.size();
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasFragment.java
@@ -46,8 +46,7 @@ import timber.log.Timber;
 @ActivityScoped
 public class OfflineAreasFragment extends AbstractFragment {
 
-  private OfflineAreaListAdapter offlineAreaListAdapter;
-  private ImmutableList<OfflineArea> offlineAreas;
+  private ImmutableList<OfflineArea> offlineAreas = ImmutableList.of();
   @Inject Schedulers schedulers;
 
   @BindView(R.id.offline_areas_list)
@@ -69,20 +68,13 @@ public class OfflineAreasFragment extends AbstractFragment {
   private void updateOfflineAreas(ImmutableList<OfflineArea> offlineAreas) {
     Timber.d("Got offline areas: %s", offlineAreas);
     this.offlineAreas = offlineAreas;
-
-    // Invoking this function prior to setting the recycler is necessary to prevent a null reference
-    // in the recycler.
-    // So, we have to avoid notifying the adapter on the first call, since it won't be set yet.
-    if (this.offlineAreaListAdapter != null) {
-      this.offlineAreaListAdapter.notifyDataSetChanged();
-    }
   }
 
   @Override
   public View onCreateView(
       @NotNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
-    com.google.android.gnd.databinding.OfflineAreasFragBinding binding =
+    OfflineAreasFragBinding binding =
         OfflineAreasFragBinding.inflate(inflater, container, false);
 
     binding.setViewModel(viewModel);
@@ -91,7 +83,7 @@ public class OfflineAreasFragment extends AbstractFragment {
     ((MainActivity) getActivity()).setActionBar(binding.offlineAreasToolbar, true);
 
     RecyclerView recyclerView = binding.offlineAreasList;
-    this.offlineAreaListAdapter = new OfflineAreaListAdapter(offlineAreas);
+    OfflineAreaListAdapter offlineAreaListAdapter = new OfflineAreaListAdapter(offlineAreas);
     recyclerView.setHasFixedSize(true);
     recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
     recyclerView.setAdapter(offlineAreaListAdapter);

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasFragment.java
@@ -30,6 +30,7 @@ import com.google.android.gnd.R;
 import com.google.android.gnd.databinding.OfflineAreasFragBinding;
 import com.google.android.gnd.inject.ActivityScoped;
 import com.google.android.gnd.ui.common.AbstractFragment;
+
 /**
  * Fragment containing a list of downloaded areas on the device. An area is a set of offline raster
  * tiles. Users can manage their areas within this fragment. They can delete areas they no longer

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasFragment.java
@@ -20,6 +20,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -29,8 +30,6 @@ import com.google.android.gnd.R;
 import com.google.android.gnd.databinding.OfflineAreasFragBinding;
 import com.google.android.gnd.inject.ActivityScoped;
 import com.google.android.gnd.ui.common.AbstractFragment;
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Fragment containing a list of downloaded areas on the device. An area is a set of offline raster
  * tiles. Users can manage their areas within this fragment. They can delete areas they no longer
@@ -38,8 +37,6 @@ import org.jetbrains.annotations.NotNull;
  */
 @ActivityScoped
 public class OfflineAreasFragment extends AbstractFragment {
-
-  private OfflineAreaListAdapter offlineAreaListAdapter;
 
   // TODO: Remove. Right now removing this results in runtime crashes. Not precisely sure why.
   // It stems from AbstractFragment and its use of ButterKnife.
@@ -52,13 +49,11 @@ public class OfflineAreasFragment extends AbstractFragment {
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     viewModel = getViewModel(OfflineAreasViewModel.class);
-    this.offlineAreaListAdapter = new OfflineAreaListAdapter();
-    viewModel.getOfflineAreas().observe(this, offlineAreaListAdapter::update);
   }
 
   @Override
   public View onCreateView(
-      @NotNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+      @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     OfflineAreasFragBinding binding = OfflineAreasFragBinding.inflate(inflater, container, false);
 
@@ -67,10 +62,13 @@ public class OfflineAreasFragment extends AbstractFragment {
 
     ((MainActivity) getActivity()).setActionBar(binding.offlineAreasToolbar, true);
 
+    OfflineAreaListAdapter offlineAreaListAdapter = new OfflineAreaListAdapter();
     RecyclerView recyclerView = binding.offlineAreasList;
     recyclerView.setHasFixedSize(true);
     recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
     recyclerView.setAdapter(offlineAreaListAdapter);
+
+    viewModel.getOfflineAreas().observe(getViewLifecycleOwner(), offlineAreaListAdapter::update);
 
     return binding.getRoot();
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
@@ -37,7 +37,7 @@ public class OfflineAreasViewModel extends AbstractViewModel {
   OfflineAreasViewModel(Navigator navigator, OfflineAreaRepository offlineAreaRepository) {
     this.navigator = navigator;
     this.offlineAreas =
-        LiveDataReactiveStreams.fromPublisher(offlineAreaRepository.getOfflineAreas());
+        LiveDataReactiveStreams.fromPublisher(offlineAreaRepository.getOfflineAreasOnceAndStream());
   }
 
   public void showOfflineAreaSelector() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
@@ -16,12 +16,13 @@
 
 package com.google.android.gnd.ui.offlinearea;
 
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.LiveDataReactiveStreams;
 import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.repository.OfflineAreaRepository;
 import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.common.collect.ImmutableList;
-import io.reactivex.Single;
 import javax.inject.Inject;
 
 /**
@@ -29,20 +30,21 @@ import javax.inject.Inject;
  */
 public class OfflineAreasViewModel extends AbstractViewModel {
 
+  private LiveData<ImmutableList<OfflineArea>> offlineAreas;
   private final Navigator navigator;
-  private final OfflineAreaRepository offlineAreaRepository;
 
   @Inject
   OfflineAreasViewModel(Navigator navigator, OfflineAreaRepository offlineAreaRepository) {
     this.navigator = navigator;
-    this.offlineAreaRepository = offlineAreaRepository;
+    this.offlineAreas =
+        LiveDataReactiveStreams.fromPublisher(offlineAreaRepository.getOfflineAreas());
   }
 
   public void showOfflineAreaSelector() {
     navigator.showOfflineAreaSelector();
   }
 
-  Single<ImmutableList<OfflineArea>> getOfflineAreas() {
-    return offlineAreaRepository.getOfflineAreas();
+  LiveData<ImmutableList<OfflineArea>> getOfflineAreas() {
+    return offlineAreas;
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
@@ -16,8 +16,12 @@
 
 package com.google.android.gnd.ui.offlinearea;
 
+import com.google.android.gnd.model.basemap.OfflineArea;
+import com.google.android.gnd.repository.OfflineAreaRepository;
 import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.android.gnd.ui.common.Navigator;
+import com.google.common.collect.ImmutableList;
+import io.reactivex.Single;
 import javax.inject.Inject;
 
 /**
@@ -26,14 +30,19 @@ import javax.inject.Inject;
 public class OfflineAreasViewModel extends AbstractViewModel {
 
   private final Navigator navigator;
-  // TODO: Implement the ViewModel
+  private final OfflineAreaRepository offlineAreaRepository;
 
   @Inject
-  OfflineAreasViewModel(Navigator navigator) {
+  OfflineAreasViewModel(Navigator navigator, OfflineAreaRepository offlineAreaRepository) {
     this.navigator = navigator;
+    this.offlineAreaRepository = offlineAreaRepository;
   }
 
   public void showOfflineAreaSelector() {
     navigator.showOfflineAreaSelector();
+  }
+
+  Single<ImmutableList<OfflineArea>> getOfflineAreas() {
+    return offlineAreaRepository.getOfflineAreas();
   }
 }

--- a/gnd/src/main/res/layout/offline_areas_list_item.xml
+++ b/gnd/src/main/res/layout/offline_areas_list_item.xml
@@ -18,13 +18,12 @@
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="wrap_content">
 
   <TextView
     android:id="@+id/offline_area_name"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:padding="26dp"
     android:textColor="@color/colorForeground"
     android:textSize="16sp" />
 

--- a/gnd/src/main/res/layout/offline_areas_list_item.xml
+++ b/gnd/src/main/res/layout/offline_areas_list_item.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2020 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <TextView
+    android:id="@+id/offline_area_name"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:padding="26dp"
+    android:textColor="@color/colorForeground"
+    android:textSize="16sp" />
+
+</FrameLayout>


### PR DESCRIPTION
Currently we just list the ID of each area. Eventually, we'll give users controls to delete and manage areas from this UI.

- [x] Enable viewBinding.
- [x] List Offline Areas downloaded on the device.
- [x] Ensure list is refreshed on subsequent downloads.

<img width="411" alt="Screen Shot 2020-04-16 at 12 55 48 PM" src="https://user-images.githubusercontent.com/11237600/79485897-ee44a000-7fe3-11ea-8e37-8a844976470f.png">

towards #308

@gino-m @shobhitagarwal1612 

Almost done -- just did a quick check and have to ensure the last item on the list is working.