### PR TITLE
Add Offline Area Viewer UI

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/MainActivityModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/MainActivityModule.java
@@ -36,6 +36,8 @@ import com.google.android.gnd.ui.offlinearea.OfflineAreasFragment;
 import com.google.android.gnd.ui.offlinearea.OfflineAreasModule;
 import com.google.android.gnd.ui.offlinearea.selector.OfflineAreaSelectorFragment;
 import com.google.android.gnd.ui.offlinearea.selector.OfflineAreaSelectorModule;
+import com.google.android.gnd.ui.offlinearea.viewer.OfflineAreaViewerFragment;
+import com.google.android.gnd.ui.offlinearea.viewer.OfflineAreaViewerModule;
 import com.google.android.gnd.ui.projectselector.ProjectSelectorDialogFragment;
 import com.google.android.gnd.ui.signin.SignInFragment;
 import com.google.android.gnd.ui.signin.SignInModule;
@@ -103,4 +105,8 @@ public abstract class MainActivityModule {
   @FragmentScoped
   @ContributesAndroidInjector(modules = OfflineAreasModule.class)
   abstract OfflineAreasFragment offlineAreasFragmentInjector();
+
+  @FragmentScoped
+  @ContributesAndroidInjector(modules = OfflineAreaViewerModule.class)
+  abstract OfflineAreaViewerFragment offlineAreaViewerFragmentInjector();
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -147,4 +147,7 @@ public interface LocalDataStore {
 
   /** Returns all queued, failed, and completed offline areas from the local data store. */
   Flowable<ImmutableList<OfflineArea>> getOfflineAreasOnceAndStream();
+
+  /** Returns the offline area with the specified id. */
+  Single<OfflineArea> getOfflineAreaById(String id);
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -488,4 +488,13 @@ public class RoomLocalDataStore implements LocalDataStore {
         .map(areas -> stream(areas).map(OfflineAreaEntity::toArea).collect(toImmutableList()))
         .subscribeOn(schedulers.io());
   }
+
+  @Override
+  public Single<OfflineArea> getOfflineAreaById(String id) {
+    return offlineAreaDao
+        .findById(id)
+        .map(OfflineAreaEntity::toArea)
+        .toSingle()
+        .subscribeOn(schedulers.io());
+  }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/common/Navigator.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/common/Navigator.java
@@ -138,4 +138,8 @@ public class Navigator {
   public void showSettings() {
     navigate(HomeScreenFragmentDirections.actionHomeScreenFragmentToSettingsActivity());
   }
+
+  public void showOfflineAreaViewer(String offlineAreaId) {
+    navigate(OfflineAreasFragmentDirections.viewOfflineArea(offlineAreaId));
+  }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/common/ViewModelModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/common/ViewModelModule.java
@@ -31,6 +31,7 @@ import com.google.android.gnd.ui.home.mapcontainer.MapContainerViewModel;
 import com.google.android.gnd.ui.observationdetails.ObservationDetailsViewModel;
 import com.google.android.gnd.ui.offlinearea.OfflineAreasViewModel;
 import com.google.android.gnd.ui.offlinearea.selector.OfflineAreaSelectorViewModel;
+import com.google.android.gnd.ui.offlinearea.viewer.OfflineAreaViewerViewModel;
 import com.google.android.gnd.ui.projectselector.ProjectSelectorViewModel;
 import com.google.android.gnd.ui.signin.SignInViewModel;
 import dagger.Binds;
@@ -53,6 +54,11 @@ public abstract class ViewModelModule {
   @IntoMap
   @ViewModelKey(OfflineAreasViewModel.class)
   abstract ViewModel bindOfflineAreasViewModel(OfflineAreasViewModel viewModel);
+
+  @Binds
+  @IntoMap
+  @ViewModelKey(OfflineAreaViewerViewModel.class)
+  abstract ViewModel bindOfflineAreaViewerViewModel(OfflineAreaViewerViewModel viewModel);
 
   @Binds
   @IntoMap

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
@@ -17,27 +17,50 @@
 package com.google.android.gnd.ui.offlinearea;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.gnd.databinding.OfflineAreasListItemBinding;
 import com.google.android.gnd.model.basemap.OfflineArea;
+import com.google.android.gnd.ui.common.Navigator;
 import com.google.common.collect.ImmutableList;
 
 class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter.ViewHolder> {
+
+  private final Navigator navigator;
   private ImmutableList<OfflineArea> offlineAreas;
 
-  public static class ViewHolder extends RecyclerView.ViewHolder {
-    public OfflineAreasListItemBinding binding;
+  public static class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
-    ViewHolder(OfflineAreasListItemBinding binding) {
+    public OfflineAreasListItemBinding binding;
+    public int position;
+    private ImmutableList<OfflineArea> areas;
+    private final Navigator navigator;
+
+    ViewHolder(
+        OfflineAreasListItemBinding binding,
+        ImmutableList<OfflineArea> areas,
+        Navigator navigator) {
       super(binding.getRoot());
       this.binding = binding;
+      this.areas = areas;
+      this.navigator = navigator;
+      binding.offlineAreaName.setOnClickListener(this);
+    }
+
+    @Override
+    public void onClick(View v) {
+      if (areas.size() > 0) {
+        String id = areas.get(position).getId();
+        navigator.showOfflineAreaViewer(id);
+      }
     }
   }
 
-  OfflineAreaListAdapter() {
+  OfflineAreaListAdapter(Navigator navigator) {
     offlineAreas = ImmutableList.of();
+    this.navigator = navigator;
   }
 
   @NonNull
@@ -48,12 +71,13 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
         OfflineAreasListItemBinding.inflate(
             LayoutInflater.from(parent.getContext()), parent, false);
 
-    return new ViewHolder(offlineAreasListItemBinding);
+    return new ViewHolder(offlineAreasListItemBinding, offlineAreas, navigator);
   }
 
   @Override
   public void onBindViewHolder(ViewHolder viewHolder, int position) {
     viewHolder.binding.offlineAreaName.setText(offlineAreas.get(position).getId());
+    viewHolder.position = position;
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasFragment.java
@@ -30,6 +30,8 @@ import com.google.android.gnd.R;
 import com.google.android.gnd.databinding.OfflineAreasFragBinding;
 import com.google.android.gnd.inject.ActivityScoped;
 import com.google.android.gnd.ui.common.AbstractFragment;
+import com.google.android.gnd.ui.common.Navigator;
+import javax.inject.Inject;
 
 /**
  * Fragment containing a list of downloaded areas on the device. An area is a set of offline raster
@@ -38,6 +40,7 @@ import com.google.android.gnd.ui.common.AbstractFragment;
  */
 @ActivityScoped
 public class OfflineAreasFragment extends AbstractFragment {
+  @Inject Navigator navigator;
 
   // TODO: Remove. Right now removing this results in runtime crashes. Not precisely sure why.
   // It stems from AbstractFragment and its use of ButterKnife.
@@ -63,7 +66,7 @@ public class OfflineAreasFragment extends AbstractFragment {
 
     ((MainActivity) getActivity()).setActionBar(binding.offlineAreasToolbar, true);
 
-    OfflineAreaListAdapter offlineAreaListAdapter = new OfflineAreaListAdapter();
+    OfflineAreaListAdapter offlineAreaListAdapter = new OfflineAreaListAdapter(navigator);
     RecyclerView recyclerView = binding.offlineAreasList;
     recyclerView.setHasFixedSize(true);
     recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
@@ -44,6 +44,10 @@ public class OfflineAreasViewModel extends AbstractViewModel {
     navigator.showOfflineAreaSelector();
   }
 
+  public void showOfflineAreaViewer(String offlineAreaId) {
+    navigator.showOfflineAreaViewer(offlineAreaId);
+  }
+
   LiveData<ImmutableList<OfflineArea>> getOfflineAreas() {
     return offlineAreas;
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerFragment.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gnd.ui.offlinearea.viewer;
+
+import static com.google.android.gnd.rx.RxAutoDispose.autoDisposable;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import butterknife.OnClick;
+import com.google.android.gnd.MainActivity;
+import com.google.android.gnd.R;
+import com.google.android.gnd.databinding.OfflineAreaViewerFragBinding;
+import com.google.android.gnd.model.basemap.OfflineArea;
+import com.google.android.gnd.model.feature.Point;
+import com.google.android.gnd.ui.common.AbstractFragment;
+import com.google.android.gnd.ui.map.MapAdapter;
+import com.google.android.gnd.ui.map.MapProvider;
+import io.reactivex.Single;
+import javax.inject.Inject;
+
+public class OfflineAreaViewerFragment extends AbstractFragment {
+
+  private static final String MAP_FRAGMENT = MapProvider.class.getName() + "#fragment";
+
+  @Inject MapProvider mapProvider;
+
+  private OfflineAreaViewerViewModel viewModel;
+  @Nullable private MapAdapter map;
+
+  public static OfflineAreaViewerFragment newInstance() {
+    return new OfflineAreaViewerFragment();
+  }
+
+  @Override
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    OfflineAreaViewerFragmentArgs args = OfflineAreaViewerFragmentArgs.fromBundle(getArguments());
+    viewModel = getViewModel(OfflineAreaViewerViewModel.class);
+    viewModel.loadOfflineArea(args);
+    Single<MapAdapter> mapAdapter = mapProvider.getMapAdapter();
+    mapAdapter.as(autoDisposable(this)).subscribe(this::onMapReady);
+    viewModel.getOfflineArea().observe(this, this::panMap);
+  }
+
+  @Override
+  public View onCreateView(
+      @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    super.onCreateView(inflater, container, savedInstanceState);
+    OfflineAreaViewerFragBinding binding =
+        OfflineAreaViewerFragBinding.inflate(inflater, container, false);
+    binding.setViewModel(viewModel);
+    binding.setLifecycleOwner(this);
+    ((MainActivity) getActivity()).setActionBar(binding.offlineAreaViewerToolbar, true);
+    return binding.getRoot();
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    if (savedInstanceState == null) {
+      replaceFragment(R.id.map, mapProvider.getFragment());
+    } else {
+      mapProvider.restore(restoreChildFragment(savedInstanceState, MAP_FRAGMENT));
+    }
+  }
+
+  private void onMapReady(MapAdapter map) {
+    this.map = map;
+  }
+
+  private void panMap(OfflineArea offlineArea) {
+    if (map == null) {
+      return;
+    }
+
+    double lat = offlineArea.getBounds().northeast.latitude;
+    double lon = offlineArea.getBounds().southwest.longitude;
+    Point point = Point.newBuilder().setLatitude(lat).setLongitude(lon).build();
+    map.moveCamera(point);
+  }
+
+  @OnClick(R.id.remove_button)
+  public void onRemoveClick() {
+    if (map == null) {
+      return;
+    }
+
+    viewModel.onRemoveClick();
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerFragment.java
@@ -36,6 +36,10 @@ import com.google.android.gnd.ui.map.MapProvider;
 import io.reactivex.Single;
 import javax.inject.Inject;
 
+/**
+ * The OfflineAreaViewerFragment provides a UI for managing a single offline area on the user's
+ * device.
+ * */
 public class OfflineAreaViewerFragment extends AbstractFragment {
 
   private static final String MAP_FRAGMENT = MapProvider.class.getName() + "#fragment";
@@ -96,6 +100,9 @@ public class OfflineAreaViewerFragment extends AbstractFragment {
     map.moveCamera(point);
   }
 
+  /**
+   * Removes the area associated with this fragment from the user's device.
+   * */
   @OnClick(R.id.remove_button)
   public void onRemoveClick() {
     if (map == null) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerFragment.java
@@ -45,9 +45,8 @@ public class OfflineAreaViewerFragment extends AbstractFragment {
   private OfflineAreaViewerViewModel viewModel;
   @Nullable private MapAdapter map;
 
-  public static OfflineAreaViewerFragment newInstance() {
-    return new OfflineAreaViewerFragment();
-  }
+  @Inject
+  public OfflineAreaViewerFragment() {}
 
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.android.gnd.ui.offlinearea.viewer;
+
+import androidx.fragment.app.Fragment;
+import com.google.android.gnd.inject.FragmentScoped;
+import dagger.Binds;
+import dagger.Module;
+
+@Module
+public abstract class OfflineAreaViewerModule {
+
+  @Binds
+  @FragmentScoped
+  abstract Fragment fragment(OfflineAreaViewerFragment fragment);
+}
+

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
@@ -25,6 +25,7 @@ import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.model.basemap.tile.Tile;
 import com.google.android.gnd.repository.OfflineAreaRepository;
 import com.google.android.gnd.ui.common.AbstractViewModel;
+import com.google.common.collect.ImmutableSet;
 import io.reactivex.processors.BehaviorProcessor;
 import java.io.File;
 import javax.inject.Inject;
@@ -50,12 +51,7 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
                         .getOfflineArea(args.getOfflineAreaId())
                         .toFlowable()
                         .flatMap(offlineAreaRepository::getIntersectingDownloadedTilesOnceAndStream)
-                        .map(
-                            tiles ->
-                                stream(tiles)
-                                    .map(this::tileStorageSize)
-                                    .reduce((x, y) -> x + y)
-                                    .orElse(0.0))));
+                        .map(this::tilesToTotalStorageSize)));
     this.offlineArea =
         LiveDataReactiveStreams.fromPublisher(
             this.argsProcessor.switchMap(
@@ -63,6 +59,10 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
                     this.offlineAreaRepository
                         .getOfflineArea(args.getOfflineAreaId())
                         .toFlowable()));
+  }
+
+  private Double tilesToTotalStorageSize(ImmutableSet<Tile> tiles) {
+    return stream(tiles).map(this::tileStorageSize).reduce((x, y) -> x + y).orElse(0.0);
   }
 
   private double tileStorageSize(Tile tile) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
@@ -32,9 +32,9 @@ import java.lang.ref.WeakReference;
 import javax.inject.Inject;
 
 /**
- * View model for the OfflineAreaViewerFragment. Manges offline area deletions and calculates
- * the storage size of an area on the user's device.
- * */
+ * View model for the OfflineAreaViewerFragment. Manges offline area deletions and calculates the
+ * storage size of an area on the user's device.
+ */
 public class OfflineAreaViewerViewModel extends AbstractViewModel {
 
   private final BehaviorProcessor<OfflineAreaViewerFragmentArgs> argsProcessor;
@@ -71,32 +71,29 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
   }
 
   private double tileStorageSize(Tile tile) {
-    if (context == null) {
+    Context context1 = context.get();
+    if (context1 == null) {
       return 0.0;
+    } else {
+      File tileFile = new File(context1.getFilesDir(), tile.getPath());
+      return (double) tileFile.length() / (1024 * 1024);
     }
-
-    File tileFile = new File(context.get().getFilesDir(), tile.getPath());
-    return (double) tileFile.length() / (1024 * 1024);
   }
 
   /**
    * Removes the offline area associated with this viewmodel from the device by removing all tile
    * sources that are not included in other areas and removing the area from the db.
-   * */
+   */
   public void onRemoveClick() {
     // TODO: Delete the area.
   }
 
-  /**
-   * Returns the offline area associated with this view model.
-   * */
+  /** Returns the offline area associated with this view model. */
   public LiveData<OfflineArea> getOfflineArea() {
     return offlineArea;
   }
 
-  /**
-   * Gets a single offline area by the id passed to the OfflineAreaViewerFragment's arguments.
-   * */
+  /** Gets a single offline area by the id passed to the OfflineAreaViewerFragment's arguments. */
   public void loadOfflineArea(OfflineAreaViewerFragmentArgs args) {
     this.argsProcessor.onNext(args);
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gnd.ui.offlinearea.viewer;
+
+import static java8.util.stream.StreamSupport.stream;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.LiveDataReactiveStreams;
+import com.google.android.gnd.model.basemap.OfflineArea;
+import com.google.android.gnd.model.basemap.tile.Tile;
+import com.google.android.gnd.repository.OfflineAreaRepository;
+import com.google.android.gnd.ui.common.AbstractViewModel;
+import io.reactivex.processors.BehaviorProcessor;
+import java.io.File;
+import javax.inject.Inject;
+
+public class OfflineAreaViewerViewModel extends AbstractViewModel {
+
+  private final BehaviorProcessor<OfflineAreaViewerFragmentArgs> argsProcessor;
+  private final OfflineAreaRepository offlineAreaRepository;
+  public LiveData<Integer> areaStorageSize;
+  private LiveData<OfflineArea> offlineArea;
+
+  @Inject
+  public OfflineAreaViewerViewModel(OfflineAreaRepository offlineAreaRepository) {
+    this.argsProcessor = BehaviorProcessor.create();
+    this.offlineAreaRepository = offlineAreaRepository;
+    this.areaStorageSize =
+        LiveDataReactiveStreams.fromPublisher(
+            this.argsProcessor.switchMap(
+                args ->
+                    this.offlineAreaRepository
+                        .getOfflineArea(args.getOfflineAreaId())
+                        .toFlowable()
+                        .flatMap(offlineAreaRepository::getIntersectingDownloadedTilesOnceAndStream)
+                        .map(
+                            tiles ->
+                                stream(tiles)
+                                    .map(this::tileStorageSize)
+                                    .reduce((x, y) -> x + y)
+                                    .orElse(0))));
+    this.offlineArea =
+        LiveDataReactiveStreams.fromPublisher(
+            this.argsProcessor.switchMap(
+                args ->
+                    this.offlineAreaRepository
+                        .getOfflineArea(args.getOfflineAreaId())
+                        .toFlowable()));
+  }
+
+  private int tileStorageSize(Tile tile) {
+    File tileFile = new File(tile.getPath());
+    return (int) tileFile.length() / 1024 * 1024;
+  }
+
+  public void onRemoveClick() {
+    // TODO: Delete the area.
+  }
+
+  public LiveData<OfflineArea> getOfflineArea() {
+    return offlineArea;
+  }
+
+  public void loadOfflineArea(OfflineAreaViewerFragmentArgs args) {
+    this.argsProcessor.onNext(args);
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
@@ -18,6 +18,7 @@ package com.google.android.gnd.ui.offlinearea.viewer;
 
 import static java8.util.stream.StreamSupport.stream;
 
+import android.content.Context;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import com.google.android.gnd.model.basemap.OfflineArea;
@@ -32,13 +33,15 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
 
   private final BehaviorProcessor<OfflineAreaViewerFragmentArgs> argsProcessor;
   private final OfflineAreaRepository offlineAreaRepository;
+  private final Context context;
   public LiveData<Integer> areaStorageSize;
   private LiveData<OfflineArea> offlineArea;
 
   @Inject
-  public OfflineAreaViewerViewModel(OfflineAreaRepository offlineAreaRepository) {
+  public OfflineAreaViewerViewModel(OfflineAreaRepository offlineAreaRepository, Context context) {
     this.argsProcessor = BehaviorProcessor.create();
     this.offlineAreaRepository = offlineAreaRepository;
+    this.context = context;
     this.areaStorageSize =
         LiveDataReactiveStreams.fromPublisher(
             this.argsProcessor.switchMap(
@@ -63,7 +66,7 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
   }
 
   private int tileStorageSize(Tile tile) {
-    File tileFile = new File(tile.getPath());
+    File tileFile = new File(context.getFilesDir(), tile.getPath());
     return (int) tileFile.length() / 1024 * 1024;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
@@ -34,7 +34,7 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
   private final BehaviorProcessor<OfflineAreaViewerFragmentArgs> argsProcessor;
   private final OfflineAreaRepository offlineAreaRepository;
   private final Context context;
-  public LiveData<Integer> areaStorageSize;
+  public LiveData<Double> areaStorageSize;
   private LiveData<OfflineArea> offlineArea;
 
   @Inject
@@ -55,7 +55,7 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
                                 stream(tiles)
                                     .map(this::tileStorageSize)
                                     .reduce((x, y) -> x + y)
-                                    .orElse(0))));
+                                    .orElse(0.0))));
     this.offlineArea =
         LiveDataReactiveStreams.fromPublisher(
             this.argsProcessor.switchMap(
@@ -65,9 +65,9 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
                         .toFlowable()));
   }
 
-  private int tileStorageSize(Tile tile) {
+  private double tileStorageSize(Tile tile) {
     File tileFile = new File(context.getFilesDir(), tile.getPath());
-    return (int) tileFile.length() / 1024 * 1024;
+    return (double) tileFile.length() / (1024 * 1024);
   }
 
   public void onRemoveClick() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
@@ -28,13 +28,14 @@ import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.common.collect.ImmutableSet;
 import io.reactivex.processors.BehaviorProcessor;
 import java.io.File;
+import java.lang.ref.WeakReference;
 import javax.inject.Inject;
 
 public class OfflineAreaViewerViewModel extends AbstractViewModel {
 
   private final BehaviorProcessor<OfflineAreaViewerFragmentArgs> argsProcessor;
   private final OfflineAreaRepository offlineAreaRepository;
-  private final Context context;
+  private final WeakReference<Context> context;
   public LiveData<Double> areaStorageSize;
   private LiveData<OfflineArea> offlineArea;
 
@@ -42,7 +43,7 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
   public OfflineAreaViewerViewModel(OfflineAreaRepository offlineAreaRepository, Context context) {
     this.argsProcessor = BehaviorProcessor.create();
     this.offlineAreaRepository = offlineAreaRepository;
-    this.context = context;
+    this.context = new WeakReference<>(context);
     this.areaStorageSize =
         LiveDataReactiveStreams.fromPublisher(
             this.argsProcessor.switchMap(
@@ -66,7 +67,11 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
   }
 
   private double tileStorageSize(Tile tile) {
-    File tileFile = new File(context.getFilesDir(), tile.getPath());
+    if (context == null) {
+      return 0.0;
+    }
+
+    File tileFile = new File(context.get().getFilesDir(), tile.getPath());
     return (double) tileFile.length() / (1024 * 1024);
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
@@ -31,6 +31,10 @@ import java.io.File;
 import java.lang.ref.WeakReference;
 import javax.inject.Inject;
 
+/**
+ * View model for the OfflineAreaViewerFragment. Manges offline area deletions and calculates
+ * the storage size of an area on the user's device.
+ * */
 public class OfflineAreaViewerViewModel extends AbstractViewModel {
 
   private final BehaviorProcessor<OfflineAreaViewerFragmentArgs> argsProcessor;
@@ -75,14 +79,24 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
     return (double) tileFile.length() / (1024 * 1024);
   }
 
+  /**
+   * Removes the offline area associated with this viewmodel from the device by removing all tile
+   * sources that are not included in other areas and removing the area from the db.
+   * */
   public void onRemoveClick() {
     // TODO: Delete the area.
   }
 
+  /**
+   * Returns the offline area associated with this view model.
+   * */
   public LiveData<OfflineArea> getOfflineArea() {
     return offlineArea;
   }
 
+  /**
+   * Gets a single offline area by the id passed to the OfflineAreaViewerFragment's arguments.
+   * */
   public void loadOfflineArea(OfflineAreaViewerFragmentArgs args) {
     this.argsProcessor.onNext(args);
   }

--- a/gnd/src/main/res/layout/offline_area_viewer_frag.xml
+++ b/gnd/src/main/res/layout/offline_area_viewer_frag.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2020 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+    <variable
+      name="viewModel"
+      type="com.google.android.gnd.ui.offlinearea.viewer.OfflineAreaViewerViewModel" />
+  </data>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.gnd.ui.common.TwoLineToolbar
+      android:id="@+id/offline_area_viewer_toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:elevation="@dimen/toolbar_elevation"
+      android:theme="@style/PrimaryToolbarTheme"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:title="@string/offline_area_viewer_title"
+      app:titleTextColor="@color/colorBackground" />
+
+    <FrameLayout
+      android:id="@+id/offline_area_viewer_map_frame"
+      android:layout_width="match_parent"
+      android:layout_height="200dp"
+      android:background="@color/colorGrey300"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0.333"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/offline_area_viewer_toolbar"
+      app:layout_constraintVertical_bias="0.533">
+      <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/map"
+        android:layout_width="140dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        app:layout_behavior="com.google.android.gnd.ui.home.mapcontainer.MapLayoutBehavior"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/offline_area_viewer_toolbar" />
+    </FrameLayout>
+
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
+      android:layout_height="476dp"
+      android:background="@color/colorBackground"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0.333"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/offline_area_viewer_map_frame"
+      app:layout_constraintVertical_bias="0.533">
+      <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:text='@{"This area takes up " + viewModel.areaStorageSize + "MB of storage space on your device."}'
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+      <Button
+        android:id="@+id/remove_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        android:background="@color/colorAlert"
+        android:text="@string/offline_area_viewer_remove_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/gnd/src/main/res/layout/offline_area_viewer_frag.xml
+++ b/gnd/src/main/res/layout/offline_area_viewer_frag.xml
@@ -79,7 +79,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="20dp"
-        android:text='@{"This area takes up " + viewModel.areaStorageSize + "MB of storage space on your device."}'
+        android:text="@{String.format(@string/offline_area_viewer_storage, viewModel.areaStorageSize)}"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/gnd/src/main/res/navigation/nav_graph.xml
+++ b/gnd/src/main/res/navigation/nav_graph.xml
@@ -99,7 +99,7 @@
   <fragment
     android:id="@+id/offline_area_viewer_fragment"
     android:name="com.google.android.gnd.ui.offlinearea.viewer.OfflineAreaViewerFragment"
-    android:label="Offline Area Viewer"
+    android:label="@string/offline_area_viewer_navgraph_label"
     tools:layout="@layout/offline_area_viewer_frag">
     <argument
       android:name="offlineAreaId"

--- a/gnd/src/main/res/navigation/nav_graph.xml
+++ b/gnd/src/main/res/navigation/nav_graph.xml
@@ -83,6 +83,9 @@
     <action
       android:id="@+id/backToHomeScreen"
       app:destination="@id/home_screen_fragment" />
+    <action
+      android:id="@+id/viewOfflineArea"
+      app:destination="@+id/offline_area_viewer_fragment"/>
   </fragment>
   <fragment
     android:id="@+id/offline_area_selector_fragment"
@@ -92,6 +95,15 @@
     <action
       android:id="@+id/backToOfflineAreas"
       app:destination="@id/offline_areas_fragment" />
+  </fragment>
+  <fragment
+    android:id="@+id/offline_area_viewer_fragment"
+    android:name="com.google.android.gnd.ui.offlinearea.viewer.OfflineAreaViewerFragment"
+    android:label="Offline Area Viewer"
+    tools:layout="@layout/offline_area_viewer_frag">
+    <argument
+      android:name="offlineAreaId"
+      app:argType="string"/>
   </fragment>
   <fragment
     android:id="@+id/observation_details_fragment"

--- a/gnd/src/main/res/values/dimens.xml
+++ b/gnd/src/main/res/values/dimens.xml
@@ -95,4 +95,6 @@
 
     <!-- Photo CardView -->
     <dimen name="cardview_elevation">4dp</dimen>
+  <dimen name="offline_area_viewer_map_container_width">20dp</dimen>
+  <dimen name="offline_area_viewer_map_container_height">20dp</dimen>
 </resources>

--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -153,4 +153,5 @@
   <string name="settings">Settings</string>
   <string name="offline_area_viewer_title">Offline Area Details</string>
   <string name="offline_area_viewer_remove_button">Remove</string>
+  <string name="offline_area_viewer_storage">This area takes up %.1f MB of storage space on your device.</string>
 </resources>

--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -151,4 +151,6 @@
   <string name="uploading_data">Uploading data</string>
   <string name="app_running">App is running</string>
   <string name="settings">Settings</string>
+  <string name="offline_area_viewer_title">Offline Area Details</string>
+  <string name="offline_area_viewer_remove_button">Remove</string>
 </resources>

--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
   <string name="uploading_data">Uploading data</string>
   <string name="app_running">App is running</string>
   <string name="settings">Settings</string>
+  <string name="offline_area_viewer_navgraph_label">Offline Area Viewer</string>
   <string name="offline_area_viewer_title">Offline Area Details</string>
   <string name="offline_area_viewer_remove_button">Remove</string>
   <string name="offline_area_viewer_storage">This area takes up %.1f MB of storage space on your device.</string>


### PR DESCRIPTION
This PR adds a UI for viewing downloaded offline areas. When a user selects an area from the list of downloaded offline areas, they're presented with a viewer that:

- [x] displays the bounds of the area in a map view
- [x] displays the storage space the area consumes on the device (in MB)
- [x] gives users the option to remove the area

The removal functionality isn't implemented yet--this PR just introduces the new UI and hooks it up to the Areas list.

<img width="411" alt="Screen Shot 2020-06-11 at 11 24 44 AM" src="https://user-images.githubusercontent.com/11237600/84408859-a9e81180-abda-11ea-8985-97342142267c.png">

