### PR TITLE
[Local persistence] Call observation response converters directly rather than via Room type converters

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
@@ -20,7 +20,6 @@ import androidx.room.Database;
 import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 import com.google.android.gnd.Config;
-import com.google.android.gnd.persistence.local.room.converter.ResponseDeltasTypeConverter;
 import com.google.android.gnd.persistence.local.room.converter.StyleTypeConverter;
 import com.google.android.gnd.persistence.local.room.dao.FeatureDao;
 import com.google.android.gnd.persistence.local.room.dao.FeatureMutationDao;
@@ -91,7 +90,6 @@ import com.google.android.gnd.persistence.local.room.models.TileEntityState;
   MutationEntityType.class,
   EntityState.class,
   OfflineBaseMapEntityState.class,
-  ResponseDeltasTypeConverter.class,
   StyleTypeConverter.class,
   TileEntityState.class
 })

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
@@ -21,7 +21,6 @@ import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 import com.google.android.gnd.Config;
 import com.google.android.gnd.persistence.local.room.converter.ResponseDeltasTypeConverter;
-import com.google.android.gnd.persistence.local.room.converter.ResponseMapTypeConverter;
 import com.google.android.gnd.persistence.local.room.converter.StyleTypeConverter;
 import com.google.android.gnd.persistence.local.room.dao.FeatureDao;
 import com.google.android.gnd.persistence.local.room.dao.FeatureMutationDao;
@@ -93,7 +92,6 @@ import com.google.android.gnd.persistence.local.room.models.TileEntityState;
   EntityState.class,
   OfflineBaseMapEntityState.class,
   ResponseDeltasTypeConverter.class,
-  ResponseMapTypeConverter.class,
   StyleTypeConverter.class,
   TileEntityState.class
 })

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -41,7 +41,9 @@ import com.google.android.gnd.model.form.Option;
 import com.google.android.gnd.model.layer.Layer;
 import com.google.android.gnd.model.observation.Observation;
 import com.google.android.gnd.model.observation.ObservationMutation;
+import com.google.android.gnd.model.observation.ResponseMap;
 import com.google.android.gnd.persistence.local.LocalDataStore;
+import com.google.android.gnd.persistence.local.room.converter.ResponseMapConverter;
 import com.google.android.gnd.persistence.local.room.dao.FeatureDao;
 import com.google.android.gnd.persistence.local.room.dao.FeatureMutationDao;
 import com.google.android.gnd.persistence.local.room.dao.FieldDao;
