### PR TITLE
[Photos] Load image from local cache if available

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/FirestoreStorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/FirestoreStorageManager.java
@@ -86,9 +86,8 @@ public class FirestoreStorageManager implements RemoteStorageManager {
                 .putFile(Uri.fromFile(file))
                 .addOnCompleteListener(
                     uploadTask -> {
-                      if (file.delete()) {
-                        Timber.d("File deleted: %s", file.getName());
-                      }
+                      // Do not delete the file after successful upload. It is used as a cache
+                      // while viewing observations when network is unavailable.
                       emitter.onComplete();
                     })
                 .addOnPausedListener(taskSnapshot -> emitter.onNext(TransferProgress.paused()))

--- a/gnd/src/main/java/com/google/android/gnd/persistence/sync/PhotoSyncWorker.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/sync/PhotoSyncWorker.java
@@ -70,7 +70,7 @@ public class PhotoSyncWorker extends BaseWorker {
       Timber.d("Starting photo upload: %s, %s", localSourcePath, remoteDestinationPath);
       try {
         remoteStorageManager
-            .uploadMediaFromFile(new File(localSourcePath), remoteDestinationPath)
+            .uploadMediaFromFile(file, remoteDestinationPath)
             .compose(this::notifyTransferState)
             .blockingForEach(this::sendNotification);
         return Result.success();


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #881

<!-- PR description. -->
Default timeout for the remote fetch was very large. Which is why the local image wasn't being loaded instantly. Also, we were removing the local copy once the photo was uploaded successfully.

To solve that:
 * Stop removing the local copy
 * Attempt to load from local cache first for better UX

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->
### Steps to verify bug

1. Enable airplane mode
2. Open app and create a new observation
3. Click a new photo and save it.
4. The image should be visible under view observation
5. Then disable the airplane mode and let the photo upload.
6. Kill the app and enable airplane mode again.
7. Open the app and load the same observation.
8. Image should still be visible

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
