### PR TITLE
[Bugs] Improve photos support

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/FirestoreStorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/FirestoreStorageManager.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java8.util.StringJoiner;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import timber.log.Timber;
 
 // TODO: Add column to Observation table for storing uploaded media urls
 // TODO: Synced to remote db as well
@@ -72,7 +73,13 @@ public class FirestoreStorageManager implements RemoteStorageManager {
         emitter ->
             createReference(remoteDestinationPath)
                 .putFile(Uri.fromFile(file))
-                .addOnCompleteListener(uploadTask -> emitter.onComplete())
+                .addOnCompleteListener(
+                    uploadTask -> {
+                      if (file.delete()) {
+                        Timber.d("File deleted: %s", file.getName());
+                      }
+                      emitter.onComplete();
+                    })
                 .addOnPausedListener(taskSnapshot -> emitter.onNext(TransferProgress.paused()))
                 .addOnFailureListener(emitter::onError)
                 .addOnProgressListener(

--- a/gnd/src/main/java/com/google/android/gnd/persistence/sync/PhotoSyncWorkManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/sync/PhotoSyncWorkManager.java
@@ -16,6 +16,7 @@
 
 package com.google.android.gnd.persistence.sync;
 
+import androidx.annotation.NonNull;
 import androidx.work.Constraints;
 import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
@@ -45,12 +46,8 @@ public class PhotoSyncWorkManager {
    * network connection is available. The returned {@code Completable} completes immediately as soon
    * as the worker is added to the work queue (not once the sync job completes).
    */
-  public void enqueueSyncWorker(String localFilePath, String remoteDestinationPath) {
-    enqueueSyncWorkerInternal(localFilePath, remoteDestinationPath);
-  }
-
-  private void enqueueSyncWorkerInternal(String localFilePath, String remoteDestinationPath) {
-    OneTimeWorkRequest request = buildWorkerRequest(localFilePath, remoteDestinationPath);
+  public void enqueueSyncWorker(@NonNull String localPath, @NonNull String remotePath) {
+    OneTimeWorkRequest request = buildWorkerRequest(localPath, remotePath);
     getWorkManager().enqueue(request);
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/sync/PhotoSyncWorkManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/sync/PhotoSyncWorkManager.java
@@ -20,7 +20,6 @@ import androidx.work.Constraints;
 import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
-import io.reactivex.Completable;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
@@ -46,9 +45,8 @@ public class PhotoSyncWorkManager {
    * network connection is available. The returned {@code Completable} completes immediately as soon
    * as the worker is added to the work queue (not once the sync job completes).
    */
-  public Completable enqueueSyncWorker(String localFilePath, String remoteDestinationPath) {
-    return Completable.fromRunnable(
-        () -> enqueueSyncWorkerInternal(localFilePath, remoteDestinationPath));
+  public void enqueueSyncWorker(String localFilePath, String remoteDestinationPath) {
+    enqueueSyncWorkerInternal(localFilePath, remoteDestinationPath);
   }
 
   private void enqueueSyncWorkerInternal(String localFilePath, String remoteDestinationPath) {

--- a/gnd/src/main/java/com/google/android/gnd/system/StorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/StorageManager.java
@@ -109,19 +109,13 @@ public class StorageManager {
         });
   }
 
-  /**
-   * Returns the path of the file saved in the sdcard used for uploading to the provided destination
-   * path.
-   */
-  private File getLocalFileFromDestinationPath(String destinationPath)
-      throws FileNotFoundException {
-    String[] splits = destinationPath.split("/");
-    return fileUtil.getFile(splits[splits.length - 1]);
-  }
-
-  private Uri getFileUriFromDestinationPath(String destinationPath) throws FileNotFoundException {
-    File file = getLocalFileFromDestinationPath(destinationPath);
-    return Uri.fromFile(file);
+  private Uri getFileUriFromDestinationPath(String destinationPath) {
+    try {
+      return Uri.fromFile(fileUtil.getLocalFileFromDestinationPath(destinationPath));
+    } catch (FileNotFoundException e) {
+      Timber.e(e);
+      return Uri.EMPTY;
+    }
   }
 
   /**

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AddPhotoDialogAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AddPhotoDialogAdapter.java
@@ -20,25 +20,35 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.gnd.R;
 import com.google.android.gnd.databinding.AddPhotoListItemBinding;
+import com.google.common.collect.ImmutableList;
 
 public class AddPhotoDialogAdapter extends RecyclerView.Adapter<AddPhotoDialogAdapter.ViewHolder> {
 
-  public static final int CAMERA = 1;
-  public static final int STORAGE = 2;
-
-  private static final int[][] ADD_PHOTO_LIST = {
-    {R.string.action_camera, R.drawable.ic_photo_camera, CAMERA},
-    {R.string.action_storage, R.drawable.ic_sd_storage, STORAGE}
-  };
+  private static final ImmutableList<PhotoStorageResource> PHOTO_STORAGE_RESOURCES =
+      ImmutableList.of(
+          new PhotoStorageResource(
+              R.string.action_camera,
+              R.drawable.ic_photo_camera,
+              PhotoStorageResource.PHOTO_SOURCE_CAMERA),
+          new PhotoStorageResource(
+              R.string.action_storage,
+              R.drawable.ic_sd_storage,
+              PhotoStorageResource.PHOTO_SOURCE_STORAGE));
 
   private ItemClickListener listener;
 
   public AddPhotoDialogAdapter(ItemClickListener listener) {
     this.listener = listener;
+  }
+
+  public static ImmutableList<PhotoStorageResource> getPhotoStorageResources() {
+    return PHOTO_STORAGE_RESOURCES;
   }
 
   @NonNull
@@ -51,14 +61,15 @@ public class AddPhotoDialogAdapter extends RecyclerView.Adapter<AddPhotoDialogAd
 
   @Override
   public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-    holder.binding.textView.setText(ADD_PHOTO_LIST[position][0]);
-    holder.binding.imageView.setImageResource(ADD_PHOTO_LIST[position][1]);
-    holder.type = ADD_PHOTO_LIST[position][2];
+    PhotoStorageResource storageResource = getPhotoStorageResources().get(position);
+    holder.binding.textView.setText(storageResource.getTitleResId());
+    holder.binding.imageView.setImageResource(storageResource.getIconResId());
+    holder.type = storageResource.getSourceType();
   }
 
   @Override
   public int getItemCount() {
-    return ADD_PHOTO_LIST.length;
+    return getPhotoStorageResources().size();
   }
 
   public interface ItemClickListener {
@@ -81,6 +92,35 @@ public class AddPhotoDialogAdapter extends RecyclerView.Adapter<AddPhotoDialogAd
     @Override
     public void onClick(View view) {
       listener.onClick(type);
+    }
+  }
+
+  public static class PhotoStorageResource {
+
+    public static final int PHOTO_SOURCE_CAMERA = 1;
+    public static final int PHOTO_SOURCE_STORAGE = 2;
+
+    private final int titleResId;
+    private final int iconResId;
+    private final int sourceType;
+
+    public PhotoStorageResource(
+        @StringRes int titleResId, @DrawableRes int iconResId, int sourceType) {
+      this.titleResId = titleResId;
+      this.iconResId = iconResId;
+      this.sourceType = sourceType;
+    }
+
+    public int getIconResId() {
+      return iconResId;
+    }
+
+    public int getSourceType() {
+      return sourceType;
+    }
+
+    public int getTitleResId() {
+      return titleResId;
     }
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AddPhotoDialogAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AddPhotoDialogAdapter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gnd.ui.editobservation;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.android.gnd.R;
+import com.google.android.gnd.databinding.AddPhotoListItemBinding;
+
+public class AddPhotoDialogAdapter extends RecyclerView.Adapter<AddPhotoDialogAdapter.ViewHolder> {
+
+  public static final int CAMERA = 1;
+  public static final int STORAGE = 2;
+
+  private static final int[][] ADD_PHOTO_LISt = {
+    {R.string.action_camera, R.drawable.ic_photo_camera, CAMERA},
+    {R.string.action_storage, R.drawable.ic_sd_storage, STORAGE}
+  };
+
+  private ItemClickListener listener;
+
+  public AddPhotoDialogAdapter(ItemClickListener listener) {
+    this.listener = listener;
+  }
+
+  @NonNull
+  @Override
+  public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+    AddPhotoListItemBinding binding =
+        AddPhotoListItemBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
+    return new ViewHolder(binding, listener);
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+    holder.binding.textView.setText(ADD_PHOTO_LISt[position][0]);
+    holder.binding.imageView.setImageResource(ADD_PHOTO_LISt[position][1]);
+    holder.type = ADD_PHOTO_LISt[position][2];
+  }
+
+  @Override
+  public int getItemCount() {
+    return ADD_PHOTO_LISt.length;
+  }
+
+  public interface ItemClickListener {
+    void onClick(int type);
+  }
+
+  public static class ViewHolder extends RecyclerView.ViewHolder implements OnClickListener {
+
+    private final AddPhotoListItemBinding binding;
+    private final ItemClickListener listener;
+    private int type;
+
+    public ViewHolder(@NonNull AddPhotoListItemBinding binding, ItemClickListener listener) {
+      super(binding.getRoot());
+      this.binding = binding;
+      this.listener = listener;
+      itemView.setOnClickListener(this);
+    }
+
+    @Override
+    public void onClick(View view) {
+      listener.onClick(type);
+    }
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AddPhotoDialogAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AddPhotoDialogAdapter.java
@@ -30,7 +30,7 @@ public class AddPhotoDialogAdapter extends RecyclerView.Adapter<AddPhotoDialogAd
   public static final int CAMERA = 1;
   public static final int STORAGE = 2;
 
-  private static final int[][] ADD_PHOTO_LISt = {
+  private static final int[][] ADD_PHOTO_LIST = {
     {R.string.action_camera, R.drawable.ic_photo_camera, CAMERA},
     {R.string.action_storage, R.drawable.ic_sd_storage, STORAGE}
   };
@@ -51,14 +51,14 @@ public class AddPhotoDialogAdapter extends RecyclerView.Adapter<AddPhotoDialogAd
 
   @Override
   public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-    holder.binding.textView.setText(ADD_PHOTO_LISt[position][0]);
-    holder.binding.imageView.setImageResource(ADD_PHOTO_LISt[position][1]);
-    holder.type = ADD_PHOTO_LISt[position][2];
+    holder.binding.textView.setText(ADD_PHOTO_LIST[position][0]);
+    holder.binding.imageView.setImageResource(ADD_PHOTO_LIST[position][1]);
+    holder.type = ADD_PHOTO_LIST[position][2];
   }
 
   @Override
   public int getItemCount() {
-    return ADD_PHOTO_LISt.length;
+    return ADD_PHOTO_LIST.length;
   }
 
   public interface ItemClickListener {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -25,6 +25,8 @@ import android.widget.LinearLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.databinding.ViewDataBinding;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import com.google.android.gnd.MainActivity;
 import com.google.android.gnd.R;
@@ -242,6 +244,26 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
     bottomSheetDialog.setContentView(addPhotoBottomSheetBinding.getRoot());
     bottomSheetDialog.setCancelable(true);
     bottomSheetDialog.show();
+
+    AddPhotoDialogAdapter.ItemClickListener listener =
+        type -> {
+          bottomSheetDialog.dismiss();
+          switch (type) {
+            case AddPhotoDialogAdapter.CAMERA:
+              viewModel.showPhotoCapture(field);
+              break;
+            case AddPhotoDialogAdapter.STORAGE:
+              viewModel.showPhotoSelector(field);
+              break;
+            default:
+              throw new IllegalArgumentException("Unknown type: " + type);
+          }
+        };
+
+    RecyclerView recyclerView = addPhotoBottomSheetBinding.recyclerView;
+    recyclerView.setHasFixedSize(true);
+    recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+    recyclerView.setAdapter(new AddPhotoDialogAdapter(listener));
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -40,6 +40,7 @@ import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.form.Form;
 import com.google.android.gnd.model.form.MultipleChoice.Cardinality;
 import com.google.android.gnd.model.observation.Response;
+import com.google.android.gnd.model.observation.TextResponse;
 import com.google.android.gnd.ui.common.AbstractFragment;
 import com.google.android.gnd.ui.common.BackPressListener;
 import com.google.android.gnd.ui.common.EphemeralPopups;
@@ -140,10 +141,11 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
   }
 
   private void addFieldViewModel(Field field, AbstractFieldViewModel fieldViewModel) {
-    fieldViewModel.init(field, viewModel.getResponse(field.getId()));
+    fieldViewModel.init(field, viewModel.getSavedOrOriginalResponse(field.getId()));
 
     if (fieldViewModel instanceof PhotoFieldViewModel) {
       observeSelectPhotoClicks((PhotoFieldViewModel) fieldViewModel);
+      observePhotoAdded((PhotoFieldViewModel) fieldViewModel);
     } else if (fieldViewModel instanceof MultipleChoiceFieldViewModel) {
       observeMultipleChoiceClicks((MultipleChoiceFieldViewModel) fieldViewModel);
     }
@@ -211,10 +213,23 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
     }
   }
 
-  private void observeSelectPhotoClicks(PhotoFieldViewModel viewModel) {
-    viewModel
+  private void observeSelectPhotoClicks(PhotoFieldViewModel fieldViewModel) {
+    fieldViewModel
         .getShowDialogClicks()
-        .observe(this, __ -> onShowPhotoSelectorDialog(viewModel.getField()));
+        .observe(this, __ -> onShowPhotoSelectorDialog(fieldViewModel.getField()));
+  }
+
+  private void observePhotoAdded(PhotoFieldViewModel fieldViewModel) {
+    viewModel
+        .getPhotoFieldUpdates()
+        .observe(
+            this,
+            map -> {
+              Field field = fieldViewModel.getField();
+              if (map.containsKey(field)) {
+                fieldViewModel.setResponse(TextResponse.fromString(map.get(field)));
+              }
+            });
   }
 
   private void onShowPhotoSelectorDialog(Field field) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -16,6 +16,9 @@
 
 package com.google.android.gnd.ui.editobservation;
 
+import static com.google.android.gnd.ui.editobservation.AddPhotoDialogAdapter.PhotoStorageResource.PHOTO_SOURCE_CAMERA;
+import static com.google.android.gnd.ui.editobservation.AddPhotoDialogAdapter.PhotoStorageResource.PHOTO_SOURCE_STORAGE;
+
 import android.app.AlertDialog;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -249,10 +252,10 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
         type -> {
           bottomSheetDialog.dismiss();
           switch (type) {
-            case AddPhotoDialogAdapter.CAMERA:
+            case PHOTO_SOURCE_CAMERA:
               viewModel.showPhotoCapture(field);
               break;
-            case AddPhotoDialogAdapter.STORAGE:
+            case PHOTO_SOURCE_STORAGE:
               viewModel.showPhotoSelector(field);
               break;
             default:

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -114,7 +114,6 @@ public class EditObservationViewModel extends AbstractViewModel {
   /** Outcome of user clicking "Save". */
   private final LiveData<Event<SaveResult>> saveResults;
 
-  private EditObservationFragmentArgs args;
   /** Observation state loaded when view is initialized. */
   @Nullable private Observation originalObservation;
 
@@ -169,7 +168,6 @@ public class EditObservationViewModel extends AbstractViewModel {
   }
 
   void initialize(EditObservationFragmentArgs args) {
-    this.args = args;
     viewArgs.onNext(args);
   }
 
@@ -226,7 +224,10 @@ public class EditObservationViewModel extends AbstractViewModel {
     String localFileName = uuidGenerator.generateUuid() + Config.PHOTO_EXT;
     String remoteDestinationPath =
         getRemoteDestinationPath(
-            args.getProjectId(), args.getFormId(), args.getFeatureId(), localFileName);
+            originalObservation.getProject().getId(),
+            originalObservation.getForm().getId(),
+            originalObservation.getFeature().getId(),
+            localFileName);
 
     photoUpdates.postValue(ImmutableMap.of(field, remoteDestinationPath));
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/util/FileUtil.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/util/FileUtil.java
@@ -51,6 +51,15 @@ public class FileUtil {
     return file;
   }
 
+  /**
+   * Returns the path of the file saved in the sdcard used for uploading to the provided destination
+   * path.
+   */
+  public File getLocalFileFromDestinationPath(String destinationPath) throws FileNotFoundException {
+    String[] splits = destinationPath.split("/");
+    return getFile(splits[splits.length - 1]);
+  }
+
   public File getFile(String filename) throws FileNotFoundException {
     File file = new File(context.getFilesDir(), filename);
     if (!file.exists()) {

--- a/gnd/src/main/res/layout/add_photo_list_item.xml
+++ b/gnd/src/main/res/layout/add_photo_list_item.xml
@@ -16,28 +16,26 @@
   ~ limitations under the License.
   -->
 
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:background="?android:attr/selectableItemBackground"
+  android:gravity="center"
+  android:orientation="horizontal">
 
-  <data>
-    <variable
-      name="field"
-      type="com.google.android.gnd.model.form.Field" />
-    <variable
-      name="viewModel"
-      type="com.google.android.gnd.ui.editobservation.EditObservationViewModel" />
-  </data>
+  <ImageView
+    android:id="@+id/imageView"
+    android:layout_width="32dp"
+    android:layout_height="32dp"
+    android:layout_margin="@dimen/add_photo_bottom_sheet_drawable_margin"
+    tools:src="@drawable/ic_photo_camera" />
 
-  <LinearLayout
+  <TextView
+    android:id="@+id/textView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp">
+    android:textSize="@dimen/add_photo_bottom_sheet_text_size"
+    tools:text="@string/action_camera" />
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/recycler_view"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content" />
-  </LinearLayout>
-
-</layout>
+</LinearLayout>

--- a/gnd/src/main/res/values/dimens.xml
+++ b/gnd/src/main/res/values/dimens.xml
@@ -88,10 +88,8 @@
     <dimen name="feature_details_header_height">120dp</dimen>
 
     <!-- Photo bottom dialog -->
-    <dimen name="add_photo_bottom_sheet_margin">16dp</dimen>
-    <dimen name="add_photo_bottom_sheet_drawable_padding">24dp</dimen>
+    <dimen name="add_photo_bottom_sheet_drawable_margin">24dp</dimen>
     <dimen name="add_photo_bottom_sheet_text_size">16sp</dimen>
-    <dimen name="add_photo_bottom_sheet_padding">16dp</dimen>
 
     <!-- Photo CardView -->
     <dimen name="cardview_elevation">4dp</dimen>

--- a/gnd/src/main/res/values/styles.xml
+++ b/gnd/src/main/res/values/styles.xml
@@ -192,14 +192,6 @@
     <item name="android:textStyle">bold</item>
   </style>
 
-  <style name="AddPhotoActionItem">
-    <item name="android:textSize">@dimen/add_photo_bottom_sheet_text_size</item>
-    <item name="android:drawablePadding">@dimen/add_photo_bottom_sheet_drawable_padding</item>
-    <item name="android:layout_width">match_parent</item>
-    <item name="android:layout_height">wrap_content</item>
-    <item name="android:padding">@dimen/add_photo_bottom_sheet_padding</item>
-  </style>
-
   <style name="FieldView">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
Towards #310, #487 

- Fix regression: photo doesn't load
- Fix bug: remote path contained "N/A" instead of `formId` when creating a new observation instead of editing old one
- Fix bug: bottom sheet dialog not dismissing after making a selection
- Use `UUID` as filename in order to support multiple photos (in upcoming PRs)
- Enqueue photos for upload when synchronizing response deltas
- Remove local file after uploading to remote storage successfully
