### PR TITLE
Rename Tile -> TileSource

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -27,7 +27,7 @@ public final class Config {
 
   // Local db settings.
   // TODO(#128): Reset version to 1 before releasing.
-  public static final int DB_VERSION = 58;
+  public static final int DB_VERSION = 60;
   public static final String DB_NAME = "gnd.db";
 
   // Firebase Cloud Firestore settings.

--- a/gnd/src/main/java/com/google/android/gnd/model/basemap/tile/TileSource.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/basemap/tile/TileSource.java
@@ -18,8 +18,9 @@ package com.google.android.gnd.model.basemap.tile;
 
 import com.google.auto.value.AutoValue;
 
+/** Represents a source of offline imagery tileset data. */
 @AutoValue
-public abstract class Tile {
+public abstract class TileSource {
 
   public enum State {
     PENDING,
@@ -37,16 +38,16 @@ public abstract class Tile {
   public abstract State getState();
 
   public static Builder newBuilder() {
-    return new AutoValue_Tile.Builder();
+    return new AutoValue_TileSource.Builder();
   }
 
-  public static String pathFromId(String tileId) {
+  public static String pathFromId(String tileSourceId) {
     // Tile ids are stored as x-y-z. Paths must be z-x-y.mbtiles.
     // TODO: Convert tile ids to paths in a less restrictive and less hacky manner.
     // TODO: Move this method to a more appropriate home? We need to perform (and possibly will no
     // matter where the tiles are stored) translation between the tile ID and the file path of the
     // corresponding tile source in remote storage/wherever we pull the source tile from.
-    String[] fields = tileId.replaceAll("[()]", "").split(", ");
+    String[] fields = tileSourceId.replaceAll("[()]", "").split(", ");
     String filename = fields[2] + "-" + fields[0] + "-" + fields[1];
 
     return filename + ".mbtiles";
@@ -64,6 +65,6 @@ public abstract class Tile {
 
     public abstract Builder setState(State state);
 
-    public abstract Tile build();
+    public abstract TileSource build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonParser.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/geojson/GeoJsonParser.java
@@ -21,8 +21,8 @@ import static java8.util.stream.StreamSupport.stream;
 
 import android.util.Log;
 import com.google.android.gms.maps.model.LatLngBounds;
-import com.google.android.gnd.model.basemap.tile.Tile;
-import com.google.android.gnd.model.basemap.tile.Tile.State;
+import com.google.android.gnd.model.basemap.tile.TileSource;
+import com.google.android.gnd.model.basemap.tile.TileSource.State;
 import com.google.android.gnd.persistence.uuid.OfflineUuidGenerator;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -52,7 +52,7 @@ public class GeoJsonParser {
    * Returns the immutable list of tiles specified in {@param geojson} that intersect {@param
    * bounds}.
    */
-  public ImmutableList<Tile> intersectingTiles(LatLngBounds bounds, File file) {
+  public ImmutableList<TileSource> intersectingTiles(LatLngBounds bounds, File file) {
     try {
       String fileContents = FileUtils.readFileToString(file, Charset.forName(JSON_SOURCE_CHARSET));
       // TODO: Separate parsing and intersection checks, make asyc (single, completable).
@@ -63,7 +63,7 @@ public class GeoJsonParser {
       return stream(toArrayList(features))
           .map(GeoJsonTile::new)
           .filter(tile -> tile.boundsIntersect(bounds))
-          .map(this::jsonToTile)
+          .map(this::jsonToTileSource)
           .collect(toImmutableList());
 
     } catch (JSONException | IOException e) {
@@ -91,15 +91,15 @@ public class GeoJsonParser {
     return result;
   }
 
-  /** Returns the {@link Tile} specified by {@param json}. */
-  private Tile jsonToTile(GeoJsonTile json) {
+  /** Returns the {@link TileSource} specified by {@param json}. */
+  private TileSource jsonToTileSource(GeoJsonTile json) {
     // TODO: Instead of returning tiles with invalid state (empty URL/ID values)
     // Throw an exception here and handle it downstream.
-    return Tile.newBuilder()
+    return TileSource.newBuilder()
         .setId(uuidGenerator.generateUuid())
         .setUrl(json.getUrl().orElse(""))
         .setState(State.PENDING)
-        .setPath(Tile.pathFromId(json.getId().orElse("")))
+        .setPath(TileSource.pathFromId(json.getId().orElse("")))
         .build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -20,7 +20,7 @@ import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.User;
 import com.google.android.gnd.model.basemap.OfflineArea;
-import com.google.android.gnd.model.basemap.tile.Tile;
+import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.FeatureMutation;
 import com.google.android.gnd.model.observation.Observation;
@@ -106,7 +106,7 @@ public interface LocalDataStore {
    * Returns a long-lived stream that emits the full set of tiles on subscribe and continues to
    * return the full set each time a tile is added/changed/removed.
    */
-  Flowable<ImmutableSet<Tile>> getTilesOnceAndStream();
+  Flowable<ImmutableSet<TileSource>> getTileSourcesOnceAndStream();
 
   /**
    * Returns all feature and observation mutations in the local mutation queue relating to feature
@@ -147,13 +147,13 @@ public interface LocalDataStore {
    * Attempts to update a tile in the local data store. If the tile doesn't exist, inserts the tile
    * into the local data store.
    */
-  Completable insertOrUpdateTile(Tile tile);
+  Completable insertOrUpdateTileSource(TileSource tileSource);
 
   /** Returns the tile with the specified id from the local data store, if found. */
-  Maybe<Tile> getTile(String tileId);
+  Maybe<TileSource> getTileSource(String tileId);
 
   /** Returns all pending tiles from the local data store. */
-  Single<ImmutableList<Tile>> getPendingTiles();
+  Single<ImmutableList<TileSource>> getPendingTileSources();
 
   /**
    * Attempts to update an offline area in the local data store. If the area doesn't exist, inserts

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStoreModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStoreModule.java
@@ -30,7 +30,7 @@ import com.google.android.gnd.persistence.local.room.dao.OfflineAreaDao;
 import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.OptionDao;
 import com.google.android.gnd.persistence.local.room.dao.ProjectDao;
-import com.google.android.gnd.persistence.local.room.dao.TileDao;
+import com.google.android.gnd.persistence.local.room.dao.TileSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.UserDao;
 import dagger.Binds;
 import dagger.Module;
@@ -94,8 +94,8 @@ public abstract class LocalDataStoreModule {
   }
 
   @Provides
-  static TileDao tileDao(LocalDatabase localDatabase) {
-    return localDatabase.tileDao();
+  static TileSourceDao tileSourceDao(LocalDatabase localDatabase) {
+    return localDatabase.tileSourceDao();
   }
 
   @Provides

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
@@ -35,7 +35,7 @@ import com.google.android.gnd.persistence.local.room.dao.OfflineAreaDao;
 import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.OptionDao;
 import com.google.android.gnd.persistence.local.room.dao.ProjectDao;
-import com.google.android.gnd.persistence.local.room.dao.TileDao;
+import com.google.android.gnd.persistence.local.room.dao.TileSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.UserDao;
 import com.google.android.gnd.persistence.local.room.entity.FeatureEntity;
 import com.google.android.gnd.persistence.local.room.entity.FeatureMutationEntity;
@@ -49,7 +49,7 @@ import com.google.android.gnd.persistence.local.room.entity.OfflineAreaEntity;
 import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapSourceEntity;
 import com.google.android.gnd.persistence.local.room.entity.OptionEntity;
 import com.google.android.gnd.persistence.local.room.entity.ProjectEntity;
-import com.google.android.gnd.persistence.local.room.entity.TileEntity;
+import com.google.android.gnd.persistence.local.room.entity.TileSourceEntity;
 import com.google.android.gnd.persistence.local.room.entity.UserEntity;
 import com.google.android.gnd.persistence.local.room.models.ElementEntityType;
 import com.google.android.gnd.persistence.local.room.models.EntityState;
@@ -79,7 +79,7 @@ import com.google.android.gnd.persistence.local.room.models.TileEntityState;
       OfflineBaseMapSourceEntity.class,
       ObservationEntity.class,
       ObservationMutationEntity.class,
-      TileEntity.class,
+      TileSourceEntity.class,
       OfflineAreaEntity.class,
       UserEntity.class
     },
@@ -121,7 +121,7 @@ public abstract class LocalDatabase extends RoomDatabase {
 
   public abstract ObservationMutationDao observationMutationDao();
 
-  public abstract TileDao tileDao();
+  public abstract TileSourceDao tileSourceDao();
 
   public abstract OfflineAreaDao offlineAreaDao();
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -27,7 +27,7 @@ import com.google.android.gnd.model.Mutation.Type;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.User;
 import com.google.android.gnd.model.basemap.OfflineArea;
-import com.google.android.gnd.model.basemap.tile.Tile;
+import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.FeatureMutation;
 import com.google.android.gnd.model.form.Element;
@@ -51,7 +51,7 @@ import com.google.android.gnd.persistence.local.room.dao.OfflineAreaDao;
 import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.OptionDao;
 import com.google.android.gnd.persistence.local.room.dao.ProjectDao;
-import com.google.android.gnd.persistence.local.room.dao.TileDao;
+import com.google.android.gnd.persistence.local.room.dao.TileSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.UserDao;
 import com.google.android.gnd.persistence.local.room.entity.AuditInfoEntity;
 import com.google.android.gnd.persistence.local.room.entity.FeatureEntity;
@@ -66,7 +66,7 @@ import com.google.android.gnd.persistence.local.room.entity.OfflineAreaEntity;
 import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapSourceEntity;
 import com.google.android.gnd.persistence.local.room.entity.OptionEntity;
 import com.google.android.gnd.persistence.local.room.entity.ProjectEntity;
-import com.google.android.gnd.persistence.local.room.entity.TileEntity;
+import com.google.android.gnd.persistence.local.room.entity.TileSourceEntity;
 import com.google.android.gnd.persistence.local.room.entity.UserEntity;
 import com.google.android.gnd.persistence.local.room.models.EntityState;
 import com.google.android.gnd.persistence.local.room.models.TileEntityState;
@@ -105,7 +105,7 @@ public class RoomLocalDataStore implements LocalDataStore {
   @Inject FeatureMutationDao featureMutationDao;
   @Inject ObservationDao observationDao;
   @Inject ObservationMutationDao observationMutationDao;
-  @Inject TileDao tileDao;
+  @Inject TileSourceDao tileSourceDao;
   @Inject UserDao userDao;
   @Inject OfflineAreaDao offlineAreaDao;
   @Inject OfflineBaseMapSourceDao offlineBaseMapSourceDao;
@@ -283,10 +283,10 @@ public class RoomLocalDataStore implements LocalDataStore {
   }
 
   @Override
-  public Flowable<ImmutableSet<Tile>> getTilesOnceAndStream() {
-    return tileDao
+  public Flowable<ImmutableSet<TileSource>> getTileSourcesOnceAndStream() {
+    return tileSourceDao
         .findAllOnceAndStream()
-        .map(list -> stream(list).map(TileEntity::toTile).collect(toImmutableSet()))
+        .map(list -> stream(list).map(TileSourceEntity::toTileSource).collect(toImmutableSet()))
         .subscribeOn(schedulers.io());
   }
 
@@ -538,20 +538,25 @@ public class RoomLocalDataStore implements LocalDataStore {
   }
 
   @Override
-  public Completable insertOrUpdateTile(Tile tile) {
-    return tileDao.insertOrUpdate(TileEntity.fromTile(tile)).subscribeOn(schedulers.io());
+  public Completable insertOrUpdateTileSource(TileSource tileSource) {
+    return tileSourceDao
+        .insertOrUpdate(TileSourceEntity.fromTile(tileSource))
+        .subscribeOn(schedulers.io());
   }
 
   @Override
-  public Maybe<Tile> getTile(String tileId) {
-    return tileDao.findById(tileId).map(TileEntity::toTile).subscribeOn(schedulers.io());
+  public Maybe<TileSource> getTileSource(String tileId) {
+    return tileSourceDao
+        .findById(tileId)
+        .map(TileSourceEntity::toTileSource)
+        .subscribeOn(schedulers.io());
   }
 
   @Override
-  public Single<ImmutableList<Tile>> getPendingTiles() {
-    return tileDao
+  public Single<ImmutableList<TileSource>> getPendingTileSources() {
+    return tileSourceDao
         .findByState(TileEntityState.PENDING.intValue())
-        .map(ts -> stream(ts).map(TileEntity::toTile).collect(toImmutableList()))
+        .map(ts -> stream(ts).map(TileSourceEntity::toTileSource).collect(toImmutableList()))
         .subscribeOn(schedulers.io());
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/TileSourceDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/TileSourceDao.java
@@ -18,24 +18,24 @@ package com.google.android.gnd.persistence.local.room.dao;
 
 import androidx.room.Dao;
 import androidx.room.Query;
-import com.google.android.gnd.persistence.local.room.entity.TileEntity;
+import com.google.android.gnd.persistence.local.room.entity.TileSourceEntity;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 import java.util.List;
 
 @Dao
-public interface TileDao extends BaseDao<TileEntity> {
+public interface TileSourceDao extends BaseDao<TileSourceEntity> {
 
-  @Query("SELECT * FROM tile")
-  Flowable<List<TileEntity>> findAllOnceAndStream();
+  @Query("SELECT * FROM tile_sources")
+  Flowable<List<TileSourceEntity>> findAllOnceAndStream();
 
-  @Query("SELECT * FROM tile WHERE state = :state")
-  Single<List<TileEntity>> findByState(int state);
+  @Query("SELECT * FROM tile_sources WHERE state = :state")
+  Single<List<TileSourceEntity>> findByState(int state);
 
-  @Query("SELECT * FROM tile WHERE id = :id")
-  Maybe<TileEntity> findById(String id);
+  @Query("SELECT * FROM tile_sources WHERE id = :id")
+  Maybe<TileSourceEntity> findById(String id);
 
-  @Query("SELECT * FROM tile WHERE path = :path")
-  Maybe<TileEntity> findByPath(String path);
+  @Query("SELECT * FROM tile_sources WHERE path = :path")
+  Maybe<TileSourceEntity> findByPath(String path);
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/TileSourceEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/TileSourceEntity.java
@@ -20,14 +20,14 @@ import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
-import com.google.android.gnd.model.basemap.tile.Tile;
+import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.persistence.local.room.models.TileEntityState;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.AutoValue.CopyAnnotations;
 
 @AutoValue
-@Entity(tableName = "tile")
-public abstract class TileEntity {
+@Entity(tableName = "tile_sources")
+public abstract class TileSourceEntity {
   @CopyAnnotations
   @NonNull
   @PrimaryKey
@@ -49,42 +49,42 @@ public abstract class TileEntity {
   @ColumnInfo(name = "state")
   public abstract TileEntityState getState();
 
-  public static Tile toTile(TileEntity tileEntity) {
-    Tile.Builder tile =
-        Tile.newBuilder()
-            .setId(tileEntity.getId())
-            .setPath(tileEntity.getPath())
-            .setState(toTileState(tileEntity.getState()))
-            .setUrl(tileEntity.getUrl());
+  public static TileSource toTileSource(TileSourceEntity tileSourceEntity) {
+    TileSource.Builder tile =
+        TileSource.newBuilder()
+            .setId(tileSourceEntity.getId())
+            .setPath(tileSourceEntity.getPath())
+            .setState(toTileState(tileSourceEntity.getState()))
+            .setUrl(tileSourceEntity.getUrl());
     return tile.build();
   }
 
-  private static Tile.State toTileState(TileEntityState state) {
+  private static TileSource.State toTileState(TileEntityState state) {
     switch (state) {
       case PENDING:
-        return Tile.State.PENDING;
+        return TileSource.State.PENDING;
       case IN_PROGRESS:
-        return Tile.State.IN_PROGRESS;
+        return TileSource.State.IN_PROGRESS;
       case DOWNLOADED:
-        return Tile.State.DOWNLOADED;
+        return TileSource.State.DOWNLOADED;
       case FAILED:
-        return Tile.State.FAILED;
+        return TileSource.State.FAILED;
       default:
-        throw new IllegalArgumentException("Unknown tile state: " + state);
+        throw new IllegalArgumentException("Unknown tile source state: " + state);
     }
   }
 
-  public static TileEntity fromTile(Tile tile) {
-    TileEntity.Builder entity =
-        TileEntity.builder()
-            .setId(tile.getId())
-            .setPath(tile.getPath())
-            .setState(toEntityState(tile.getState()))
-            .setUrl(tile.getUrl());
+  public static TileSourceEntity fromTile(TileSource tileSource) {
+    TileSourceEntity.Builder entity =
+        TileSourceEntity.builder()
+            .setId(tileSource.getId())
+            .setPath(tileSource.getPath())
+            .setState(toEntityState(tileSource.getState()))
+            .setUrl(tileSource.getUrl());
     return entity.build();
   }
 
-  private static TileEntityState toEntityState(Tile.State state) {
+  private static TileEntityState toEntityState(TileSource.State state) {
     switch (state) {
       case PENDING:
         return TileEntityState.PENDING;
@@ -99,12 +99,12 @@ public abstract class TileEntity {
     }
   }
 
-  public static TileEntity create(String id, String path, TileEntityState state, String url) {
+  public static TileSourceEntity create(String id, String path, TileEntityState state, String url) {
     return builder().setId(id).setState(state).setPath(path).setUrl(url).build();
   }
 
   public static Builder builder() {
-    return new AutoValue_TileEntity.Builder();
+    return new AutoValue_TileSourceEntity.Builder();
   }
 
   @AutoValue.Builder
@@ -117,6 +117,6 @@ public abstract class TileEntity {
 
     public abstract Builder setState(TileEntityState newState);
 
-    public abstract TileEntity build();
+    public abstract TileSourceEntity build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/sync/TileSourceDownloadWorkManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/sync/TileSourceDownloadWorkManager.java
@@ -24,20 +24,20 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 /** Enqueues file download work to be done in the background. */
-public class TileDownloadWorkManager extends BaseWorkManager {
+public class TileSourceDownloadWorkManager extends BaseWorkManager {
 
   private final LocalValueStore localValueStore;
 
   @Inject
-  public TileDownloadWorkManager(
+  public TileSourceDownloadWorkManager(
       Provider<WorkManager> workManagerProvider, LocalValueStore localValueStore) {
     super(workManagerProvider);
     this.localValueStore = localValueStore;
   }
 
   @Override
-  Class<TileDownloadWorker> getWorkerClass() {
-    return TileDownloadWorker.class;
+  Class<TileSourceDownloadWorker> getWorkerClass() {
+    return TileSourceDownloadWorker.class;
   }
 
   @Override
@@ -51,11 +51,11 @@ public class TileDownloadWorkManager extends BaseWorkManager {
    * Enqueues a worker that downloads files when a network connection is available, returning a
    * completable upon enqueueing.
    */
-  public Completable enqueueTileDownloadWorker() {
-    return Completable.fromRunnable(this::enqueueTileDownloadWorkerInternal);
+  public Completable enqueueTileSourceDownloadWorker() {
+    return Completable.fromRunnable(this::enqueueTileSourceDownloadWorkerInternal);
   }
 
-  private void enqueueTileDownloadWorkerInternal() {
+  private void enqueueTileSourceDownloadWorkerInternal() {
     getWorkManager().enqueue(buildWorkerRequest());
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
@@ -24,7 +24,7 @@ import androidx.lifecycle.LiveDataReactiveStreams;
 import androidx.lifecycle.MutableLiveData;
 import com.cocoahero.android.gmaps.addons.mapbox.MapBoxOfflineTileProvider;
 import com.google.android.gnd.model.Project;
-import com.google.android.gnd.model.basemap.tile.Tile;
+import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.repository.FeatureRepository;
@@ -105,8 +105,8 @@ public class MapContainerViewModel extends AbstractViewModel {
     this.mbtilesFilePaths =
         LiveDataReactiveStreams.fromPublisher(
             offlineAreaRepository
-                .getDownloadedTilesOnceAndStream()
-                .map(set -> stream(set).map(Tile::getPath).collect(toImmutableSet())));
+                .getDownloadedTileSourcesOnceAndStream()
+                .map(set -> stream(set).map(TileSource::getPath).collect(toImmutableSet())));
   }
 
   private Flowable<CameraUpdate> createCameraUpdateFlowable(

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinearea/viewer/OfflineAreaViewerViewModel.java
@@ -22,7 +22,7 @@ import android.content.Context;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import com.google.android.gnd.model.basemap.OfflineArea;
-import com.google.android.gnd.model.basemap.tile.Tile;
+import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.repository.OfflineAreaRepository;
 import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.common.collect.ImmutableSet;
@@ -57,8 +57,10 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
                     this.offlineAreaRepository
                         .getOfflineArea(args.getOfflineAreaId())
                         .toFlowable()
-                        .flatMap(offlineAreaRepository::getIntersectingDownloadedTilesOnceAndStream)
-                        .map(this::tilesToTotalStorageSize)));
+                        .flatMap(
+                            offlineAreaRepository
+                                ::getIntersectingDownloadedTileSourcesOnceAndStream)
+                        .map(this::tileSourcesToTotalStorageSize)));
     this.offlineArea =
         LiveDataReactiveStreams.fromPublisher(
             this.argsProcessor.switchMap(
@@ -68,16 +70,16 @@ public class OfflineAreaViewerViewModel extends AbstractViewModel {
                         .toFlowable()));
   }
 
-  private Double tilesToTotalStorageSize(ImmutableSet<Tile> tiles) {
-    return stream(tiles).map(this::tileStorageSize).reduce((x, y) -> x + y).orElse(0.0);
+  private Double tileSourcesToTotalStorageSize(ImmutableSet<TileSource> tileSources) {
+    return stream(tileSources).map(this::tileSourceStorageSize).reduce((x, y) -> x + y).orElse(0.0);
   }
 
-  private double tileStorageSize(Tile tile) {
+  private double tileSourceStorageSize(TileSource tileSource) {
     Context context1 = context.get();
     if (context1 == null) {
       return 0.0;
     } else {
-      File tileFile = new File(context1.getFilesDir(), tile.getPath());
+      File tileFile = new File(context1.getFilesDir(), tileSource.getPath());
       return (double) tileFile.length() / (1024 * 1024);
     }
   }

--- a/gnd/src/main/res/values/strings.xml
+++ b/gnd/src/main/res/values/strings.xml
@@ -147,7 +147,7 @@
   <string name="in_progress">In progress</string>
   <string name="uploading_photos">Uploading photos</string>
   <string name="starting">Starting</string>
-  <string name="downloading_tiles">Downloading tiles</string>
+  <string name="downloading_tiles">Downloading tile sources</string>
   <string name="uploading_data">Uploading data</string>
   <string name="app_running">App is running</string>
   <string name="settings">Settings</string>

--- a/gnd/src/test/java/com/google/android/gnd/persistence/local/LocalDataStoreTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/persistence/local/LocalDataStoreTest.java
@@ -26,8 +26,8 @@ import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.User;
 import com.google.android.gnd.model.basemap.OfflineArea;
-import com.google.android.gnd.model.basemap.tile.Tile;
-import com.google.android.gnd.model.basemap.tile.Tile.State;
+import com.google.android.gnd.model.basemap.tile.TileSource;
+import com.google.android.gnd.model.basemap.tile.TileSource.State;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.FeatureMutation;
 import com.google.android.gnd.model.feature.Point;
@@ -150,24 +150,24 @@ public class LocalDataStoreTest {
           .setClientTimestamp(new Date())
           .build();
 
-  private static final Tile TEST_PENDING_TILE =
-      Tile.newBuilder()
+  private static final TileSource TEST_PENDING_TILE_SOURCE =
+      TileSource.newBuilder()
           .setId("id_1")
           .setState(State.PENDING)
           .setPath("some_path 1")
           .setUrl("some_url 1")
           .build();
 
-  private static final Tile TEST_DOWNLOADED_TILE =
-      Tile.newBuilder()
+  private static final TileSource TEST_DOWNLOADED_TILE_SOURCE =
+      TileSource.newBuilder()
           .setId("id_2")
           .setState(State.DOWNLOADED)
           .setPath("some_path 2")
           .setUrl("some_url 2")
           .build();
 
-  private static final Tile TEST_FAILED_TILE =
-      Tile.newBuilder()
+  private static final TileSource TEST_FAILED_TILE_SOURCE =
+      TileSource.newBuilder()
           .setId("id_3")
           .setState(State.FAILED)
           .setPath("some_path 3")
@@ -520,37 +520,45 @@ public class LocalDataStoreTest {
 
   @Test
   public void testInsertTile() {
-    localDataStore.insertOrUpdateTile(TEST_PENDING_TILE).test().assertComplete();
+    localDataStore.insertOrUpdateTileSource(TEST_PENDING_TILE_SOURCE).test().assertComplete();
   }
 
   @Test
   public void testGetTile() {
-    localDataStore.insertOrUpdateTile(TEST_PENDING_TILE).blockingAwait();
-    localDataStore.getTile("id_1").test().assertValueCount(1).assertValue(TEST_PENDING_TILE);
+    localDataStore.insertOrUpdateTileSource(TEST_PENDING_TILE_SOURCE).blockingAwait();
+    localDataStore
+        .getTileSource("id_1")
+        .test()
+        .assertValueCount(1)
+        .assertValue(TEST_PENDING_TILE_SOURCE);
   }
 
   @Test
   public void testGetTilesOnceAndStream() {
-    TestSubscriber<ImmutableSet<Tile>> subscriber = localDataStore.getTilesOnceAndStream().test();
+    TestSubscriber<ImmutableSet<TileSource>> subscriber =
+        localDataStore.getTileSourcesOnceAndStream().test();
 
     subscriber.assertValue(ImmutableSet.of());
 
-    localDataStore.insertOrUpdateTile(TEST_DOWNLOADED_TILE).blockingAwait();
-    localDataStore.insertOrUpdateTile(TEST_PENDING_TILE).blockingAwait();
+    localDataStore.insertOrUpdateTileSource(TEST_DOWNLOADED_TILE_SOURCE).blockingAwait();
+    localDataStore.insertOrUpdateTileSource(TEST_PENDING_TILE_SOURCE).blockingAwait();
 
     subscriber.assertValueSet(
         ImmutableSet.of(
             ImmutableSet.of(),
-            ImmutableSet.of(TEST_DOWNLOADED_TILE),
-            ImmutableSet.of(TEST_DOWNLOADED_TILE, TEST_PENDING_TILE)));
+            ImmutableSet.of(TEST_DOWNLOADED_TILE_SOURCE),
+            ImmutableSet.of(TEST_DOWNLOADED_TILE_SOURCE, TEST_PENDING_TILE_SOURCE)));
   }
 
   @Test
   public void testGetPendingTile() {
-    localDataStore.insertOrUpdateTile(TEST_DOWNLOADED_TILE).blockingAwait();
-    localDataStore.insertOrUpdateTile(TEST_FAILED_TILE).blockingAwait();
-    localDataStore.insertOrUpdateTile(TEST_PENDING_TILE).blockingAwait();
-    localDataStore.getPendingTiles().test().assertValue(ImmutableList.of(TEST_PENDING_TILE));
+    localDataStore.insertOrUpdateTileSource(TEST_DOWNLOADED_TILE_SOURCE).blockingAwait();
+    localDataStore.insertOrUpdateTileSource(TEST_FAILED_TILE_SOURCE).blockingAwait();
+    localDataStore.insertOrUpdateTileSource(TEST_PENDING_TILE_SOURCE).blockingAwait();
+    localDataStore
+        .getPendingTileSources()
+        .test()
+        .assertValue(ImmutableList.of(TEST_PENDING_TILE_SOURCE));
   }
 
   @Test


### PR DESCRIPTION
TileSource better captures what this object represents--some URL and eventually file path that points to a file that contains tileset data that we can render on the map as an overlay. The old name, Tile, suggests that the object represents a single tile, at a single zoom level, while the tileset files we use actually are pyramidal and contain tiles at multiple zoom levels.

@gino-m @shobhitagarwal1612 

Fixes #400. 