### PR TITLE
fix: stop unintended cursor movement on number fields

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/model/observation/NumberResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/NumberResponse.java
@@ -23,32 +23,29 @@ import java8.util.Optional;
 /** A user provided response to a number {@link Field}. */
 public class NumberResponse implements Response {
 
-  private Number number;
+  private final String number;
 
-  public NumberResponse(Number number) {
+  public NumberResponse(String number) {
     this.number = number;
   }
 
   public double getValue() {
-    return number.doubleValue();
+    return Double.parseDouble(number);
   }
 
   @Override
   public String getSummaryText(Field field) {
-    return number.toString();
+    return number;
   }
 
   @Override
   public String getDetailsText(Field field) {
-    if (Double.isNaN(number.doubleValue())) {
-      return "";
-    }
-    return number.toString();
+    return number;
   }
 
   @Override
   public boolean isEmpty() {
-    return number.toString().isEmpty();
+    return number.isEmpty();
   }
 
   @Override
@@ -67,12 +64,10 @@ public class NumberResponse implements Response {
   @NonNull
   @Override
   public String toString() {
-    return number.toString();
+    return number;
   }
 
-  public static Optional<Response> fromNumber(Number number) {
-    return number.toString().isEmpty()
-        ? Optional.empty()
-        : Optional.of(new NumberResponse(number));
+  public static Optional<Response> fromNumber(String number) {
+    return number.isEmpty() ? Optional.empty() : Optional.of(new NumberResponse(number));
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseJsonConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseJsonConverter.java
@@ -68,10 +68,10 @@ class ResponseJsonConverter {
         return MultipleChoiceResponse.fromList(toList((JSONArray) obj));
       case NUMBER:
         if (JSONObject.NULL == obj) {
-          return NumberResponse.fromNumber(Double.NaN);
+          return NumberResponse.fromNumber("");
         }
         DataStoreException.checkType(Number.class, obj);
-        return NumberResponse.fromNumber((Number) obj);
+        return NumberResponse.fromNumber(obj.toString());
       case UNKNOWN:
       default:
         throw new DataStoreException("Unknown type in field: " + obj.getClass().getName());

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
@@ -105,8 +105,9 @@ class ObservationConverter {
   }
 
   private static void putNumberResponse(String fieldId, Object obj, Builder responses) {
-    Number value = (Number) DataStoreException.checkType(Number.class, obj);
-    NumberResponse.fromNumber(value).ifPresent(r -> responses.putResponse(fieldId, r));
+    double value = (Double) DataStoreException.checkType(Double.class, obj);
+    NumberResponse.fromNumber(Double.toString(value))
+        .ifPresent(r -> responses.putResponse(fieldId, r));
   }
 
   private static void putTextResponse(String fieldId, Object obj, ResponseMap.Builder responses) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/NumberFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/NumberFieldViewModel.java
@@ -28,11 +28,6 @@ public class NumberFieldViewModel extends AbstractFieldViewModel {
   }
 
   public void updateResponse(String number) {
-    if (number.isEmpty()) {
-      setResponse(NumberResponse.fromNumber(Double.NaN));
-      return;
-    }
-
-    setResponse(NumberResponse.fromNumber(Double.parseDouble(number)));
+    setResponse(NumberResponse.fromNumber(number));
   }
 }

--- a/gnd/src/main/res/layout/number_input_field.xml
+++ b/gnd/src/main/res/layout/number_input_field.xml
@@ -41,12 +41,12 @@
         android:id="@+id/number_input_edit_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:inputType="numberDecimal"
         android:maxLines="1"
         android:text="@{viewModel.responseText}"
         app:error="@{viewModel.error}"
         app:onTextChanged="@{s -> viewModel.updateResponse((String)s)}"
-        tools:text="Text value"
-        android:inputType="number"/>
+        tools:text="Text value" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/gnd/src/main/res/layout/number_input_field.xml
+++ b/gnd/src/main/res/layout/number_input_field.xml
@@ -46,7 +46,7 @@
         android:text="@{viewModel.responseText}"
         app:error="@{viewModel.error}"
         app:onTextChanged="@{s -> viewModel.updateResponse((String)s)}"
-        tools:text="Text value" />
+        tools:text="123.45" />
 
     </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
This commit fixes an issue whereby number fields would sporadically move
the cursor while adjusting values.

We move numeric conversions further down the stack and treat field
values as strings, additionally specifying the correct field type for
numeric field (numberDecimal)

@gino-m 

fixes #787 