### PR TITLE
[Map] Allow GeoJSON to be tappable

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -200,7 +200,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
     showBottomSheet(marker.getFeature());
   }
 
-  public void showBottomSheet(Feature feature) {
+  private void showBottomSheet(Feature feature) {
     Timber.d("showing bottom sheet");
     isObservationButtonVisible.setValue(true);
     bottomSheetState.setValue(BottomSheetState.visible(feature));

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -37,6 +37,7 @@ import com.google.android.gnd.rx.annotations.Hot;
 import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.common.SharedViewModel;
+import com.google.android.gnd.ui.map.MapGeoJson;
 import com.google.android.gnd.ui.map.MapPin;
 import io.reactivex.Single;
 import io.reactivex.processors.FlowableProcessor;
@@ -199,7 +200,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
     showBottomSheet(marker.getFeature());
   }
 
-  private void showBottomSheet(Feature feature) {
+  public void showBottomSheet(Feature feature) {
     Timber.d("showing bottom sheet");
     isObservationButtonVisible.setValue(true);
     bottomSheetState.setValue(BottomSheetState.visible(feature));
@@ -255,5 +256,9 @@ public class HomeScreenViewModel extends AbstractViewModel {
 
   public void showSettings() {
     navigator.navigate(HomeScreenFragmentDirections.actionHomeScreenFragmentToSettingsActivity());
+  }
+
+  public void onGeoJsonClick(MapGeoJson mapGeoJson) {
+    showBottomSheet(mapGeoJson.getFeature());
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -83,6 +83,16 @@ public class MapContainerFragment extends AbstractFragment {
         .subscribe(mapContainerViewModel::onMarkerClick);
     mapAdapter
         .toObservable()
+        .flatMap(MapAdapter::getMapGeoJsonClicks)
+        .as(disposeOnDestroy(this))
+        .subscribe(mapContainerViewModel::onGeoJsonClick);
+    mapAdapter
+        .toObservable()
+        .flatMap(MapAdapter::getMapGeoJsonClicks)
+        .as(disposeOnDestroy(this))
+        .subscribe(homeScreenViewModel::onGeoJsonClick);
+    mapAdapter
+        .toObservable()
         .flatMap(MapAdapter::getMapPinClicks)
         .as(disposeOnDestroy(this))
         .subscribe(homeScreenViewModel::onMarkerClick);

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -83,6 +83,11 @@ public class MapContainerFragment extends AbstractFragment {
         .subscribe(mapContainerViewModel::onMarkerClick);
     mapAdapter
         .toObservable()
+        .flatMap(MapAdapter::getMapPinClicks)
+        .as(disposeOnDestroy(this))
+        .subscribe(homeScreenViewModel::onMarkerClick);
+    mapAdapter
+        .toObservable()
         .flatMap(MapAdapter::getMapGeoJsonClicks)
         .as(disposeOnDestroy(this))
         .subscribe(mapContainerViewModel::onGeoJsonClick);
@@ -91,11 +96,6 @@ public class MapContainerFragment extends AbstractFragment {
         .flatMap(MapAdapter::getMapGeoJsonClicks)
         .as(disposeOnDestroy(this))
         .subscribe(homeScreenViewModel::onGeoJsonClick);
-    mapAdapter
-        .toObservable()
-        .flatMap(MapAdapter::getMapPinClicks)
-        .as(disposeOnDestroy(this))
-        .subscribe(homeScreenViewModel::onMarkerClick);
     mapAdapter
         .toFlowable()
         .flatMap(MapAdapter::getDragInteractions)

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
@@ -184,6 +184,7 @@ public class MapContainerViewModel extends AbstractViewModel {
         .setId(feature.getId())
         .setGeoJson(jsonObject)
         .setStyle(feature.getLayer().getDefaultStyle())
+        .setFeature(feature)
         .build();
   }
 
@@ -320,6 +321,10 @@ public class MapContainerViewModel extends AbstractViewModel {
 
   public void setSelectedFeature(Optional<Feature> selectedFeature) {
     this.selectedFeature = selectedFeature;
+  }
+
+  public void onGeoJsonClick(MapGeoJson mapGeoJson) {
+    // TODO: Move the camera and adjust styling appropriately.
   }
 
   public enum Mode {

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/MapAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/MapAdapter.java
@@ -35,6 +35,10 @@ public interface MapAdapter {
   @Hot
   Observable<MapPin> getMapPinClicks();
 
+  /** Returns polygon click events. */
+  @Hot
+  Observable<MapGeoJson> getMapGeoJsonClicks();
+
   /**
    * Returns map drag events. Emits the new viewport center each time the map is dragged by the
    * user. Subscribers that can't keep up receive the latest event ({@link

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/MapGeoJson.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/MapGeoJson.java
@@ -16,6 +16,7 @@
 
 package com.google.android.gnd.ui.map;
 
+import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.layer.Style;
 import com.google.auto.value.AutoValue;
 import org.json.JSONObject;
@@ -33,6 +34,9 @@ public abstract class MapGeoJson extends MapFeature {
 
   public abstract Style getStyle();
 
+  // TODO: Just store the ID and pull the feature when needed.
+  public abstract Feature getFeature();
+
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setId(String newId);
@@ -40,6 +44,8 @@ public abstract class MapGeoJson extends MapFeature {
     public abstract Builder setGeoJson(JSONObject newGeoJson);
 
     public abstract Builder setStyle(Style style);
+
+    public abstract Builder setFeature(Feature feature);
 
     public abstract MapGeoJson build();
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapAdapter.java
@@ -22,6 +22,7 @@ import static java8.util.stream.StreamSupport.stream;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
+import androidx.core.graphics.ColorUtils;
 import com.cocoahero.android.gmaps.addons.mapbox.MapBoxOfflineTileProvider;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -286,7 +287,10 @@ class GoogleMapsMapAdapter implements MapAdapter {
 
     GeoJsonPolygonStyle polygonStyle = layer.getDefaultPolygonStyle();
     polygonStyle.setLineStringWidth(width);
-    polygonStyle.setPolygonFillColor(color);
+    float alpha =  0.25f;
+    int a = (int) (alpha * 0xFF);
+    polygonStyle.setPolygonFillColor(ColorUtils.setAlphaComponent(color, a));
+    polygonStyle.setStrokeColor(color);
 
     GeoJsonLineStringStyle lineStringStyle = layer.getDefaultLineStringStyle();
     lineStringStyle.setLineStringWidth(width);

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapAdapter.java
@@ -75,6 +75,8 @@ import timber.log.Timber;
  */
 class GoogleMapsMapAdapter implements MapAdapter {
 
+  private static final float GEOJSON_POLYGON_FILL_ALPHA = 0.25f;
+
   private final GoogleMap map;
   private final Context context;
   private final MarkerIconFactory markerIconFactory;
@@ -287,8 +289,7 @@ class GoogleMapsMapAdapter implements MapAdapter {
 
     GeoJsonPolygonStyle polygonStyle = layer.getDefaultPolygonStyle();
     polygonStyle.setLineStringWidth(width);
-    float alpha =  0.25f;
-    int a = (int) (alpha * 0xFF);
+    int a = (int) (GEOJSON_POLYGON_FILL_ALPHA * 0xFF);
     polygonStyle.setPolygonFillColor(ColorUtils.setAlphaComponent(color, a));
     polygonStyle.setStrokeColor(color);
 

--- a/gnd/src/main/res/values/dimens.xml
+++ b/gnd/src/main/res/values/dimens.xml
@@ -18,7 +18,8 @@
 
 <resources>
     <!-- Map -->
-    <dimen name="polyline_stroke_width">12dp</dimen>
+    <dimen name="polyline_stroke_width">4dp</dimen>
+    <dimen name="selected_polyline_stroke_width">18dp</dimen>
 
     <!-- Forms -->
     <dimen name="field_label_text_size">14sp</dimen>


### PR DESCRIPTION
Builds on #782. 

Next steps in fast-follow PR(s):

* Parse GeoJSON at load time rather than rendering time.
* Use on shared GeoJSONLayer rather than one for each feature. Set parsed geometries on that layer.
* Let view model provide GeoJSON styles rather than setting them in MapAdapter.
* View  model updates GeoJSON styles to reflect whether feature is selected.

@scolsen This PR includes your commits as well. PTAL?
