### PR TITLE
Geocoding Fixes

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -27,7 +27,7 @@ public final class Config {
 
   // Local db settings.
   // TODO(#128): Reset version to 1 before releasing.
-  public static final int DB_VERSION = 56;
+  public static final int DB_VERSION = 58;
   public static final String DB_NAME = "gnd.db";
 
   // Firebase Cloud Firestore settings.

--- a/gnd/src/main/java/com/google/android/gnd/model/basemap/OfflineArea.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/basemap/OfflineArea.java
@@ -29,6 +29,8 @@ public abstract class OfflineArea {
 
   public abstract LatLngBounds getBounds();
 
+  public abstract String getName();
+
   public abstract Builder toBuilder();
 
   public enum State {
@@ -50,6 +52,8 @@ public abstract class OfflineArea {
     public abstract Builder setState(State state);
 
     public abstract Builder setId(String id);
+
+    public abstract Builder setName(String name);
 
     public abstract OfflineArea build();
   }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OfflineAreaEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OfflineAreaEntity.java
@@ -38,6 +38,11 @@ public abstract class OfflineAreaEntity {
 
   @AutoValue.CopyAnnotations
   @NonNull
+  @ColumnInfo(name = "name")
+  public abstract String getName();
+
+  @AutoValue.CopyAnnotations
+  @NonNull
   @ColumnInfo(name = "state")
   public abstract OfflineAreaEntityState getState();
 
@@ -66,6 +71,7 @@ public abstract class OfflineAreaEntity {
         .setId(offlineAreaEntity.getId())
         .setBounds(bounds)
         .setState(toAreaState(offlineAreaEntity.getState()))
+        .setName(offlineAreaEntity.getName())
         .build();
   }
 
@@ -89,6 +95,7 @@ public abstract class OfflineAreaEntity {
         OfflineAreaEntity.builder()
             .setId(offlineArea.getId())
             .setState(toEntityState(offlineArea.getState()))
+            .setName(offlineArea.getName())
             .setNorth(offlineArea.getBounds().northeast.latitude)
             .setEast(offlineArea.getBounds().northeast.longitude)
             .setSouth(offlineArea.getBounds().southwest.latitude)
@@ -113,6 +120,7 @@ public abstract class OfflineAreaEntity {
 
   public static OfflineAreaEntity create(
       String id,
+      String name,
       OfflineAreaEntityState state,
       double north,
       double east,
@@ -120,6 +128,7 @@ public abstract class OfflineAreaEntity {
       double west) {
     return builder()
         .setId(id)
+        .setName(name)
         .setState(state)
         .setNorth(north)
         .setEast(east)
@@ -136,6 +145,8 @@ public abstract class OfflineAreaEntity {
   public abstract static class Builder {
 
     public abstract Builder setId(String newId);
+
+    public abstract Builder setName(String newName);
 
     public abstract Builder setState(OfflineAreaEntityState newState);
 

--- a/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
+++ b/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
@@ -143,15 +143,17 @@ public class OfflineAreaRepository {
   }
 
   public Completable addAreaAndEnqueue(LatLngBounds bounds) {
-    OfflineArea offlineArea =
-        OfflineArea.newBuilder()
-            .setBounds(bounds)
-            .setId(uuidGenerator.generateUuid())
-            .setState(State.PENDING)
-            .setName(geocodingManager.getOfflineAreaName(bounds))
-            .build();
-
-    return enqueueTileDownloads(offlineArea);
+    return geocodingManager
+        .getOfflineAreaName(bounds)
+        .map(
+            name ->
+                OfflineArea.newBuilder()
+                    .setBounds(bounds)
+                    .setId(uuidGenerator.generateUuid())
+                    .setState(State.PENDING)
+                    .setName(name)
+                    .build())
+        .flatMapCompletable(this::enqueueTileDownloads);
   }
 
   public Flowable<ImmutableList<OfflineArea>> getOfflineAreasOnceAndStream() {

--- a/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
+++ b/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
@@ -32,6 +32,7 @@ import com.google.android.gnd.persistence.sync.TileDownloadWorkManager;
 import com.google.android.gnd.persistence.uuid.OfflineUuidGenerator;
 import com.google.android.gnd.rx.Loadable;
 import com.google.android.gnd.rx.Schedulers;
+import com.google.android.gnd.system.GeocodingManager;
 import com.google.android.gnd.ui.util.FileUtil;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -52,6 +53,7 @@ public class OfflineAreaRepository {
   private final GeoJsonParser geoJsonParser;
   private final FileUtil fileUtil;
   private final Schedulers schedulers;
+  private final GeocodingManager geocodingManager;
 
   private final OfflineUuidGenerator uuidGenerator;
 
@@ -63,7 +65,8 @@ public class OfflineAreaRepository {
       GeoJsonParser geoJsonParser,
       OfflineUuidGenerator uuidGenerator,
       FileUtil fileUtil,
-      Schedulers schedulers) {
+      Schedulers schedulers,
+      GeocodingManager geocodingManager) {
     this.tileDownloadWorkManager = tileDownloadWorkManager;
     this.localDataStore = localDataStore;
     this.geoJsonParser = geoJsonParser;
@@ -71,6 +74,7 @@ public class OfflineAreaRepository {
     this.projectRepository = projectRepository;
     this.fileUtil = fileUtil;
     this.schedulers = schedulers;
+    this.geocodingManager = geocodingManager;
   }
 
   /**
@@ -140,11 +144,11 @@ public class OfflineAreaRepository {
 
   public Completable addAreaAndEnqueue(LatLngBounds bounds) {
     OfflineArea offlineArea =
-        // TODO: Geocode
         OfflineArea.newBuilder()
             .setBounds(bounds)
             .setId(uuidGenerator.generateUuid())
             .setState(State.PENDING)
+            .setName(geocodingManager.getOfflineAreaName(bounds))
             .build();
 
     return enqueueTileDownloads(offlineArea);

--- a/gnd/src/main/java/com/google/android/gnd/system/GeocodingManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/GeocodingManager.java
@@ -22,7 +22,9 @@ import android.location.Geocoder;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gnd.R;
+import com.google.android.gnd.rx.Schedulers;
 import dagger.hilt.android.qualifiers.ApplicationContext;
+import io.reactivex.Single;
 import java.io.IOException;
 import java.util.List;
 import java8.util.Optional;
@@ -41,12 +43,36 @@ public class GeocodingManager {
   }
 
   private final Geocoder geocoder;
+  private final Schedulers schedulers;
   private final String defaultAreaName;
 
   @Inject
-  public GeocodingManager(@ApplicationContext Context context) {
+  public GeocodingManager(@ApplicationContext Context context, Schedulers schedulers) {
     this.geocoder = new Geocoder(context);
+    this.schedulers = schedulers;
     this.defaultAreaName = context.getString(R.string.offline_areas_unknown_area);
+  }
+
+  private String getOfflineAreaNameInternal(LatLngBounds bounds)
+      throws AddressNotFoundException, IOException {
+    LatLng center = bounds.getCenter();
+
+    List<Address> addresses = geocoder.getFromLocation(center.latitude, center.longitude, 1);
+
+    if (addresses.isEmpty()) {
+      throw new AddressNotFoundException("No address found for area.");
+    }
+
+    Address address = addresses.get(0);
+
+    // TODO: Decide exactly what set of address parts we want to show the user.
+    Optional<String> country = Optional.ofNullable(address.getCountryName());
+    Optional<String> locality = Optional.ofNullable(address.getLocality());
+
+    return country
+        .map(
+            countryName -> locality.isPresent() ? countryName + ", " + locality.get() : countryName)
+        .orElse(defaultAreaName);
   }
 
   /**
@@ -55,32 +81,9 @@ public class GeocodingManager {
    *
    * <p>If no address is found for the given area, returns a default value.
    */
-  public String getOfflineAreaName(LatLngBounds bounds) {
-    LatLng center = bounds.getCenter();
-
-    try {
-      List<Address> addresses = geocoder.getFromLocation(center.latitude, center.longitude, 1);
-
-      if (addresses.isEmpty()) {
-        throw new AddressNotFoundException("No address found for area.");
-      }
-
-      Address address = addresses.get(0);
-
-      // TODO: Decide exactly what set of address parts we want to show the user.
-      Optional<String> country = Optional.ofNullable(address.getCountryName());
-      Optional<String> locality = Optional.ofNullable(address.getLocality());
-
-      return country
-          .map(
-              countryName ->
-                  locality.isPresent() ? countryName + ", " + locality.get() : countryName)
-          .orElse(defaultAreaName);
-
-    } catch (AddressNotFoundException | IOException e) {
-      Timber.e(e, "Couldn't get address for lat: %f, lng: %f", center.latitude, center.longitude);
-    }
-
-    return defaultAreaName;
+  public Single<String> getOfflineAreaName(LatLngBounds bounds) {
+    return Single.fromCallable(() -> getOfflineAreaNameInternal(bounds))
+        .doOnError(throwable -> Timber.e(throwable, "Couldn't get address for bounds: %s", bounds))
+        .subscribeOn(schedulers.io());
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/system/GeocodingManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/GeocodingManager.java
@@ -67,11 +67,14 @@ public class GeocodingManager {
 
       Address address = addresses.get(0);
 
-      return Optional.ofNullable(address.getFeatureName())
-          .or(() -> Optional.ofNullable(address.getLocality()))
-          .or(() -> Optional.ofNullable(address.getSubAdminArea()))
-          .or(() -> Optional.ofNullable(address.getAdminArea()))
-          .or(() -> Optional.ofNullable(address.getCountryName()))
+      // TODO: Decide exactly what set of address parts we want to show the user.
+      Optional<String> country = Optional.ofNullable(address.getCountryName());
+      Optional<String> locality = Optional.ofNullable(address.getLocality());
+
+      return country
+          .map(
+              countryName ->
+                  locality.isPresent() ? countryName + ", " + locality.get() : countryName)
           .orElse(defaultAreaName);
 
     } catch (AddressNotFoundException | IOException e) {

--- a/gnd/src/main/java/com/google/android/gnd/system/GeocodingManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/GeocodingManager.java
@@ -20,8 +20,8 @@ import android.content.Context;
 import android.location.Address;
 import android.location.Geocoder;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gnd.R;
-import com.google.android.gnd.model.basemap.OfflineArea;
 import dagger.hilt.android.qualifiers.ApplicationContext;
 import java.io.IOException;
 import java.util.List;
@@ -50,13 +50,13 @@ public class GeocodingManager {
   }
 
   /**
-   * Performs reverse geocoding on an {@link OfflineArea} to retrieve a human readable name for the
-   * region captured in the area's bounds.
+   * Performs reverse geocoding on {@param bounds} to retrieve a human readable name for the region
+   * captured in the bounds.
    *
    * <p>If no address is found for the given area, returns a default value.
    */
-  public String getOfflineAreaName(OfflineArea area) {
-    LatLng center = area.getBounds().getCenter();
+  public String getOfflineAreaName(LatLngBounds bounds) {
+    LatLng center = bounds.getCenter();
 
     try {
       List<Address> addresses = geocoder.getFromLocation(center.latitude, center.longitude, 1);
@@ -75,12 +75,7 @@ public class GeocodingManager {
           .orElse(defaultAreaName);
 
     } catch (AddressNotFoundException | IOException e) {
-      Timber.e(
-          e,
-          "Couldn't get address for area: %s, lat: %f, lng: %f",
-          area.getId(),
-          center.latitude,
-          center.longitude);
+      Timber.e(e, "Couldn't get address for lat: %f, lng: %f", center.latitude, center.longitude);
     }
 
     return defaultAreaName;

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
@@ -25,7 +25,6 @@ import com.google.android.gnd.databinding.OfflineAreasListItemBinding;
 import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter.ViewHolder> {
   private final Navigator navigator;

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreaListAdapter.java
@@ -29,25 +29,22 @@ import com.google.common.collect.ImmutableMap;
 
 class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter.ViewHolder> {
   private final Navigator navigator;
-  private ImmutableMap<String, OfflineArea> offlineAreas;
-  private ImmutableList<String> keys;
+  private ImmutableList<OfflineArea> offlineAreas;
 
   public static class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
     public OfflineAreasListItemBinding binding;
     public int position;
-    private ImmutableMap<String, OfflineArea> areas;
-    private ImmutableList<String> keys;
+    private ImmutableList<OfflineArea> areas;
     private final Navigator navigator;
 
     ViewHolder(
         OfflineAreasListItemBinding binding,
-        ImmutableMap<String, OfflineArea> areas,
+        ImmutableList<OfflineArea> areas,
         Navigator navigator) {
       super(binding.getRoot());
       this.binding = binding;
       this.areas = areas;
-      this.keys = areas.keySet().asList();
       this.navigator = navigator;
       binding.offlineAreaName.setOnClickListener(this);
     }
@@ -55,14 +52,14 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
     @Override
     public void onClick(View v) {
       if (areas.size() > 0) {
-        String id = areas.get(keys.get(position)).getId();
+        String id = areas.get(position).getId();
         navigator.showOfflineAreaViewer(id);
       }
     }
   }
 
   OfflineAreaListAdapter(Navigator navigator) {
-    offlineAreas = ImmutableMap.of();
+    offlineAreas = ImmutableList.of();
     this.navigator = navigator;
   }
 
@@ -79,7 +76,7 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
 
   @Override
   public void onBindViewHolder(@NonNull ViewHolder viewHolder, int position) {
-    viewHolder.binding.offlineAreaName.setText(keys.get(position));
+    viewHolder.binding.offlineAreaName.setText(offlineAreas.get(position).getName());
     viewHolder.position = position;
   }
 
@@ -88,9 +85,8 @@ class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter
     return offlineAreas.size();
   }
 
-  void update(ImmutableMap<String, OfflineArea> offlineAreas) {
+  void update(ImmutableList<OfflineArea> offlineAreas) {
     this.offlineAreas = offlineAreas;
-    this.keys = offlineAreas.keySet().asList();
     notifyDataSetChanged();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/OfflineAreasViewModel.java
@@ -16,17 +16,13 @@
 
 package com.google.android.gnd.ui.offlinearea;
 
-import static java8.util.stream.StreamSupport.stream;
-
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.repository.OfflineAreaRepository;
-import com.google.android.gnd.system.GeocodingManager;
 import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.android.gnd.ui.common.Navigator;
-import com.google.common.collect.ImmutableMap;
-import java8.util.stream.Collectors;
+import com.google.common.collect.ImmutableList;
 import javax.inject.Inject;
 
 /**
@@ -34,33 +30,21 @@ import javax.inject.Inject;
  */
 public class OfflineAreasViewModel extends AbstractViewModel {
 
-  private LiveData<ImmutableMap<String, OfflineArea>> offlineAreas;
+  private LiveData<ImmutableList<OfflineArea>> offlineAreas;
   private final Navigator navigator;
 
   @Inject
-  OfflineAreasViewModel(
-      Navigator navigator, OfflineAreaRepository offlineAreaRepository, GeocodingManager geocoder) {
+  OfflineAreasViewModel(Navigator navigator, OfflineAreaRepository offlineAreaRepository) {
     this.navigator = navigator;
     this.offlineAreas =
-        LiveDataReactiveStreams.fromPublisher(
-            offlineAreaRepository
-                .getOfflineAreasOnceAndStream()
-                .map(
-                    areas ->
-                        stream(areas)
-                            .collect(Collectors.toMap(geocoder::getOfflineAreaName, this::id)))
-                .map(ImmutableMap::copyOf));
+        LiveDataReactiveStreams.fromPublisher(offlineAreaRepository.getOfflineAreasOnceAndStream());
   }
 
   public void showOfflineAreaSelector() {
     navigator.showOfflineAreaSelector();
   }
 
-  private OfflineArea id(OfflineArea area) {
-    return area;
-  }
-
-  LiveData<ImmutableMap<String, OfflineArea>> getOfflineAreas() {
+  LiveData<ImmutableList<OfflineArea>> getOfflineAreas() {
     return offlineAreas;
   }
 }

--- a/gnd/src/test/java/com/google/android/gnd/persistence/local/LocalDataStoreTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/persistence/local/LocalDataStoreTest.java
@@ -178,6 +178,7 @@ public class LocalDataStoreTest {
           .setId("id_1")
           .setBounds(LatLngBounds.builder().include(new LatLng(0.0, 0.0)).build())
           .setState(OfflineArea.State.PENDING)
+          .setName("Test Area")
           .build();
 
   // This rule makes sure that Room executes all the database operations instantly.


### PR DESCRIPTION
The main motivation for this PR is to make our offline areas functionality truly offline, by persisting area names offline--before, we had run the geocoder (which requires a connection) on rendering area details. Instead, we now run it before storing an area, so that the name is saved.

I've also refactored the code accordingly, eliminating a duplicate map key bug in the areas list.