### PR TITLE
[Code health] Use form definition when deserializing observations from remote db

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/model/TestModelBuilders.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/TestModelBuilders.java
@@ -29,40 +29,40 @@ import java.util.Date;
  * specific values should explicitly set them in relevant test methods or during test setup.
  */
 public class TestModelBuilders {
-  public static Project.Builder newTestProject() {
+  public static Project.Builder newProject() {
     return Project.newBuilder().setId("").setTitle("").setDescription("");
   }
 
-  public static User.Builder newTestUser() {
+  public static User.Builder newUser() {
     return User.builder().setId("").setEmail("").setDisplayName("");
   }
 
-  public static AuditInfo.Builder newTestAuditInfo() {
-    return AuditInfo.builder().setClientTimestamp(new Date(0)).setUser(newTestUser().build());
+  public static AuditInfo.Builder newAuditInfo() {
+    return AuditInfo.builder().setClientTimestamp(new Date(0)).setUser(newUser().build());
   }
 
-  public static Point.Builder newTestPoint() {
+  public static Point.Builder newPoint() {
     return Point.newBuilder().setLatitude(0).setLongitude(0);
   }
 
-  public static Feature.Builder newTestFeature() {
+  public static Feature.Builder newFeature() {
     return Feature.newBuilder()
         .setId("")
-        .setProject(newTestProject().build())
-        .setPoint(newTestPoint().build())
-        .setCreated(newTestAuditInfo().build())
-        .setLastModified(newTestAuditInfo().build());
+        .setProject(newProject().build())
+        .setPoint(newPoint().build())
+        .setCreated(newAuditInfo().build())
+        .setLastModified(newAuditInfo().build());
   }
 
-  public static Layer.Builder newTestLayer() {
-    return Layer.newBuilder().setId("").setName("").setDefaultStyle(newTestStyle().build());
+  public static Layer.Builder newLayer() {
+    return Layer.newBuilder().setId("").setName("").setDefaultStyle(newStyle().build());
   }
 
-  public static Style.Builder newTestStyle() {
+  public static Style.Builder newStyle() {
     return Style.builder().setColor("");
   }
 
-  public static Form.Builder newTestForm() {
+  public static Form.Builder newForm() {
     return Form.newBuilder().setId("");
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/model/TestModelBuilders.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/TestModelBuilders.java
@@ -18,6 +18,8 @@ package com.google.android.gnd.model;
 
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.Point;
+import com.google.android.gnd.model.form.Field;
+import com.google.android.gnd.model.form.Field.Type;
 import com.google.android.gnd.model.form.Form;
 import com.google.android.gnd.model.layer.Layer;
 import com.google.android.gnd.model.layer.Style;
@@ -64,5 +66,14 @@ public class TestModelBuilders {
 
   public static Form.Builder newForm() {
     return Form.newBuilder().setId("");
+  }
+
+  public static Field.Builder newField() {
+    return Field.newBuilder()
+        .setId("")
+        .setIndex(0)
+        .setType(Type.TEXT)
+        .setLabel("")
+        .setRequired(false);
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/model/TestModelBuilders.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/TestModelBuilders.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gnd.model;
+
+import com.google.android.gnd.model.feature.Feature;
+import com.google.android.gnd.model.feature.Point;
+import com.google.android.gnd.model.form.Form;
+import com.google.android.gnd.model.layer.Layer;
+import com.google.android.gnd.model.layer.Style;
+import java.util.Date;
+
+/**
+ * Helper methods for building model objects for use in tests. Method return builders with required
+ * fields set to placeholder values. Rather than depending on these values, tests that test for
+ * specific values should explicitly set them in relevant test methods or during test setup.
+ */
+public class TestModelBuilders {
+  public static Project.Builder newTestProject() {
+    return Project.newBuilder().setId("").setTitle("").setDescription("");
+  }
+
+  public static User.Builder newTestUser() {
+    return User.builder().setId("").setEmail("").setDisplayName("");
+  }
+
+  public static AuditInfo.Builder newTestAuditInfo() {
+    return AuditInfo.builder().setClientTimestamp(new Date(0)).setUser(newTestUser().build());
+  }
+
+  public static Point.Builder newTestPoint() {
+    return Point.newBuilder().setLatitude(0).setLongitude(0);
+  }
+
+  public static Feature.Builder newTestFeature() {
+    return Feature.newBuilder()
+        .setId("")
+        .setProject(newTestProject().build())
+        .setPoint(newTestPoint().build())
+        .setCreated(newTestAuditInfo().build())
+        .setLastModified(newTestAuditInfo().build());
+  }
+
+  public static Layer.Builder newTestLayer() {
+    return Layer.newBuilder().setId("").setName("").setDefaultStyle(newTestStyle().build());
+  }
+
+  public static Style.Builder newTestStyle() {
+    return Style.builder().setColor("");
+  }
+
+  public static Form.Builder newTestForm() {
+    return Form.newBuilder().setId("");
+  }
+}

--- a/gnd/src/main/java/com/google/android/gnd/model/feature/Feature.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/feature/Feature.java
@@ -52,7 +52,6 @@ public abstract class Feature {
   @Nullable
   public abstract String getCaption();
 
-  @Nullable
   public abstract Point getPoint();
 
   @Nullable
@@ -83,7 +82,7 @@ public abstract class Feature {
 
     public abstract Builder setCaption(@Nullable String newCaption);
 
-    public abstract Builder setPoint(@Nullable Point newPoint);
+    public abstract Builder setPoint(Point newPoint);
 
     public abstract Builder setGeoJsonString(@Nullable String newGeoJsonString);
 

--- a/gnd/src/main/java/com/google/android/gnd/model/feature/Feature.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/feature/Feature.java
@@ -52,6 +52,7 @@ public abstract class Feature {
   @Nullable
   public abstract String getCaption();
 
+  @Nullable
   public abstract Point getPoint();
 
   @Nullable
@@ -82,7 +83,7 @@ public abstract class Feature {
 
     public abstract Builder setCaption(@Nullable String newCaption);
 
-    public abstract Builder setPoint(Point newPoint);
+    public abstract Builder setPoint(@Nullable Point newPoint);
 
     public abstract Builder setGeoJsonString(@Nullable String newGeoJsonString);
 

--- a/gnd/src/main/java/com/google/android/gnd/model/form/Field.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/form/Field.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class Field {
   public enum Type {
+    UNKNOWN,
     TEXT,
     MULTIPLE_CHOICE,
     PHOTO

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/ResponseMap.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/ResponseMap.java
@@ -21,6 +21,7 @@ import static java8.lang.Iterables.forEach;
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.Map;
+import java8.util.Objects;
 import java8.util.Optional;
 
 /** An immutable map of field ids to related user responses. */
@@ -70,12 +71,12 @@ public class ResponseMap {
 
     ResponseMap that = (ResponseMap) o;
 
-    return responses != null ? responses.equals(that.responses) : that.responses == null;
+    return Objects.equals(responses, that.responses);
   }
 
   @Override
   public int hashCode() {
-    return responses != null ? responses.hashCode() : 0;
+    return responses == null ? 0 : responses.hashCode();
   }
 
   public static class Builder {

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/ResponseMap.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/ResponseMap.java
@@ -59,6 +59,25 @@ public class ResponseMap {
     return new Builder();
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ResponseMap that = (ResponseMap) o;
+
+    return responses != null ? responses.equals(that.responses) : that.responses == null;
+  }
+
+  @Override
+  public int hashCode() {
+    return responses != null ? responses.hashCode() : 0;
+  }
+
   public static class Builder {
     private final Map<String, Response> map = new HashMap<>();
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/DataStoreException.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/DataStoreException.java
@@ -38,4 +38,18 @@ public class DataStoreException extends RuntimeException {
       throws DataStoreException {
     return optional.orElseThrow(() -> new DataStoreException("Missing " + field));
   }
+
+  /**
+   * Checks if the provided object is of the same type as (or a subtype of) the specified type. If
+   * not, a {@code DataStoreException} is thrown with relevant details.
+   */
+  @NonNull
+  public static <T> T checkType(@NonNull Class expectedType, @NonNull T obj)
+      throws DataStoreException {
+    if (!expectedType.isAssignableFrom(obj.getClass())) {
+      throw new DataStoreException(
+          "Expected " + expectedType.getName() + ", got " + obj.getClass().getName());
+    }
+    return obj;
+  }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
@@ -42,10 +42,10 @@ class ObservationConverter {
       throws DataStoreException {
     ObservationDocument doc = snapshot.toObject(ObservationDocument.class);
     String featureId = checkNotNull(doc.getFeatureId(), "featureId");
-    String formId = checkNotNull(doc.getFormId(), "formId");
     if (!feature.getId().equals(featureId)) {
       throw new DataStoreException("Observation doc featureId doesn't match specified feature id");
     }
+    String formId = checkNotNull(doc.getFormId(), "formId");
     Form form = checkNotEmpty(feature.getLayer().getForm(formId), "form " + formId);
     // Degrade gracefully when audit info missing in remote db.
     AuditInfoNestedObject created =

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
@@ -54,13 +54,13 @@ class ObservationConverter {
         .setProject(feature.getProject())
         .setFeature(feature)
         .setForm(form)
-        .setResponses(toResponseMap(doc.getResponses()))
+        .setResponses(toResponseMap(form, doc.getResponses()))
         .setCreated(AuditInfoConverter.toAuditInfo(created))
         .setLastModified(AuditInfoConverter.toAuditInfo(lastModified))
         .build();
   }
 
-  private static ResponseMap toResponseMap(@Nullable Map<String, Object> docResponses) {
+  private static ResponseMap toResponseMap(Form form, @Nullable Map<String, Object> docResponses) {
     ResponseMap.Builder responses = ResponseMap.builder();
     if (docResponses == null) {
       return responses.build();

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
@@ -44,9 +44,9 @@ class ObservationConverter {
     String featureId = checkNotNull(doc.getFeatureId(), "featureId");
     String formId = checkNotNull(doc.getFormId(), "formId");
     if (!feature.getId().equals(featureId)) {
-      Timber.e("Observation featureId doesn't match specified feature id");
+      throw new DataStoreException("Observation doc featureId doesn't match specified feature id");
     }
-    Form form = checkNotEmpty(feature.getLayer().getForm(formId), "form");
+    Form form = checkNotEmpty(feature.getLayer().getForm(formId), "form " + formId);
     // Degrade gracefully when audit info missing in remote db.
     AuditInfoNestedObject created =
         Objects.requireNonNullElse(doc.getCreated(), AuditInfoNestedObject.FALLBACK_VALUE);

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/UserConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/UserConverter.java
@@ -30,14 +30,14 @@ class UserConverter {
 
   @NonNull
   static User toUser(@Nullable UserNestedObject ud) {
-    if (ud == null || ud.getId() == null || ud.getEmail() == null || ud.getDisplayName() == null) {
-      // Degrade gracefully when user info missing in remote db.
+    // Degrade gracefully when user missing in remote db.
+    if (ud == null || ud.getId() == null) {
       ud = UserNestedObject.UNKNOWN_USER;
     }
     return User.builder()
         .setId(ud.getId())
-        .setEmail(ud.getEmail())
-        .setDisplayName(ud.getDisplayName())
+        .setEmail(ud.getEmail() == null ? "" : ud.getEmail())
+        .setDisplayName(ud.getDisplayName() == null ? "" : ud.getDisplayName())
         .build();
   }
 }

--- a/gnd/src/test/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverterTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gnd.persistence.remote.firestore.schema;
+
+import static com.google.android.gnd.model.TestModelBuilders.newTestAuditInfo;
+import static com.google.android.gnd.model.TestModelBuilders.newTestFeature;
+import static com.google.android.gnd.model.TestModelBuilders.newTestForm;
+import static com.google.android.gnd.model.TestModelBuilders.newTestLayer;
+import static com.google.android.gnd.model.TestModelBuilders.newTestProject;
+import static com.google.android.gnd.model.TestModelBuilders.newTestUser;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.android.gnd.model.Project;
+import com.google.android.gnd.model.feature.Feature;
+import com.google.android.gnd.model.form.Element;
+import com.google.android.gnd.model.form.Form;
+import com.google.android.gnd.model.layer.Layer;
+import com.google.android.gnd.model.observation.Observation;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.DocumentSnapshot;
+import java.util.Date;
+import java8.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ObservationConverterTest {
+
+  @Mock private DocumentSnapshot snapshot;
+
+  @Before
+  public void setUp() {}
+
+  @Test
+  public void testToObservation() {
+
+    ImmutableList<Element> elements = ImmutableList.of();
+    Form form = newTestForm().setId("form001").setElements(elements).build();
+    Layer layer = newTestLayer().setId("layer001").setForm(form).build();
+    Project project = newTestProject().putLayer("layer001", layer).build();
+    Feature feature =
+        newTestFeature().setId("feature001").setProject(project).setLayer(layer).build();
+
+    ObservationDocument doc =
+        new ObservationDocument(
+            "feature001",
+            "form001",
+            new AuditInfoNestedObject(
+                new UserNestedObject("user1", null, null),
+                new Timestamp(new Date(100)),
+                new Timestamp(new Date(101))),
+            new AuditInfoNestedObject(
+                new UserNestedObject("user2", null, null),
+                new Timestamp(new Date(200)),
+                new Timestamp(new Date(201))),
+            ImmutableMap.of());
+
+    when(snapshot.getId()).thenReturn("observation123");
+    when(snapshot.toObject(ObservationDocument.class)).thenReturn(doc);
+
+    Observation actual = ObservationConverter.toObservation(feature, snapshot);
+
+    Observation expected =
+        Observation.newBuilder()
+            .setId("observation123")
+            .setProject(project)
+            .setFeature(feature)
+            .setForm(form)
+            .setCreated(
+                newTestAuditInfo()
+                    .setUser(newTestUser().setId("user1").build())
+                    .setClientTimestamp(new Date(100))
+                    .setServerTimestamp(Optional.of(new Date(101)))
+                    .build())
+            .setLastModified(
+                newTestAuditInfo()
+                    .setUser(newTestUser().setId("user2").build())
+                    .setClientTimestamp(new Date(200))
+                    .setServerTimestamp(Optional.of(new Date(201)))
+                    .build())
+            .build();
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/gnd/src/test/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverterTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverterTest.java
@@ -16,28 +16,40 @@
 
 package com.google.android.gnd.persistence.remote.firestore.schema;
 
-import static com.google.android.gnd.model.TestModelBuilders.newTestAuditInfo;
-import static com.google.android.gnd.model.TestModelBuilders.newTestFeature;
-import static com.google.android.gnd.model.TestModelBuilders.newTestForm;
-import static com.google.android.gnd.model.TestModelBuilders.newTestLayer;
-import static com.google.android.gnd.model.TestModelBuilders.newTestProject;
-import static com.google.android.gnd.model.TestModelBuilders.newTestUser;
+import static com.google.android.gnd.model.TestModelBuilders.newAuditInfo;
+import static com.google.android.gnd.model.TestModelBuilders.newFeature;
+import static com.google.android.gnd.model.TestModelBuilders.newField;
+import static com.google.android.gnd.model.TestModelBuilders.newForm;
+import static com.google.android.gnd.model.TestModelBuilders.newLayer;
+import static com.google.android.gnd.model.TestModelBuilders.newProject;
+import static com.google.android.gnd.model.TestModelBuilders.newUser;
+import static com.google.android.gnd.util.ImmutableListCollector.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
+import static java8.util.J8Arrays.stream;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.google.android.gnd.model.AuditInfo;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.form.Element;
+import com.google.android.gnd.model.form.Field;
+import com.google.android.gnd.model.form.Field.Type;
 import com.google.android.gnd.model.form.Form;
+import com.google.android.gnd.model.form.MultipleChoice;
+import com.google.android.gnd.model.form.MultipleChoice.Cardinality;
 import com.google.android.gnd.model.layer.Layer;
+import com.google.android.gnd.model.observation.MultipleChoiceResponse;
 import com.google.android.gnd.model.observation.Observation;
+import com.google.android.gnd.model.observation.ResponseMap;
+import com.google.android.gnd.model.observation.TextResponse;
+import com.google.android.gnd.persistence.remote.DataStoreException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentSnapshot;
 import java.util.Date;
 import java8.util.Optional;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -45,60 +57,270 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ObservationConverterTest {
+  @Mock private DocumentSnapshot observationDocumentSnapshot;
 
-  @Mock private DocumentSnapshot snapshot;
+  private Form form;
+  private Layer layer;
+  private Project project;
+  private Feature feature;
 
-  @Before
-  public void setUp() {}
+  private static AuditInfo AUDIT_INFO_1 =
+      newAuditInfo()
+          .setUser(newUser().setId("user1").build())
+          .setClientTimestamp(new Date(100))
+          .setServerTimestamp(Optional.of(new Date(101)))
+          .build();
+
+  private static AuditInfo AUDIT_INFO_2 =
+      newAuditInfo()
+          .setUser(newUser().setId("user2").build())
+          .setClientTimestamp(new Date(200))
+          .setServerTimestamp(Optional.of(new Date(201)))
+          .build();
+
+  private static AuditInfoNestedObject AUDIT_INFO_1_NESTED_OBJECT =
+      new AuditInfoNestedObject(
+          new UserNestedObject("user1", null, null),
+          new Timestamp(new Date(100)),
+          new Timestamp(new Date(101)));
+
+  private static AuditInfoNestedObject AUDIT_INFO_2_NESTED_OBJECT =
+      new AuditInfoNestedObject(
+          new UserNestedObject("user2", null, null),
+          new Timestamp(new Date(200)),
+          new Timestamp(new Date(201)));
 
   @Test
   public void testToObservation() {
-
-    ImmutableList<Element> elements = ImmutableList.of();
-    Form form = newTestForm().setId("form001").setElements(elements).build();
-    Layer layer = newTestLayer().setId("layer001").setForm(form).build();
-    Project project = newTestProject().putLayer("layer001", layer).build();
-    Feature feature =
-        newTestFeature().setId("feature001").setProject(project).setLayer(layer).build();
-
-    ObservationDocument doc =
+    setUpTestProject(
+        "layer001",
+        "form001",
+        newField().setId("field1").setType(Type.TEXT).build(),
+        newField()
+            .setId("field2")
+            .setType(Type.MULTIPLE_CHOICE)
+            .setMultipleChoice(
+                MultipleChoice.newBuilder().setCardinality(Cardinality.SELECT_ONE).build())
+            .build(),
+        newField().setId("field3").setType(Type.MULTIPLE_CHOICE).build(),
+        newField().setId("field4").setType(Type.PHOTO).build());
+    setUpTestFeature("feature001");
+    mockObservationDocumentSnapshot(
+        "observation123",
         new ObservationDocument(
+            /* featureId */
             "feature001",
+            /* formId */
             "form001",
-            new AuditInfoNestedObject(
-                new UserNestedObject("user1", null, null),
-                new Timestamp(new Date(100)),
-                new Timestamp(new Date(101))),
-            new AuditInfoNestedObject(
-                new UserNestedObject("user2", null, null),
-                new Timestamp(new Date(200)),
-                new Timestamp(new Date(201))),
-            ImmutableMap.of());
+            /* created */
+            AUDIT_INFO_1_NESTED_OBJECT,
+            /* lastModified */
+            AUDIT_INFO_2_NESTED_OBJECT,
+            /* responses */
+            ImmutableMap.of(
+                "field1",
+                "Text response",
+                "field2",
+                ImmutableList.of("option2"),
+                "field3",
+                ImmutableList.of("optionA", "optionB"),
+                "field4",
+                "Photo URL")));
 
-    when(snapshot.getId()).thenReturn("observation123");
-    when(snapshot.toObject(ObservationDocument.class)).thenReturn(doc);
+    assertThat(toObservation())
+        .isEqualTo(
+            Observation.newBuilder()
+                .setId("observation123")
+                .setProject(project)
+                .setFeature(feature)
+                .setForm(form)
+                .setResponses(
+                    ResponseMap.builder()
+                        .putResponse("field1", new TextResponse("Text response"))
+                        .putResponse(
+                            "field2", new MultipleChoiceResponse(ImmutableList.of("option2")))
+                        .putResponse(
+                            "field3",
+                            new MultipleChoiceResponse(ImmutableList.of("optionA", "optionB")))
+                        .putResponse("field4", new TextResponse("Photo URL"))
+                        .build())
+                .setCreated(AUDIT_INFO_1)
+                .setLastModified(AUDIT_INFO_2)
+                .build());
+  }
 
-    Observation actual = ObservationConverter.toObservation(feature, snapshot);
+  @Test
+  public void testToObservation_mismatchedFeatureId() {
+    setUpTestProject("layer001", "form001", newField().setId("field1").setType(Type.TEXT).build());
+    setUpTestFeature("feature001");
+    mockObservationDocumentSnapshot(
+        "observation123",
+        new ObservationDocument(
+            /* featureId */
+            "feature999",
+            /* formId */
+            "form001",
+            /* created */
+            AUDIT_INFO_1_NESTED_OBJECT,
+            /* lastModified */
+            AUDIT_INFO_2_NESTED_OBJECT,
+            /* responses */
+            ImmutableMap.of("field1", "")));
 
-    Observation expected =
-        Observation.newBuilder()
-            .setId("observation123")
-            .setProject(project)
-            .setFeature(feature)
-            .setForm(form)
-            .setCreated(
-                newTestAuditInfo()
-                    .setUser(newTestUser().setId("user1").build())
-                    .setClientTimestamp(new Date(100))
-                    .setServerTimestamp(Optional.of(new Date(101)))
-                    .build())
-            .setLastModified(
-                newTestAuditInfo()
-                    .setUser(newTestUser().setId("user2").build())
-                    .setClientTimestamp(new Date(200))
-                    .setServerTimestamp(Optional.of(new Date(201)))
-                    .build())
+    assertThrows(DataStoreException.class, () -> toObservation());
+  }
+
+  @Test
+  public void testToObservation_nullResponses() {
+    setUpTestProject("layer001", "form001", newField().setId("field1").setType(Type.TEXT).build());
+    setUpTestFeature("feature001");
+    mockObservationDocumentSnapshot(
+        "observation123",
+        new ObservationDocument(
+            /* featureId */
+            "feature001",
+            /* formId */
+            "form001",
+            /* created */
+            AUDIT_INFO_1_NESTED_OBJECT,
+            /* lastModified */
+            AUDIT_INFO_2_NESTED_OBJECT,
+            /* responses */
+            null));
+
+    assertThat(toObservation())
+        .isEqualTo(
+            Observation.newBuilder()
+                .setId("observation123")
+                .setProject(project)
+                .setFeature(feature)
+                .setForm(form)
+                .setCreated(AUDIT_INFO_1)
+                .setLastModified(AUDIT_INFO_2)
+                .build());
+  }
+
+  @Test
+  public void testToObservation_emptyTextResponse() {
+    setUpTestProject("layer001", "form001", newField().setId("field1").setType(Type.TEXT).build());
+    setUpTestFeature("feature001");
+    mockObservationDocumentSnapshot(
+        "observation123",
+        new ObservationDocument(
+            /* featureId */
+            "feature001",
+            /* formId */
+            "form001",
+            /* created */
+            AUDIT_INFO_1_NESTED_OBJECT,
+            /* lastModified */
+            AUDIT_INFO_2_NESTED_OBJECT,
+            /* responses */
+            ImmutableMap.of("field1", "")));
+
+    assertThat(toObservation())
+        .isEqualTo(
+            Observation.newBuilder()
+                .setId("observation123")
+                .setProject(project)
+                .setFeature(feature)
+                .setForm(form)
+                .setCreated(AUDIT_INFO_1)
+                .setLastModified(AUDIT_INFO_2)
+                .build());
+  }
+
+  @Test
+  public void testToObservation_emptyMultipleChoiceResponse() {
+    setUpTestProject(
+        "layer001", "form001", newField().setId("field1").setType(Type.MULTIPLE_CHOICE).build());
+    setUpTestFeature("feature001");
+    mockObservationDocumentSnapshot(
+        "observation123",
+        new ObservationDocument(
+            /* featureId */
+            "feature001",
+            /* formId */
+            "form001",
+            /* created */
+            AUDIT_INFO_1_NESTED_OBJECT,
+            /* lastModified */
+            AUDIT_INFO_2_NESTED_OBJECT,
+            /* responses */
+            ImmutableMap.of("field1", ImmutableList.of())));
+
+    assertThat(toObservation())
+        .isEqualTo(
+            Observation.newBuilder()
+                .setId("observation123")
+                .setProject(project)
+                .setFeature(feature)
+                .setForm(form)
+                .setCreated(AUDIT_INFO_1)
+                .setLastModified(AUDIT_INFO_2)
+                .build());
+  }
+
+  private void setUpTestProject(String layerId, String formId, Field... fields) {
+    form =
+        newForm()
+            .setId(formId)
+            .setElements(stream(fields).map(Element::ofField).collect(toImmutableList()))
             .build();
-    assertThat(actual).isEqualTo(expected);
+    layer = newLayer().setId(layerId).setForm(form).build();
+    project = newProject().putLayer(layerId, layer).build();
+  }
+
+  @Test
+  public void testToObservation_unknownFieldType() {
+    setUpTestProject(
+        "layer001",
+        "form001",
+        newField().setId("field1").setType(Type.UNKNOWN).build(),
+        newField().setId("field2").setType(Type.TEXT).build());
+    setUpTestFeature("feature001");
+    mockObservationDocumentSnapshot(
+        "observation123",
+        new ObservationDocument(
+            /* featureId */
+            "feature001",
+            /* formId */
+            "form001",
+            /* created */
+            AUDIT_INFO_1_NESTED_OBJECT,
+            /* lastModified */
+            AUDIT_INFO_2_NESTED_OBJECT,
+            /* responses */
+            ImmutableMap.of("field1", "Unknown", "field2", "Text response")));
+
+    assertThat(toObservation())
+        .isEqualTo(
+            Observation.newBuilder()
+                .setId("observation123")
+                .setProject(project)
+                .setFeature(feature)
+                .setForm(form)
+                .setResponses(
+                    // Field "field1" with unknown field type ignored.
+                    ResponseMap.builder()
+                        .putResponse("field2", new TextResponse("Text response"))
+                        .build())
+                .setCreated(AUDIT_INFO_1)
+                .setLastModified(AUDIT_INFO_2)
+                .build());
+  }
+
+  private void setUpTestFeature(String featureId) {
+    feature = newFeature().setId(featureId).setProject(project).setLayer(layer).build();
+  }
+
+  /** Mock observation document snapshot to return the specified id and object representation. */
+  private void mockObservationDocumentSnapshot(String id, ObservationDocument doc) {
+    when(observationDocumentSnapshot.getId()).thenReturn(id);
+    when(observationDocumentSnapshot.toObject(ObservationDocument.class)).thenReturn(doc);
+  }
+
+  private Observation toObservation() {
+    return ObservationConverter.toObservation(feature, observationDocumentSnapshot);
   }
 }


### PR DESCRIPTION
Contributes to #754. This will be used to allow date, time, and other Ground form field types to use the same remote and local representation as other field types.

@atalekar @HemanParbhakar PTAL?