### PR TITLE
[Code Health] Move visibility logic from ViewModels to layouts

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
@@ -38,16 +38,16 @@ public class PhotoFieldViewModel extends AbstractFieldViewModel {
   private final StorageManager storageManager;
   private final BehaviorProcessor<String> destinationPath = BehaviorProcessor.create();
   private final LiveData<Uri> uri;
-  private final LiveData<Integer> visibility;
+  public final LiveData<Boolean> isVisible;
   private final MutableLiveData<Field> showDialogClicks = new MutableLiveData<>();
 
   @Inject
   PhotoFieldViewModel(StorageManager storageManager, Application application) {
     super(application);
     this.storageManager = storageManager;
-    this.visibility =
+    this.isVisible =
         LiveDataReactiveStreams.fromPublisher(
-            destinationPath.map(path -> path.isEmpty() ? View.GONE : View.VISIBLE));
+            destinationPath.map(path -> !path.isEmpty()));
     this.uri =
         LiveDataReactiveStreams.fromPublisher(
             destinationPath.switchMapSingle(this::getDownloadUrl));
@@ -59,10 +59,6 @@ public class PhotoFieldViewModel extends AbstractFieldViewModel {
 
   public LiveData<Uri> getUri() {
     return uri;
-  }
-
-  public LiveData<Integer> getVisibility() {
-    return visibility;
   }
 
   @Override

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
@@ -18,7 +18,6 @@ package com.google.android.gnd.ui.editobservation;
 
 import android.app.Application;
 import android.net.Uri;
-import android.view.View;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import androidx.lifecycle.MutableLiveData;

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -16,7 +16,6 @@
 
 package com.google.android.gnd.ui.home;
 
-import android.view.View;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import androidx.lifecycle.MutableLiveData;
@@ -57,8 +56,8 @@ public class HomeScreenViewModel extends AbstractViewModel {
   // TODO: Move into FeatureDetailsViewModel.
   private final MutableLiveData<Action> openDrawerRequests;
   private final MutableLiveData<BottomSheetState> bottomSheetState;
-  private final MutableLiveData<Integer> addObservationButtonVisibility =
-      new MutableLiveData<>(View.GONE);
+  public final MutableLiveData<Boolean> isObservationButtonVisible =
+      new MutableLiveData<>(false);
 
   @Inject
   HomeScreenViewModel(
@@ -106,10 +105,6 @@ public class HomeScreenViewModel extends AbstractViewModel {
     return projectRepository.getLastActiveProjectId().isEmpty();
   }
 
-  public MutableLiveData<Integer> getAddObservationButtonVisibility() {
-    return addObservationButtonVisibility;
-  }
-
   private void onAddFeatureError(Throwable throwable) {
     // TODO: Show an error message to the user.
     Timber.e(throwable, "Couldn't add feature.");
@@ -141,7 +136,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
   }
 
   private void showBottomSheet(Feature feature) {
-    addObservationButtonVisibility.setValue(View.VISIBLE);
+    isObservationButtonVisible.setValue(true);
     bottomSheetState.setValue(BottomSheetState.visible(feature));
   }
 
@@ -156,7 +151,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
 
   public void onBottomSheetHidden() {
     bottomSheetState.setValue(BottomSheetState.hidden());
-    addObservationButtonVisibility.setValue(View.GONE);
+    isObservationButtonVisible.setValue(false);
   }
 
   public void addObservation() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuredetails/FeatureDetailsViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuredetails/FeatureDetailsViewModel.java
@@ -16,9 +16,8 @@
 
 package com.google.android.gnd.ui.home.featuredetails;
 
-import android.view.View;
+import androidx.databinding.ObservableBoolean;
 import androidx.databinding.ObservableField;
-import androidx.databinding.ObservableInt;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import androidx.lifecycle.ViewModel;
@@ -34,7 +33,7 @@ public class FeatureDetailsViewModel extends ViewModel {
 
   public final ObservableField<String> featureTitle;
   public final ObservableField<String> featureSubtitle;
-  public final ObservableInt featureSubtitleVisibility;
+  public final ObservableBoolean isFeatureSubtitleVisible = new ObservableBoolean(false);
 
   private final BehaviorProcessor<Optional<Feature>> selectedFeature;
 
@@ -42,7 +41,6 @@ public class FeatureDetailsViewModel extends ViewModel {
   public FeatureDetailsViewModel() {
     featureTitle = new ObservableField<>();
     featureSubtitle = new ObservableField<>();
-    featureSubtitleVisibility = new ObservableInt();
     selectedFeature = BehaviorProcessor.createDefault(Optional.empty());
   }
 
@@ -62,8 +60,7 @@ public class FeatureDetailsViewModel extends ViewModel {
 
     featureTitle.set(state.getFeature().getTitle());
     featureSubtitle.set(state.getFeature().getSubtitle());
-    featureSubtitleVisibility.set(
-        state.getFeature().getSubtitle().isEmpty() ? View.GONE : View.VISIBLE);
+    isFeatureSubtitleVisible.set(!state.getFeature().getSubtitle().isEmpty());
 
     selectedFeature.onNext(Optional.of(state.getFeature()));
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuredetails/ObservationListViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuredetails/ObservationListViewModel.java
@@ -16,9 +16,7 @@
 
 package com.google.android.gnd.ui.home.featuredetails;
 
-import android.util.Log;
-import android.view.View;
-import androidx.databinding.ObservableInt;
+import androidx.databinding.ObservableBoolean;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import com.google.android.gnd.model.Project;
@@ -32,15 +30,15 @@ import io.reactivex.Single;
 import io.reactivex.processors.PublishProcessor;
 import java8.util.Optional;
 import javax.inject.Inject;
+import timber.log.Timber;
 
 public class ObservationListViewModel extends AbstractViewModel {
 
   private static final String TAG = ObservationListViewModel.class.getSimpleName();
+  public final ObservableBoolean isLoading = new ObservableBoolean(false);
   private final ObservationRepository observationRepository;
   private PublishProcessor<ObservationListRequest> observationListRequests;
   private LiveData<ImmutableList<Observation>> observationList;
-
-  public final ObservableInt loadingSpinnerVisibility = new ObservableInt();
 
   @Inject
   public ObservationListViewModel(ObservationRepository observationRepository) {
@@ -49,9 +47,9 @@ public class ObservationListViewModel extends AbstractViewModel {
     observationList =
         LiveDataReactiveStreams.fromPublisher(
             observationListRequests
-                .doOnNext(__ -> loadingSpinnerVisibility.set(View.VISIBLE))
+                .doOnNext(__ -> isLoading.set(true))
                 .switchMapSingle(this::getObservations)
-                .doOnNext(__ -> loadingSpinnerVisibility.set(View.GONE)));
+                .doOnNext(__ -> isLoading.set(false)));
   }
 
   public LiveData<ImmutableList<Observation>> getObservations() {
@@ -77,7 +75,7 @@ public class ObservationListViewModel extends AbstractViewModel {
 
   private Single<ImmutableList<Observation>> onGetObservationsError(Throwable t) {
     // TODO: Show an appropriate error message to the user.
-    Log.d(TAG, "Failed to fetch observation list.", t);
+    Timber.e(t, "Failed to fetch observation list.");
     return Single.just(ImmutableList.of());
   }
 
@@ -85,7 +83,7 @@ public class ObservationListViewModel extends AbstractViewModel {
     observationListRequests.onNext(new ObservationListRequest(project, featureId, formId));
   }
 
-  class ObservationListRequest {
+  static class ObservationListRequest {
     final Project project;
     final String featureId;
     final Optional<String> formId;

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuredetails/ObservationListViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuredetails/ObservationListViewModel.java
@@ -34,7 +34,6 @@ import timber.log.Timber;
 
 public class ObservationListViewModel extends AbstractViewModel {
 
-  private static final String TAG = ObservationListViewModel.class.getSimpleName();
   public final ObservableBoolean isLoading = new ObservableBoolean(false);
   private final ObservationRepository observationRepository;
   private PublishProcessor<ObservationListRequest> observationListRequests;

--- a/gnd/src/main/java/com/google/android/gnd/ui/observationdetails/ObservationDetailsViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/observationdetails/ObservationDetailsViewModel.java
@@ -16,7 +16,7 @@
 
 package com.google.android.gnd.ui.observationdetails;
 
-import android.view.View;
+
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import com.google.android.gnd.model.feature.Feature;
@@ -32,7 +32,7 @@ public class ObservationDetailsViewModel extends AbstractViewModel {
 
   private final BehaviorProcessor<ObservationDetailsFragmentArgs> argsProcessor;
   public final LiveData<Loadable<Observation>> observations;
-  public final LiveData<Integer> progressBarVisibility;
+  public final LiveData<Boolean> isProgressBarVisible;
   public final LiveData<Feature> feature;
 
   @Inject
@@ -51,7 +51,7 @@ public class ObservationDetailsViewModel extends AbstractViewModel {
     // TODO: Refactor to expose the fetched observation directly.
     this.observations = LiveDataReactiveStreams.fromPublisher(observationStream);
 
-    this.progressBarVisibility =
+    this.isProgressBarVisible =
         LiveDataReactiveStreams.fromPublisher(
             observationStream.map(ObservationDetailsViewModel::getProgressBarVisibility));
 
@@ -64,8 +64,8 @@ public class ObservationDetailsViewModel extends AbstractViewModel {
     this.argsProcessor.onNext(args);
   }
 
-  private static Integer getProgressBarVisibility(Loadable<Observation> observation) {
-    return observation.value().isPresent() ? View.VISIBLE : View.GONE;
+  private static Boolean getProgressBarVisibility(Loadable<Observation> observation) {
+    return observation.value().isPresent();
   }
 
   private static Feature getFeature(Loadable<Observation> observation) {

--- a/gnd/src/main/res/layout/edit_observation_frag.xml
+++ b/gnd/src/main/res/layout/edit_observation_frag.xml
@@ -19,6 +19,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
+    <import type="android.view.View" />
     <variable
       name="viewModel"
       type="com.google.android.gnd.ui.editobservation.EditObservationViewModel"/>
@@ -88,7 +89,7 @@
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:padding="48dp"
-        android:visibility="@{viewModel.loadingSpinnerVisibility}"/>
+        android:visibility="@{viewModel.isLoading ? View.VISIBLE : View.GONE }"/>
 
     </RelativeLayout>
 
@@ -104,7 +105,7 @@
       android:layout_gravity="top|end"
       android:elevation="2dp"
       android:text="@string/save_observation_button_label"
-      android:visibility="@{viewModel.saveButtonVisibility}"
+      android:visibility="@{viewModel.isSaving ? View.GONE : View.VISIBLE }"
       android:onClick="@{() -> fragment.onSaveClick()}"
       app:useCompatPadding="true"/>
 
@@ -113,7 +114,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
-      android:visibility="@{viewModel.savingProgressVisibility}">
+      android:visibility="@{viewModel.isSaving ? View.VISIBLE : View.GONE }">
       <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/gnd/src/main/res/layout/feature_details_chrome.xml
+++ b/gnd/src/main/res/layout/feature_details_chrome.xml
@@ -19,6 +19,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <data>
+    <import type="android.view.View" />
     <variable
       name="viewModel"
       type="com.google.android.gnd.ui.home.HomeScreenViewModel" />
@@ -59,7 +60,7 @@
       android:elevation="6dp"
       android:onClick="@{() -> viewModel.addObservation()}"
       android:text="@string/add_observation_button_label"
-      android:visibility="@{viewModel.addObservationButtonVisibility}"
+      android:visibility="@{viewModel.isObservationButtonVisible ? View.VISIBLE : View.GONE}"
       app:chipIcon="@drawable/ic_add"
       app:useCompatPadding="true" />
 

--- a/gnd/src/main/res/layout/feature_details_header.xml
+++ b/gnd/src/main/res/layout/feature_details_header.xml
@@ -21,6 +21,7 @@
   xmlns:tools="http://schemas.android.com/tools">
 
   <data>
+    <import type="android.view.View" />
     <variable
       name="viewModel"
       type="com.google.android.gnd.ui.home.featuredetails.FeatureDetailsViewModel" />
@@ -63,7 +64,7 @@
           android:textAlignment="center"
           android:textColor="@color/colorGrey600"
           android:textSize="12sp"
-          android:visibility="@{viewModel.featureSubtitleVisibility}"
+          android:visibility="@{viewModel.isFeatureSubtitleVisible ? View.VISIBLE : View.GONE}"
           tools:text="Feature Subtitle"
           android:gravity="center_horizontal" />
       </LinearLayout>

--- a/gnd/src/main/res/layout/observation_details_frag.xml
+++ b/gnd/src/main/res/layout/observation_details_frag.xml
@@ -18,6 +18,7 @@
 
 <layout>
   <data>
+    <import type="android.view.View" />
     <variable
       name="viewModel"
       type="com.google.android.gnd.ui.observationdetails.ObservationDetailsViewModel" />
@@ -43,7 +44,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:padding="48dp"
-        android:visibility="@{safeUnbox(viewModel.progressBarVisibility)}" />
+        android:visibility="@{safeUnbox(viewModel.isProgressBarVisible) ? View.VISIBLE : View.GONE }" />
 
       <!-- CardView is used to create the drop shadow effect -->
       <androidx.cardview.widget.CardView

--- a/gnd/src/main/res/layout/observation_list_frag.xml
+++ b/gnd/src/main/res/layout/observation_list_frag.xml
@@ -17,6 +17,7 @@
   -->
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
   <data>
+    <import type="android.view.View" />
     <variable
         name="viewModel"
         type="com.google.android.gnd.ui.home.featuredetails.ObservationListViewModel"/>
@@ -34,7 +35,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center|top"
         android:paddingTop="32dp"
-        android:visibility="@{viewModel.loadingSpinnerVisibility}"/>
+        android:visibility="@{viewModel.isLoading ? View.VISIBLE : View.GONE}"/>
 
     <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/observation_list_container"

--- a/gnd/src/main/res/layout/photo_field.xml
+++ b/gnd/src/main/res/layout/photo_field.xml
@@ -19,6 +19,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
   <data>
+    <import type="android.view.View" />
     <variable
       name="viewModel"
       type="com.google.android.gnd.ui.editobservation.PhotoFieldViewModel" />
@@ -28,7 +29,7 @@
     android:id="@+id/material_card"
     android:layout_width="match_parent"
     android:layout_height="200dp"
-    android:visibility="@{viewModel.visibility}"
+    android:visibility="@{viewModel.isVisible ? View.VISIBLE : View.GONE }"
     app:cardElevation="@dimen/cardview_elevation">
     <ImageView
       android:id="@+id/image_thumbnail_preview"


### PR DESCRIPTION
Slightly simplifies the view models by refactoring the "visibility" variables from ints which hold the visibility to booleans which hold the underlying state e.g. `isLoading` `isSaving` and can then be used in the layouts. 