### PR TITLE
[Feature sheet] Simplify bottom sheet header design

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/BottomSheetChromeBehavior.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/BottomSheetChromeBehavior.java
@@ -49,9 +49,7 @@ public class BottomSheetChromeBehavior extends OnBottomSheetSlideBehavior<ViewGr
     metrics.hideWithSheet(hamburgerButton, HIDE_ADD_BUTTON_THRESHOLD, SHOW_ADD_BUTTON_THRESHOLD);
     metrics.showWithSheet(
         addObservationButton, HIDE_ADD_BUTTON_THRESHOLD, SHOW_ADD_BUTTON_THRESHOLD);
-    toolbarWrapper.setBackgroundColor(layout.getResources().getColor(R.color.colorPrimary));
     toolbarWrapper.setTranslationY(
         scale(metrics.getVisibleRatio(), 0.3f, 0.5f, -toolbarWrapper.getHeight(), 0));
-    metrics.showWithSheet(toolbarWrapper.getBackground(), 0.9f, 1);
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/BottomSheetChromeBehavior.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/BottomSheetChromeBehavior.java
@@ -44,7 +44,6 @@ public class BottomSheetChromeBehavior extends OnBottomSheetSlideBehavior<ViewGr
     View bottomSheetScrim = layout.findViewById(R.id.bottom_sheet_bottom_inset_scrim);
     View addObservationButton = layout.findViewById(R.id.add_observation_btn);
     ViewGroup toolbarWrapper = layout.findViewById(R.id.toolbar_wrapper);
-    ViewGroup toolbarTitles = toolbarWrapper.findViewById(R.id.toolbar_titles_layout);
     metrics.showWithSheet(mapScrim, 0.75f, 1.0f);
     metrics.showWithSheet(bottomSheetScrim, HIDE_SCRIM_THRESHOLD, SHOW_SCRIM_THRESHOLD);
     metrics.hideWithSheet(hamburgerButton, HIDE_ADD_BUTTON_THRESHOLD, SHOW_ADD_BUTTON_THRESHOLD);
@@ -54,8 +53,5 @@ public class BottomSheetChromeBehavior extends OnBottomSheetSlideBehavior<ViewGr
     toolbarWrapper.setTranslationY(
         scale(metrics.getVisibleRatio(), 0.3f, 0.5f, -toolbarWrapper.getHeight(), 0));
     metrics.showWithSheet(toolbarWrapper.getBackground(), 0.9f, 1);
-    // Fade in toolbar text labels with sheet expansion.
-    float alpha = scale(metrics.getTop(), 0, toolbarWrapper.getHeight(), 1f, 0f);
-    toolbarTitles.setAlpha(alpha);
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -176,9 +176,7 @@ public class HomeScreenFragment extends AbstractFragment
     }
   }
 
-  /**
-   * Set the height of the bottom sheet so it completely fills the screen when expanded.
-   */
+  /** Set the height of the bottom sheet so it completely fills the screen when expanded. */
   private void setBottomSheetHeight() {
     CoordinatorLayout.LayoutParams params =
         (CoordinatorLayout.LayoutParams) bottomSheetScrollView.getLayoutParams();
@@ -245,8 +243,8 @@ public class HomeScreenFragment extends AbstractFragment
 
     // When the bottom sheet is expanded, the bottom edge of the header needs to be aligned with
     // the bottom edge of the toolbar (the header slides up under it).
-    bottomSheetBehavior.setExpandedOffset(
-        toolbarWrapper.getHeight() - bottomSheetHeader.getHeight());
+    int featureSheetMarginTop = (int) getResources().getDimension(R.dimen.feature_sheet_margin_top);
+    bottomSheetBehavior.setExpandedOffset(toolbarWrapper.getHeight() - featureSheetMarginTop);
 
     setBottomSheetHeight();
     getView().getViewTreeObserver().removeOnGlobalLayoutListener(this);

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -34,7 +34,6 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.view.GravityCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
@@ -176,20 +175,6 @@ public class HomeScreenFragment extends AbstractFragment
     }
   }
 
-  /** Set the height of the bottom sheet so it completely fills the screen when expanded. */
-  private void setBottomSheetHeight() {
-    CoordinatorLayout.LayoutParams params =
-        (CoordinatorLayout.LayoutParams) bottomSheetScrollView.getLayoutParams();
-
-    int screenHeight = getScreenHeight(getActivity());
-    int statusBarHeight = statusBarScrim.getHeight();
-    int toolbarHeight = toolbar.getHeight();
-    int headerHeight = bottomSheetHeader.getHeight();
-
-    params.height = headerHeight + (screenHeight - (toolbarHeight + statusBarHeight));
-    bottomSheetScrollView.setLayoutParams(params);
-  }
-
   /** Fetches offline saved projects and adds them to navigation drawer. */
   private void updateNavDrawer() {
     projectSelectorViewModel
@@ -246,7 +231,6 @@ public class HomeScreenFragment extends AbstractFragment
     int featureSheetMarginTop = (int) getResources().getDimension(R.dimen.feature_sheet_margin_top);
     bottomSheetBehavior.setExpandedOffset(toolbarWrapper.getHeight() - featureSheetMarginTop);
 
-    setBottomSheetHeight();
     getView().getViewTreeObserver().removeOnGlobalLayoutListener(this);
   }
 

--- a/gnd/src/main/res/layout/feature_sheet_chrome.xml
+++ b/gnd/src/main/res/layout/feature_sheet_chrome.xml
@@ -42,9 +42,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:elevation="@dimen/toolbar_elevation"
-        android:theme="@style/GreenToolbarTheme"
-        app:subtitle="@{viewModel.featureSheetState.feature.subtitle}"
-        app:title="@{viewModel.featureSheetState.feature.title}" />
+        android:theme="@style/GreenToolbarTheme" />
 
     </FrameLayout>
 

--- a/gnd/src/main/res/layout/feature_sheet_chrome.xml
+++ b/gnd/src/main/res/layout/feature_sheet_chrome.xml
@@ -35,7 +35,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_alignParentTop="true"
-      android:background="@color/colorPrimary">
+      android:background="@android:color/transparent">
 
       <com.google.android.gnd.ui.common.TwoLineToolbar
         android:id="@+id/toolbar"

--- a/gnd/src/main/res/layout/feature_sheet_frag.xml
+++ b/gnd/src/main/res/layout/feature_sheet_frag.xml
@@ -38,13 +38,12 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:layout_marginTop="@dimen/feature_sheet_margin_top"
-      android:layout_gravity="top"
-      android:background="@color/colorBackground"/>
+      android:layout_gravity="top" />
 
     <LinearLayout
         android:id="@+id/feature_sheet_card_contents"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_gravity="top"
         android:orientation="vertical">
 
@@ -56,7 +55,7 @@
         android:id="@+id/observation_list_frag"
         android:name="com.google.android.gnd.ui.home.featuresheet.ObservationListFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="match_parent" />
 
     </LinearLayout>
 

--- a/gnd/src/main/res/layout/observation_list_frag.xml
+++ b/gnd/src/main/res/layout/observation_list_frag.xml
@@ -24,7 +24,8 @@
 
   <FrameLayout
     android:layout_width="match_parent"
-      android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/colorBackground">
 
     <ProgressBar
         android:id="@+id/observation_list_progress_bar"


### PR DESCRIPTION
Move header into bottom sheet and stop requiring negative expanded offset. This unblocks upgrading to latest Material components and upcoming simplifications and cleanup. See commit history for details.