### PR TITLE
[Code health] Tweak plugin and update gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,9 +77,23 @@ gitVersioner {
     baseBranch "master"
 }
 
+def isNonStable = { String version ->
+    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
+    def regex = /^[0-9,.v-]+(-r)?$/
+    return !stableKeyword && !(version ==~ regex)
+}
+
+// https://github.com/ben-manes/gradle-versions-plugin
 // To check which dependencies are out of date:
 // ./gradlew dependencyUpdates
 tasks.dependencyUpdates {
+
+    // Disallow release candidates as upgradable versions from stable versions
+    rejectVersionIf {
+        isNonStable(it.candidate.version) && !isNonStable(it.currentVersion)
+    }
+
+    checkForGradleUpdate = true
     checkConstraints = true
     gradleReleaseChannel = "current"
     outputFormatter = "json,plain"

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
         classpath 'com.google.firebase:perf-plugin:1.3.1'
 
         // Crashlytics plugin
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.1.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -25,7 +25,7 @@ apply from: '../config/pmd/pmd.gradle'
 
 project.ext {
     autoDisposeVersion = "1.4.0"
-    autoValueVersion = "1.6.3"
+    autoValueVersion = "1.7.3"
     butterKnifeVersion = "10.2.1"
     firebaseCoreVersion = "17.4.3"
     gmsVersion = "17.0.0"
@@ -128,7 +128,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-location:$project.gmsVersion"
 
     // GeoJSON support
-    implementation "com.google.maps.android:android-maps-utils:1.3.1"
+    implementation "com.google.maps.android:android-maps-utils:2.0.0"
 
     // Firebase and related libraries.
     implementation "com.google.firebase:firebase-analytics:$project.firebaseCoreVersion"
@@ -138,7 +138,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-perf:19.0.7'
     implementation 'com.github.FrangSierra:RxFirebase:1.5.7'
     implementation 'com.google.firebase:firebase-storage:19.1.1'
-    implementation 'com.google.firebase:firebase-crashlytics:17.0.1'
+    implementation 'com.google.firebase:firebase-crashlytics:17.1.0'
 
     // Hilt
     implementation "com.google.dagger:hilt-android:$project.hiltVersion"
@@ -206,7 +206,7 @@ dependencies {
 
     // Apache Commons IO
     // https://mvnrepository.com/artifact/commons-io/commons-io
-    implementation 'commons-io:commons-io:2.6'
+    implementation 'commons-io:commons-io:2.7'
 
     // Testing
     testImplementation 'junit:junit:4.13'
@@ -215,7 +215,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'android.arch.core:core-testing:1.1.1'
 
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0-alpha4', {
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.3.0-rc01', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 }

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -25,7 +25,7 @@ apply from: '../config/pmd/pmd.gradle'
 
 project.ext {
     autoDisposeVersion = "1.4.0"
-    autoValueVersion = "1.7.3"
+    autoValueVersion = "1.6.3"
     butterKnifeVersion = "10.2.1"
     firebaseCoreVersion = "17.4.3"
     gmsVersion = "17.0.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip


### PR DESCRIPTION
* Add a filter to `dependencyUpdates` plugin to prevent notifying update from stable to unstable version. (We hardly ever do that. Except for when testing latest libraries e.g. `hilt`). This shows the code health more accurately in the Github badge

* Bump gradle and several other dependencies

@gino-m PTAL.