### PR TITLE
Fix GeoJson coordinate parsing

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonExtent.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonExtent.java
@@ -54,7 +54,10 @@ class GeoJsonExtent {
       double lat = point.optDouble(1, 0.0);
       double lng = point.optDouble(0, 0.0);
 
-      coordinates.add(new LatLng(lat, lng));
+      // PMD complains about instantiating objects in loops, but here, we retain a reference to the
+      // object after the loop exits--the PMD recommendation here makes little sense, and is
+      // presumably intended to prevent short-lived allocations.
+      coordinates.add(new LatLng(lat, lng)); // NOPMD
     }
 
     return stream(coordinates).collect(toImmutableList());

--- a/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonExtent.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonExtent.java
@@ -48,10 +48,10 @@ class GeoJsonExtent {
       return ImmutableList.of();
     }
 
-    double south = sw.optDouble(0, 0.0);
-    double west = sw.optDouble(1, 0.0);
-    double north = ne.optDouble(0, 0.0);
-    double east = ne.optDouble(1, 0.0);
+    double south = sw.optDouble(1, 0.0);
+    double west = sw.optDouble(0, 0.0);
+    double north = ne.optDouble(1, 0.0);
+    double east = ne.optDouble(0, 0.0);
 
     return ImmutableList.of(
         new LatLng(south, west),


### PR DESCRIPTION
The GeoJson spec states that positions must be described by a longitude followed by a latitude; we previously assumed the reverse order, leading to errors.