### PR TITLE
[WIP - On hold] [Fix hack] Don't maintain state of photo clicked in viewmodel

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AbstractFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AbstractFieldViewModel.java
@@ -31,13 +31,14 @@ import java8.util.Optional;
 /** Defines the state of an inflated {@link Field} and controls its UI. */
 public class AbstractFieldViewModel extends AbstractViewModel {
 
-  /** Current value. */
-  private final LiveData<Optional<Response>> response;
-
-  /** Transcoded text to be displayed for the current {@link AbstractFieldViewModel#response}. */
+  /**
+   * Transcoded text to be displayed for the current {@link AbstractFieldViewModel#responseSubject}.
+   */
   private final LiveData<String> responseText;
 
-  /** Error message to be displayed for the current {@link AbstractFieldViewModel#response}. */
+  /**
+   * Error message to be displayed for the current {@link AbstractFieldViewModel#responseSubject}.
+   */
   private final LiveData<Optional<String>> error;
 
   private final BehaviorProcessor<Optional<Response>> responseSubject = BehaviorProcessor.create();
@@ -54,7 +55,6 @@ public class AbstractFieldViewModel extends AbstractViewModel {
     error =
         LiveDataReactiveStreams.fromPublisher(
             responseSubject.distinctUntilChanged().switchMapSingle(this::getErrorText));
-    response = LiveDataReactiveStreams.fromPublisher(responseSubject.distinctUntilChanged());
   }
 
   // TODO: Add a reference of Field in Response for simplification.
@@ -91,8 +91,8 @@ public class AbstractFieldViewModel extends AbstractViewModel {
     return error;
   }
 
-  LiveData<Optional<Response>> getResponse() {
-    return response;
+  Optional<Response> getResponse() {
+    return responseSubject.getValue();
   }
 
   public void setResponse(Optional<Response> response) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -40,12 +40,14 @@ import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.form.Form;
 import com.google.android.gnd.model.form.MultipleChoice.Cardinality;
 import com.google.android.gnd.model.observation.Response;
+import com.google.android.gnd.model.observation.TextResponse;
 import com.google.android.gnd.ui.common.AbstractFragment;
 import com.google.android.gnd.ui.common.BackPressListener;
 import com.google.android.gnd.ui.common.EphemeralPopups;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.common.TwoLineToolbar;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
+import java.util.Map.Entry;
 import java8.util.Optional;
 import java8.util.function.Consumer;
 import javax.inject.Inject;
@@ -137,6 +139,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
 
     if (fieldViewModel instanceof PhotoFieldViewModel) {
       observeSelectPhotoClicks((PhotoFieldViewModel) fieldViewModel);
+      observePhotoAdded(((PhotoFieldViewModel) fieldViewModel));
     } else if (fieldViewModel instanceof MultipleChoiceFieldViewModel) {
       observeMultipleChoiceClicks((MultipleChoiceFieldViewModel) fieldViewModel);
     }
@@ -189,10 +192,23 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
     }
   }
 
