### PR TITLE
[Bug] Prevent duplicate entries of multiple choice fields

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -21,7 +21,7 @@ public final class Config {
 
   // Local db settings.
   // TODO(#128): Reset version to 1 before releasing.
-  public static final int DB_VERSION = 43;
+  public static final int DB_VERSION = 44;
   public static final String DB_NAME = "gnd.db";
 
   // Firebase Cloud Firestore settings.

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/MultipleChoiceEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/MultipleChoiceEntity.java
@@ -42,15 +42,13 @@ import java.util.List;
     indices = {@Index("field_id")})
 public abstract class MultipleChoiceEntity {
 
-  @PrimaryKey(autoGenerate = true)
-  public int id;
-
   @CopyAnnotations
   @NonNull
   @ColumnInfo(name = "type")
   public abstract MultipleChoiceEntityType getType();
 
   @CopyAnnotations
+  @PrimaryKey
   @NonNull
   @ColumnInfo(name = "field_id")
   public abstract String getFieldId();

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OptionEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OptionEntity.java
@@ -32,10 +32,10 @@ import com.google.auto.value.AutoValue.CopyAnnotations;
         @ForeignKey(
             entity = FieldEntity.class,
             parentColumns = "id",
-            childColumns = "field_id",
-            onDelete = ForeignKey.CASCADE),
-    indices = {@Index("field_id")},
-    primaryKeys = {"code", "field_id"})
+            childColumns = "field_id", // NOPMD
+          onDelete = ForeignKey.CASCADE),
+    indices = {@Index("field_id")}, // NOPMD
+    primaryKeys = {"code", "field_id"}) // NOPMD
 public abstract class OptionEntity {
 
   @CopyAnnotations
@@ -50,7 +50,7 @@ public abstract class OptionEntity {
 
   @CopyAnnotations
   @NonNull
-  @ColumnInfo(name = "field_id")
+  @ColumnInfo(name = "field_id") // NOPMD
   public abstract String getFieldId();
 
   public static OptionEntity fromOption(String fieldId, Option option) {

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OptionEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OptionEntity.java
@@ -21,7 +21,6 @@ import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.ForeignKey;
 import androidx.room.Index;
-import androidx.room.PrimaryKey;
 import com.google.android.gnd.model.form.Option;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.AutoValue.CopyAnnotations;
@@ -35,11 +34,9 @@ import com.google.auto.value.AutoValue.CopyAnnotations;
             parentColumns = "id",
             childColumns = "field_id",
             onDelete = ForeignKey.CASCADE),
-    indices = {@Index("field_id")})
+    indices = {@Index("field_id")},
+    primaryKeys = {"code", "field_id"})
 public abstract class OptionEntity {
-
-  @PrimaryKey(autoGenerate = true)
-  public int id;
 
   @CopyAnnotations
   @NonNull


### PR DESCRIPTION
Fixes #491.

Update primary keys for OptionEntity and MultipleChoiceEntity.

Verified by following the steps in issue and confirmed that duplicate entries were not saved.

@gino-m  PTAL?
