### PR TITLE
[Photo] Fix "save to gallery"

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/system/CameraManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/CameraManager.java
@@ -17,18 +17,14 @@
 package com.google.android.gnd.system;
 
 import android.Manifest.permission;
-import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.net.Uri;
 import android.provider.MediaStore;
 import androidx.annotation.Nullable;
 import com.google.android.gnd.rx.annotations.Cold;
 import com.google.android.gnd.rx.annotations.Hot;
-import dagger.hilt.android.qualifiers.ApplicationContext;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
-import java.io.File;
 import java8.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -43,16 +39,11 @@ public class CameraManager {
 
   private final PermissionsManager permissionsManager;
   private final ActivityStreams activityStreams;
-  private final Context context;
 
   @Inject
-  public CameraManager(
-      PermissionsManager permissionsManager,
-      ActivityStreams activityStreams,
-      @ApplicationContext Context context) {
+  public CameraManager(PermissionsManager permissionsManager, ActivityStreams activityStreams) {
     this.permissionsManager = permissionsManager;
     this.activityStreams = activityStreams;
-    this.context = context;
   }
 
   /** Launches the system's photo capture flow, first obtaining permissions if necessary. */
@@ -104,16 +95,6 @@ public class CameraManager {
           } else {
             emitter.onComplete();
           }
-        });
-  }
-
-  public Completable addPhotoToGallery(String photoPath) {
-    return Completable.fromRunnable(
-        () -> {
-          Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-          Uri contentUri = Uri.fromFile(new File(photoPath));
-          mediaScanIntent.setData(contentUri);
-          context.sendBroadcast(mediaScanIntent);
         });
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/system/StorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/StorageManager.java
@@ -17,14 +17,17 @@
 package com.google.android.gnd.system;
 
 import android.Manifest.permission;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.provider.MediaStore;
 import androidx.annotation.Nullable;
 import com.google.android.gnd.rx.annotations.Cold;
 import com.google.android.gnd.rx.annotations.Hot;
 import com.google.android.gnd.ui.util.BitmapUtil;
 import com.google.android.gnd.ui.util.FileUtil;
+import dagger.hilt.android.qualifiers.ApplicationContext;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import java.io.File;
@@ -40,6 +43,7 @@ public class StorageManager {
 
   static final int PICK_PHOTO_REQUEST_CODE = StorageManager.class.hashCode() & 0xffff;
 
+  private final Context context;
   private final PermissionsManager permissionsManager;
   private final ActivityStreams activityStreams;
   private final FileUtil fileUtil;
@@ -47,10 +51,12 @@ public class StorageManager {
 
   @Inject
   public StorageManager(
+      @ApplicationContext Context context,
       PermissionsManager permissionsManager,
       ActivityStreams activityStreams,
       FileUtil fileUtil,
       BitmapUtil bitmapUtil) {
+    this.context = context;
     this.permissionsManager = permissionsManager;
     this.activityStreams = activityStreams;
     this.fileUtil = fileUtil;
@@ -123,11 +129,16 @@ public class StorageManager {
   @Cold
   public Completable savePhoto(Bitmap bitmap, String filename) {
     try {
+      addImageToGallery(bitmap, filename);
       File file = fileUtil.saveBitmap(bitmap, filename);
       Timber.d("Photo saved %s : %b", filename, file.exists());
       return Completable.complete();
     } catch (IOException e) {
       return Completable.error(e);
     }
+  }
+
+  private void addImageToGallery(Bitmap bitmap, String title) {
+    MediaStore.Images.Media.insertImage(context.getContentResolver(), bitmap, title, "");
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationViewModel.java
@@ -196,14 +196,11 @@ public class EditObservationViewModel extends AbstractViewModel {
     checkNotNull(
         originalObservation, "originalObservation was empty when attempting to save bitmap");
 
-    String remoteDestinationpath =
-        getRemoteMediaPath(originalObservation,  localFileName);
+    String remoteDestinationpath = getRemoteMediaPath(originalObservation, localFileName);
 
     photoUpdates.postValue(ImmutableMap.of(field, remoteDestinationpath));
 
-    return storageManager
-        .savePhoto(bitmap, localFileName)
-        .andThen(cameraManager.addPhotoToGallery(localFileName));
+    return storageManager.savePhoto(bitmap, localFileName);
   }
 
   LiveData<ImmutableMap<Field, String>> getPhotoFieldUpdates() {

--- a/gnd/src/main/res/layout/photo_field.xml
+++ b/gnd/src/main/res/layout/photo_field.xml
@@ -28,7 +28,7 @@
 
   <FrameLayout
     android:layout_width="match_parent"
-    android:layout_height="200dp"
+    android:layout_height="wrap_content"
     android:paddingTop="@dimen/field_value_top_padding"
     android:visibility="@{viewModel.isPhotoPresent() ? View.VISIBLE : View.GONE}">
     <ImageView

--- a/gnd/src/test/java/com/google/android/gnd/system/CameraManagerTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/system/CameraManagerTest.java
@@ -65,7 +65,7 @@ public class CameraManagerTest {
   @Before
   public void setUp() {
     hiltRule.inject();
-    cameraManager = new CameraManager(mockPermissionsManager, activityStreams, null);
+    cameraManager = new CameraManager(mockPermissionsManager, activityStreams);
   }
 
   private void mockPermissions(boolean allow) {

--- a/gnd/src/test/java/com/google/android/gnd/system/StorageManagerTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/system/StorageManagerTest.java
@@ -77,6 +77,7 @@ public class StorageManagerTest {
     hiltRule.inject();
     storageManager =
         new StorageManager(
+            null,
             mockPermissionsManager,
             activityStreams,
             fileUtil,


### PR DESCRIPTION
Fixes image path being sent for adding images.

As of API level 29, ACTION_MEDIA_SCANNER_SCAN_FILE is deprecated

https://developer.android.com/reference/android/content/Intent#ACTION_MEDIA_SCANNER_SCAN_FILE

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->



<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #891 

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

Tested manually on physical device

@gino-m  PTAL?
