### PR TITLE
[Add observation] Display bottom sheet instead on adding a new feature

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenFragment.java
@@ -48,7 +48,6 @@ import com.google.android.gnd.databinding.HomeScreenFragBinding;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.Point;
-import com.google.android.gnd.model.form.Form;
 import com.google.android.gnd.rx.Loadable;
 import com.google.android.gnd.rx.Schedulers;
 import com.google.android.gnd.system.auth.AuthenticationManager;
@@ -123,14 +122,7 @@ public class HomeScreenFragment extends AbstractFragment
   }
 
   private void onFeatureAdded(Feature feature) {
-    feature.getLayer().getForm().ifPresent(form -> addNewObservation(feature, form));
-  }
-
-  private void addNewObservation(Feature feature, Form form) {
-    String projectId = feature.getProject().getId();
-    String featureId = feature.getId();
-    String formId = form.getId();
-    navigator.navigate(HomeScreenFragmentDirections.addObservation(projectId, featureId, formId));
+    viewModel.showBottomSheet(feature);
   }
 
   /** This is only possible after updating the location of the feature. So, reset the UI. */

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -199,7 +199,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
     showBottomSheet(marker.getFeature());
   }
 
-  private void showBottomSheet(Feature feature) {
+  public void showBottomSheet(Feature feature) {
     Timber.d("showing bottom sheet");
     isObservationButtonVisible.setValue(true);
     bottomSheetState.setValue(BottomSheetState.visible(feature));


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #694, Fixes #695

<!-- PR description. -->
Instead of redirecting to a new observation, open the bottom sheet fragment.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->
Verified by following the steps mentioned in the bug.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m PTAL?