@@ -417,9 +419,11 @@ public class RoomLocalDataStore implements LocalDataStore {
     long clientTimestamp = lastMutation.getClientTimestamp();
     Timber.v("Merging observation " + this + " with mutations " + mutations);
     ObservationEntity.Builder builder = observation.toBuilder();
-    // Merge changes to responses.
+    ResponseMap.Builder responseMap =
+        ResponseMapConverter.fromString(observation.getResponses()).toBuilder();
     for (ObservationMutationEntity mutation : mutations) {
-      builder.applyMutation(mutation);
+      // Merge changes to responses.
+      responseMap.applyDeltas(mutation.getResponseDeltas());
     }
     // Update modified user and time.
     AuditInfoEntity lastModified =

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -43,6 +43,7 @@ import com.google.android.gnd.model.observation.Observation;
 import com.google.android.gnd.model.observation.ObservationMutation;
 import com.google.android.gnd.model.observation.ResponseMap;
 import com.google.android.gnd.persistence.local.LocalDataStore;
+import com.google.android.gnd.persistence.local.room.converter.ResponseDeltasConverter;
 import com.google.android.gnd.persistence.local.room.converter.ResponseMapConverter;
 import com.google.android.gnd.persistence.local.room.dao.FeatureDao;
 import com.google.android.gnd.persistence.local.room.dao.FeatureMutationDao;
@@ -423,7 +424,7 @@ public class RoomLocalDataStore implements LocalDataStore {
         ResponseMapConverter.fromString(observation.getResponses()).toBuilder();
     for (ObservationMutationEntity mutation : mutations) {
       // Merge changes to responses.
-      responseMap.applyDeltas(mutation.getResponseDeltas());
+      responseMap.applyDeltas(ResponseDeltasConverter.fromString(mutation.getResponseDeltas()));
     }
     // Update modified user and time.
     AuditInfoEntity lastModified =

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseDeltasConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseDeltasConverter.java
@@ -20,7 +20,6 @@ import static com.google.android.gnd.util.Enums.toEnum;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.room.TypeConverter;
 import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.observation.ResponseDelta;
 import com.google.common.collect.ImmutableList;
@@ -30,15 +29,13 @@ import org.json.JSONObject;
 import timber.log.Timber;
 
 /**
- * {@link TypeConverter} for converting between {@link ResponseDelta}s and JSON strings used to
- * represent them in the local db.
+ * Converts between {@link ResponseDelta}s and JSON strings used to represent them in the local db.
  */
-public class ResponseDeltasTypeConverter {
+public class ResponseDeltasConverter {
 
   private static final String KEY_FIELD_TYPE = "fieldType";
   private static final String KEY_NEW_RESPONSE = "newResponse";
 
-  @TypeConverter
   @NonNull
   public static String toString(@NonNull ImmutableList<ResponseDelta> responseDeltas) {
     JSONObject json = new JSONObject();
@@ -61,7 +58,6 @@ public class ResponseDeltasTypeConverter {
     return json.toString();
   }
 
-  @TypeConverter
   @NonNull
   public static ImmutableList<ResponseDelta> fromString(@Nullable String jsonString) {
     ImmutableList.Builder<ResponseDelta> deltas = ImmutableList.builder();

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseMapConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseMapConverter.java
@@ -18,20 +18,15 @@ package com.google.android.gnd.persistence.local.room.converter;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.room.TypeConverter;
 import com.google.android.gnd.model.observation.ResponseMap;
 import java.util.Iterator;
 import org.json.JSONException;
 import org.json.JSONObject;
 import timber.log.Timber;
 
-/**
- * {@link TypeConverter} for converting between {@link ResponseMap} and JSON strings used to
- * represent them in the local db.
- */
-public class ResponseMapTypeConverter {
+/** Converts between {@link ResponseMap} and JSON strings used to represent them in the local db. */
+public class ResponseMapConverter {
 
-  @TypeConverter
   @Nullable
   public static String toString(@NonNull ResponseMap responseDeltas) {
     JSONObject json = new JSONObject();
@@ -50,7 +45,6 @@ public class ResponseMapTypeConverter {
     return json.toString();
   }
 
-  @TypeConverter
   @NonNull
   public static ResponseMap fromString(@Nullable String jsonString) {
     ResponseMap.Builder map = ResponseMap.builder();

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/ObservationMutationEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/ObservationMutationEntity.java
@@ -24,11 +24,10 @@ import androidx.room.Entity;
 import androidx.room.ForeignKey;
 import androidx.room.Index;
 import com.google.android.gnd.model.observation.ObservationMutation;
-import com.google.android.gnd.model.observation.ResponseDelta;
+import com.google.android.gnd.persistence.local.room.converter.ResponseDeltasConverter;
 import com.google.android.gnd.persistence.local.room.models.MutationEntityType;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.AutoValue.CopyAnnotations;
-import com.google.common.collect.ImmutableList;
 import java.util.Date;
 import org.json.JSONObject;
 
@@ -76,7 +75,7 @@ public abstract class ObservationMutationEntity extends MutationEntity {
   @CopyAnnotations
   @Nullable
   @ColumnInfo(name = "response_deltas")
-  public abstract ImmutableList<ResponseDelta> getResponseDeltas();
+  public abstract String getResponseDeltas();
 
   public static ObservationMutationEntity create(
       long id,
@@ -86,7 +85,7 @@ public abstract class ObservationMutationEntity extends MutationEntity {
       String formId,
       String observationId,
       MutationEntityType type,
-      ImmutableList<ResponseDelta> responseDeltas,
+      String responseDeltas,
       long retryCount,
       @Nullable String lastError,
       @Nullable String userId,
@@ -116,7 +115,7 @@ public abstract class ObservationMutationEntity extends MutationEntity {
         .setFormId(m.getFormId())
         .setObservationId(m.getObservationId())
         .setType(MutationEntityType.fromMutationType(m.getType()))
-        .setResponseDeltas(m.getResponseDeltas())
+        .setResponseDeltas(ResponseDeltasConverter.toString(m.getResponseDeltas()))
         .setRetryCount(m.getRetryCount())
         .setLastError(m.getLastError())
         .setUserId(m.getUserId())
@@ -133,7 +132,7 @@ public abstract class ObservationMutationEntity extends MutationEntity {
         .setFormId(getFormId())
         .setObservationId(getObservationId())
         .setType(getType().toMutationType())
-        .setResponseDeltas(getResponseDeltas())
+        .setResponseDeltas(ResponseDeltasConverter.fromString(getResponseDeltas()))
         .setRetryCount(getRetryCount())
         .setLastError(getLastError())
         .setUserId(getUserId())
@@ -158,7 +157,7 @@ public abstract class ObservationMutationEntity extends MutationEntity {
 
     public abstract Builder setObservationId(String newObservationId);
 
-    public abstract Builder setResponseDeltas(ImmutableList<ResponseDelta> newResponseDeltas);
+    public abstract Builder setResponseDeltas(String newResponseDeltas);
 
     public abstract ObservationMutationEntity build();
   }


### PR DESCRIPTION
Contributes to  #754. . This change is required to allow us to pass in form metadata in a subsequent PR.

Depends on #760. Please review that PR first.

