### PR TITLE
[Code health] Update to gradle plugin version 4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     }
     dependencies {
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0"
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "com.google.gms:google-services:4.3.3"
         classpath "com.pascalwelsch.gitversioner:gitversioner:0.5.0"
 
@@ -43,7 +43,7 @@ buildscript {
 
 plugins {
     id "com.github.ben-manes.versions" version "0.28.0"
-    id 'com.github.spotbugs' version '1.6.4'
+    id 'com.github.spotbugs' version '4.3.0'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,9 @@ buildscript {
 
 plugins {
     id "com.github.ben-manes.versions" version "0.28.0"
-    id 'com.github.spotbugs' version '4.3.0'
+    // Spotbugs has been disabled due to incompatibility with Gradle 6
+    // See history here: https://github.com/google/ground-android/pull/501
+    //id 'com.github.spotbugs' version '4.3.0'
 }
 
 allprojects {
@@ -58,7 +60,7 @@ allprojects {
 }
 
 task checkCode(type: GradleBuild) {
-    tasks = ['checkstyle', 'lintDebug', 'pmd', 'spotbugs', 'dependencyUpdates']
+    tasks = ['checkstyle', 'lintDebug', 'pmd', 'dependencyUpdates']
 }
 
 task clean(type: Delete) {

--- a/config/spotbugs/spotbugs.gradle
+++ b/config/spotbugs/spotbugs.gradle
@@ -36,14 +36,15 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.4'
+        classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.7.1'
     }
 }
 
 apply plugin: 'com.github.spotbugs'
 
+
 spotbugs {
-    toolVersion = '4.0.0-beta4'
+    toolVersion = '4.3.0'
 }
 
 def configDir = "${project.rootDir}/config/spotbugs"

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -210,8 +210,6 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0-alpha4', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-
-    debugImplementation 'androidx.fragment:fragment-testing:1.2.5'
 }
 
 apply plugin: 'androidx.navigation.safeargs'

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.google.firebase.crashlytics'
 apply from: '../config/checkstyle/checkstyle.gradle'
 apply from: '../config/lint/lint.gradle'
 apply from: '../config/pmd/pmd.gradle'
-apply from: '../config/spotbugs/spotbugs.gradle'
+//apply from: '../config/spotbugs/spotbugs.gradle'
 
 project.ext {
     autoDisposeVersion = "1.4.0"
@@ -79,11 +79,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    dataBinding {
-        enabled = true
-    }
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding true
+        viewBinding true
     }
     sourceSets {
         test.manifest.srcFile "src/test/AndroidManifest.xml"
@@ -212,6 +210,8 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0-alpha4', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
+
+    debugImplementation 'androidx.fragment:fragment-testing:1.2.5'
 }
 
 apply plugin: 'androidx.navigation.safeargs'

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,4 @@ android.enableBuildCache=true
 org.gradle.caching=true
 # Increase memory allotted to JVM
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-# Run annotation processing in a separate task
-android.enableSeparateAnnotationProcessing=true
-# Robolectric testing
-android.enableUnitTestBinaryResources=true
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 17 00:44:45 IST 2020
+#Wed Jun 17 16:29:45 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-all.zip

--- a/third_party/android-gmaps-addons/build.gradle
+++ b/third_party/android-gmaps-addons/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 15
@@ -18,6 +17,6 @@ android {
 }
 
 dependencies {
-  implementation "com.google.android.gms:play-services-base:17.2.1"
+  implementation "com.google.android.gms:play-services-base:17.3.0"
   implementation "com.google.android.gms:play-services-maps:17.0.0"
 }


### PR DESCRIPTION
Upgrade to gradle plugin to 4.0.0 and some other version bumps, notably:

- Remove `android.enableUnitTestBinaryResources=true`. [No longer needed since Android 3.3](http://robolectric.org/blog/2018/10/25/robolectric-4-0/).
- Remove `android.enableSeparateAnnotationProcessing=true`. [No longer supported in Gradle Plugin 4.0.0](https://developer.android.com/studio/releases/gradle-plugin) (see section titled "Separate annotation processing feature removed")
- Update com.google.android.gms:play-services-base:17.2.1 to 17.3.0
- Update gradle version to 6.5

Problem:

Spotbugs gives an error so is currently commented out. Need expert help from @gino-m :)