-  private void observeSelectPhotoClicks(PhotoFieldViewModel viewModel) {
-    viewModel
+  private void observeSelectPhotoClicks(PhotoFieldViewModel fieldViewModel) {
+    fieldViewModel
         .getShowDialogClicks()
-        .observe(this, __ -> onShowPhotoSelectorDialog(viewModel.getField()));
+        .observe(this, __ -> onShowPhotoSelectorDialog(fieldViewModel.getField()));
+  }
+
+  private void observePhotoAdded(PhotoFieldViewModel fieldViewModel) {
+    viewModel
+        .getPhotoUpdated()
+        .observe(
+            this,
+            map -> {
+              Entry<Field, String> entry = map.entrySet().iterator().next();
+              if (entry.getKey().equals(fieldViewModel.getField())) {
+                fieldViewModel.setResponse(TextResponse.fromString(entry.getValue()));
+              }
+            });
   }
 
   private void onShowPhotoSelectorDialog(Field field) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -47,7 +47,6 @@ import com.google.android.gnd.ui.common.EphemeralPopups;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.common.TwoLineToolbar;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
-import java.util.Map.Entry;
 import java8.util.Optional;
 import java8.util.function.Consumer;
 import javax.inject.Inject;
@@ -204,9 +203,9 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
         .observe(
             this,
             map -> {
-              Entry<Field, String> entry = map.entrySet().iterator().next();
-              if (entry.getKey().equals(fieldViewModel.getField())) {
-                fieldViewModel.setResponse(TextResponse.fromString(entry.getValue()));
+              Field field = fieldViewModel.getField();
+              if (map.containsKey(field)) {
+                fieldViewModel.setResponse(TextResponse.fromString(map.get(field)));
               }
             });
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -134,6 +134,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
   }
 
   private void addFieldViewModel(Field field, AbstractFieldViewModel fieldViewModel) {
+    // TODO: Get initial response via parameters.
     fieldViewModel.init(field, viewModel.getSavedOrOriginalResponse(field.getId()));
 
     if (fieldViewModel instanceof PhotoFieldViewModel) {
@@ -143,11 +144,8 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
       observeMultipleChoiceClicks((MultipleChoiceFieldViewModel) fieldViewModel);
     }
 
-    fieldViewModel
-        .getResponse()
-        .observe(this, response -> viewModel.onResponseChanged(field, response));
-
-    fieldViewModel.getError().observe(this, error -> viewModel.onErrorChanged(field, error));
+    fieldViewModel.getResponse().observe(this, r -> viewModel.onResponseChanged(field, r));
+    fieldViewModel.getError().observe(this, e -> viewModel.onErrorChanged(field, e));
   }
 
   private void rebuildForm(Form form) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -134,7 +134,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
   }
 
   private void addFieldViewModel(Field field, AbstractFieldViewModel fieldViewModel) {
-    fieldViewModel.init(field, viewModel.getResponse(field.getId()));
+    fieldViewModel.init(field, viewModel.getSavedOrOriginalResponse(field.getId()));
 
     if (fieldViewModel instanceof PhotoFieldViewModel) {
       observeSelectPhotoClicks((PhotoFieldViewModel) fieldViewModel);

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -139,7 +139,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
 
     if (fieldViewModel instanceof PhotoFieldViewModel) {
       observeSelectPhotoClicks((PhotoFieldViewModel) fieldViewModel);
-      observePhotoAdded(((PhotoFieldViewModel) fieldViewModel));
+      observePhotoAdded((PhotoFieldViewModel) fieldViewModel);
     } else if (fieldViewModel instanceof MultipleChoiceFieldViewModel) {
       observeMultipleChoiceClicks((MultipleChoiceFieldViewModel) fieldViewModel);
     }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -199,7 +199,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
 
   private void observePhotoAdded(PhotoFieldViewModel fieldViewModel) {
     viewModel
-        .getPhotoUpdated()
+        .getPhotoUpdates()
         .observe(
             this,
             map -> {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -199,7 +199,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
 
   private void observePhotoAdded(PhotoFieldViewModel fieldViewModel) {
     viewModel
-        .getPhotoUpdates()
+        .getPhotoFieldUpdates()
         .observe(
             this,
             map -> {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -90,8 +90,8 @@ public class EditObservationViewModel extends AbstractViewModel {
   /** Toolbar title, based on whether user is adding new or editing existing observation. */
   private final MutableLiveData<String> toolbarTitle = new MutableLiveData<>();
 
-  /** Captured / selected photo. */
-  private final MutableLiveData<Map<Field, String>> photoUpdated = new MutableLiveData<>();
+  /** Stream of updates to photo fields. */
+  private final MutableLiveData<Map<Field, String>> photoUpdates = new MutableLiveData<>();
 
   /** Original form responses, loaded when view is initialized. */
   private final ObservableMap<String, Response> responses = new ObservableArrayMap<>();
@@ -228,13 +228,13 @@ public class EditObservationViewModel extends AbstractViewModel {
 
     Map<Field, String> map = new HashMap<>();
     map.put(field, destinationPath);
-    photoUpdated.postValue(map);
+    photoUpdates.postValue(map);
 
     return storageManager.savePhoto(bitmap, localFileName, destinationPath);
   }
 
-  MutableLiveData<Map<Field, String>> getPhotoUpdated() {
-    return photoUpdated;
+  MutableLiveData<Map<Field, String>> getPhotoUpdates() {
+    return photoUpdates;
   }
 
   public void onSaveClick() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -46,14 +46,13 @@ import com.google.android.gnd.system.CameraManager;
 import com.google.android.gnd.system.StorageManager;
 import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.reactivex.processors.BehaviorProcessor;
 import io.reactivex.processors.PublishProcessor;
 import java.io.IOException;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java8.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -91,7 +90,7 @@ public class EditObservationViewModel extends AbstractViewModel {
   private final MutableLiveData<String> toolbarTitle = new MutableLiveData<>();
 
   /** Stream of updates to photo fields. */
-  private final MutableLiveData<Map<Field, String>> photoUpdates = new MutableLiveData<>();
+  private final MutableLiveData<ImmutableMap<Field, String>> photoUpdates = new MutableLiveData<>();
 
   /** Original form responses, loaded when view is initialized. */
   private final ObservableMap<String, Response> responses = new ObservableArrayMap<>();
@@ -226,15 +225,11 @@ public class EditObservationViewModel extends AbstractViewModel {
     String destinationPath =
         getRemoteDestinationPath(
             args.getProjectId(), args.getFormId(), args.getFeatureId(), localFileName);
-
-    Map<Field, String> map = new HashMap<>();
-    map.put(field, destinationPath);
-    photoUpdates.postValue(map);
-
+    photoUpdates.postValue(ImmutableMap.of(field, destinationPath));
     return storageManager.savePhoto(bitmap, localFileName, destinationPath);
   }
 
-  MutableLiveData<Map<Field, String>> getPhotoUpdates() {
+  MutableLiveData<ImmutableMap<Field, String>> getPhotoUpdates() {
     return photoUpdates;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -229,7 +229,7 @@ public class EditObservationViewModel extends AbstractViewModel {
     return storageManager.savePhoto(bitmap, localFileName, destinationPath);
   }
 
-  MutableLiveData<ImmutableMap<Field, String>> getPhotoUpdates() {
+  MutableLiveData<ImmutableMap<Field, String>> getPhotoFieldUpdates() {
     return photoUpdates;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -177,9 +177,12 @@ public class EditObservationViewModel extends AbstractViewModel {
     }
   }
 
-  void onErrorChanged(Field field, Optional<String> error) {
-    error.ifPresentOrElse(
-        e -> validationErrors.put(field.getId(), e), () -> validationErrors.remove(field.getId()));
+  void onErrorChanged(Field field, @Nullable Optional<String> error) {
+    if (error != null) {
+      error.ifPresentOrElse(
+          e -> validationErrors.put(field.getId(), e),
+          () -> validationErrors.remove(field.getId()));
+    }
   }
 
   void onResponseChanged(Field field, Optional<Response> newResponse) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -170,7 +170,8 @@ public class EditObservationViewModel extends AbstractViewModel {
     viewArgs.onNext(args);
   }
 
-  Optional<Response> getResponse(String fieldId) {
+  /** If present, return saved responses. Otherwise, return original responses. */
+  Optional<Response> getSavedOrOriginalResponse(String fieldId) {
     if (responses.isEmpty()) {
       return originalObservation.getResponses().getResponse(fieldId);
     } else {
@@ -335,7 +336,8 @@ public class EditObservationViewModel extends AbstractViewModel {
       }
       String fieldId = e.getField().getId();
       Optional<Response> originalResponse = originalResponses.getResponse(fieldId);
-      Optional<Response> currentResponse = getResponse(fieldId).filter(r -> !r.isEmpty());
+      Optional<Response> currentResponse =
+          getSavedOrOriginalResponse(fieldId).filter(r -> !r.isEmpty());
       if (currentResponse.equals(originalResponse)) {
         continue;
       }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -229,7 +229,7 @@ public class EditObservationViewModel extends AbstractViewModel {
     return storageManager.savePhoto(bitmap, localFileName, destinationPath);
   }
 
-  MutableLiveData<ImmutableMap<Field, String>> getPhotoFieldUpdates() {
+  LiveData<ImmutableMap<Field, String>> getPhotoFieldUpdates() {
     return photoUpdates;
   }
 

--- a/gnd/src/main/res/layout/edit_observation_frag.xml
+++ b/gnd/src/main/res/layout/edit_observation_frag.xml
@@ -21,7 +21,10 @@
   <data>
     <variable
       name="viewModel"
-      type="com.google.android.gnd.ui.editobservation.EditObservationViewModel"/>
+      type="com.google.android.gnd.ui.editobservation.EditObservationViewModel" />
+    <variable
+      name="fragment"
+      type="com.google.android.gnd.ui.editobservation.EditObservationFragment" />
   </data>
 
   <!-- Use CoordinatorLayout to avoid rendering over top system bar. -->
@@ -102,7 +105,7 @@
       android:elevation="2dp"
       android:text="@string/save_observation_button_label"
       android:visibility="@{viewModel.saveButtonVisibility}"
-      android:onClick="@{() -> viewModel.onSaveClick()}"
+      android:onClick="@{() -> fragment.onSaveClick()}"
       app:useCompatPadding="true"/>
 
     <!-- TODO: Refactor and use in place of deprecated ProgressDialog. -->


### PR DESCRIPTION
 - Minor cleanup
 - Remove storing state of `isPhotoUpdated` in view model across fragment recreation. Instead, notify the respective field binding through LiveData

@gino-m PTAL