### PR TITLE
[Code health] Use Objects instead of Optional to resolve null values to defaults

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/FeatureConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/FeatureConverter.java
@@ -29,7 +29,7 @@ import com.google.android.gnd.persistence.remote.DataStoreException;
 import com.google.common.base.Strings;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.GeoPoint;
-import java8.util.Optional;
+import java8.util.Objects;
 
 /** Converts between Firestore documents and {@link Feature} instances. */
 public class FeatureConverter {
@@ -49,8 +49,8 @@ public class FeatureConverter {
     String geoJsonString = Strings.isNullOrEmpty(f.getGeoJson()) ? null : f.getGeoJson();
     // Degrade gracefully when audit info missing in remote db.
     AuditInfoNestedObject created =
-        Optional.ofNullable(f.getCreated()).orElse(AuditInfoNestedObject.FALLBACK_VALUE);
-    AuditInfoNestedObject lastModified = Optional.ofNullable(f.getLastModified()).orElse(created);
+        Objects.requireNonNullElse(f.getCreated(), AuditInfoNestedObject.FALLBACK_VALUE);
+    AuditInfoNestedObject lastModified = Objects.requireNonNullElse(f.getLastModified(), created);
     return Feature.newBuilder()
         .setId(doc.getId())
         .setProject(project)

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/FieldConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/FieldConverter.java
@@ -21,6 +21,7 @@ import static com.google.android.gnd.util.Localization.getLocalizedMessage;
 
 import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.form.Field.Type;
+import java8.util.Objects;
 import java8.util.Optional;
 
 /** Converts between Firestore nested objects and {@link Field} instances. */
@@ -45,7 +46,7 @@ class FieldConverter {
     field.setRequired(em.getRequired() != null && em.getRequired());
     field.setId(id);
     // Default index to -1 to degrade gracefully on older dev db instances and projects.
-    field.setIndex(Optional.ofNullable(em.getIndex()).orElse(-1));
+    field.setIndex(Objects.requireNonNullElse(em.getIndex(), -1));
     field.setLabel(getLocalizedMessage(em.getLabel()));
     return Optional.of(field.build());
   }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/FormConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/FormConverter.java
@@ -19,13 +19,10 @@ package com.google.android.gnd.persistence.remote.firestore.schema;
 import static com.google.android.gnd.util.ImmutableListCollector.toImmutableList;
 import static java8.util.stream.StreamSupport.stream;
 
-import androidx.annotation.Nullable;
 import com.google.android.gnd.model.form.Element;
 import com.google.android.gnd.model.form.Form;
 import com.google.common.collect.ImmutableList;
-import java.util.Collections;
 import java.util.Map;
-import java8.util.Optional;
 
 /** Converts between Firestore nested objects and {@link Form} instances. */
 class FormConverter {
@@ -34,9 +31,8 @@ class FormConverter {
     return Form.newBuilder().setId(formId).setElements(toList(obj.getElements())).build();
   }
 
-  private static ImmutableList<Element> toList(
-      @Nullable Map<String, ElementNestedObject> elements) {
-    return stream(Optional.ofNullable(elements).map(Map::entrySet).orElse(Collections.emptySet()))
+  private static ImmutableList<Element> toList(Map<String, ElementNestedObject> elements) {
+    return stream(elements.entrySet())
         .map(e -> ElementConverter.toElement(e.getKey(), e.getValue()))
         .collect(toImmutableList());
   }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/FormNestedObject.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/FormNestedObject.java
@@ -18,7 +18,9 @@ package com.google.android.gnd.persistence.remote.firestore.schema;
 
 import androidx.annotation.Nullable;
 import com.google.firebase.firestore.IgnoreExtraProperties;
+import java.util.Collections;
 import java.util.Map;
+import java8.util.Objects;
 
 /** Firestore representation of form definitions. */
 @IgnoreExtraProperties
@@ -33,8 +35,7 @@ class FormNestedObject {
     this.elements = elements;
   }
 
-  @Nullable
   public Map<String, ElementNestedObject> getElements() {
-    return elements;
+    return Objects.requireNonNullElse(elements, Collections.emptyMap());
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
@@ -21,6 +21,7 @@ import static com.google.android.gnd.util.Localization.getLocalizedMessage;
 import android.util.Log;
 import com.google.android.gnd.model.layer.Layer;
 import com.google.android.gnd.model.layer.Style;
+import java8.util.Objects;
 import java8.util.Optional;
 
 /** Converts between Firestore documents and {@link Layer} instances. */
@@ -54,7 +55,7 @@ class LayerConverter {
     // TODO(https://github.com/google/ground-platform/issues/402): Remove fallback once updated in
     // web client.
     return Style.builder()
-        .setColor(Optional.ofNullable(obj.getColor()).orElse(FALLBACK_COLOR))
+        .setColor(Objects.requireNonNullElse(obj.getColor(), FALLBACK_COLOR))
         .build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
@@ -30,7 +30,7 @@ import com.google.android.gnd.persistence.remote.DataStoreException;
 import com.google.firebase.firestore.DocumentSnapshot;
 import java.util.List;
 import java.util.Map;
-import java8.util.Optional;
+import java8.util.Objects;
 import javax.annotation.Nullable;
 
 /** Converts between Firestore documents and {@link Observation} instances. */
@@ -49,8 +49,8 @@ class ObservationConverter {
     Form form = checkNotEmpty(feature.getLayer().getForm(formId), "form");
     // Degrade gracefully when audit info missing in remote db.
     AuditInfoNestedObject created =
-        Optional.ofNullable(doc.getCreated()).orElse(AuditInfoNestedObject.FALLBACK_VALUE);
-    AuditInfoNestedObject lastModified = Optional.ofNullable(doc.getLastModified()).orElse(created);
+        Objects.requireNonNullElse(doc.getCreated(), AuditInfoNestedObject.FALLBACK_VALUE);
+    AuditInfoNestedObject lastModified = Objects.requireNonNullElse(doc.getLastModified(), created);
     return Observation.newBuilder()
         .setId(snapshot.getId())
         .setProject(feature.getProject())

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/AddFeatureDialogFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/AddFeatureDialogFragment.java
@@ -84,7 +84,7 @@ public class AddFeatureDialogFragment extends AbstractDialogFragment {
           Objects.requireNonNull(
               mapContainerViewModel.getCameraPosition().getValue(), "No camera position");
       return createDialog(activeProject, cameraPosition);
-    } catch (NullPointerException e) {
+    } catch (RuntimeException e) {
       addFeatureRequestSubject.onError(e);
       return fail(Objects.requireNonNullElse(e.getMessage(), "Unknown error"));
     }


### PR DESCRIPTION
This is preferred since it doesn't unnecessarily create an extra Optional, and doesn't introduce another concept (Optionals) in code where they aren't used. Split off of #639.

@shobhitagarwal1612 PTAL?

@dturner @scolsen FYI.