### PR TITLE
Disable saving artifacts to cloud storage

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -155,10 +155,11 @@ options:
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY
 
+# TODO: Re-enable saving artifacts when a valid google-services.json is used in GCB
 # Save the APKs
-artifacts:
-  objects:
-    location: 'gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID'
-    paths: ['gnd/build/outputs/apk/*/*.apk']
+#artifacts:
+#  objects:
+#    location: 'gs://${_ARTIFACT_BUCKET}/$BRANCH_NAME-$BUILD_ID'
+#    paths: ['gnd/build/outputs/apk/*/*.apk']
 
 timeout: 1800s


### PR DESCRIPTION
A dummy `google-services.json` is used for building apks on GCB. This is fine for unit tests as we don't install the apk. But it can't be used on a real device.

So, let's disable this until the issue is resolved