### PR TITLE
Work around negative expanded offset bug

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/BottomSheetMetrics.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/BottomSheetMetrics.java
@@ -20,6 +20,7 @@ import android.view.View;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.google.android.gnd.R;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import timber.log.Timber;
 
 /** Abstracts access to dimensions and positions of elements relative to the bottom sheet UI. */
 public class BottomSheetMetrics {
@@ -80,6 +81,12 @@ public class BottomSheetMetrics {
    * stop expanding just below the top toolbar.
    */
   public int getExpandedOffset() {
+    if (toolbarWrapper.getHeight() < marginTop) {
+      Timber.e(
+          "toolbarWrapper height %d < marginTop %d. Falling back to default height",
+          toolbarWrapper.getHeight(), marginTop);
+      return 210 - 168;
+    }
     return toolbarWrapper.getHeight() - marginTop;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/BottomSheetMetrics.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/BottomSheetMetrics.java
@@ -24,6 +24,10 @@ import timber.log.Timber;
 
 /** Abstracts access to dimensions and positions of elements relative to the bottom sheet UI. */
 public class BottomSheetMetrics {
+
+  /** Fallback toolbar height - margin top used when toolbar height is uninitialized. */
+  public static final int FALLBACK_EXPANDED_OFFSET = 210 - 168;
+
   private final CoordinatorLayout parent;
   private final View bottomSheet;
   private final View addObservationButton;
@@ -81,11 +85,12 @@ public class BottomSheetMetrics {
    * stop expanding just below the top toolbar.
    */
   public int getExpandedOffset() {
+    // TODO(#828): Remove this workaround once the root cause is identified and fixed.
     if (toolbarWrapper.getHeight() < marginTop) {
       Timber.e(
           "toolbarWrapper height %d < marginTop %d. Falling back to default height",
           toolbarWrapper.getHeight(), marginTop);
-      return 210 - 168;
+      return FALLBACK_EXPANDED_OFFSET;
     }
     return toolbarWrapper.getHeight() - marginTop;
   }


### PR DESCRIPTION
Workaround for #828. Logs message when the crash would occur and falls back to default value. @scolsen @HemanParbhakar Could you please keep an eye out for the error message and see if you can understand when it's happening? It's seems to be hard to repro.

@HemanParbhakar Could you PTAL?