### PR TITLE
[GCB] Improvements to remote build

### DIFF
--- a/cloud-builder/cloudbuild.yaml
+++ b/cloud-builder/cloudbuild.yaml
@@ -51,4 +51,8 @@ images:
   - 'gcr.io/$PROJECT_ID/android:base'
   - 'gcr.io/$PROJECT_ID/android:${_ANDROID_VERSION}'
 
+# Available options: https://cloud.google.com/compute/docs/machine-types
+options:
+  machineType: 'N1_HIGHCPU_8'
+
 timeout: 2000s

--- a/cloud-builder/cloudbuild.yaml
+++ b/cloud-builder/cloudbuild.yaml
@@ -51,8 +51,4 @@ images:
   - 'gcr.io/$PROJECT_ID/android:base'
   - 'gcr.io/$PROJECT_ID/android:${_ANDROID_VERSION}'
 
-# Available options: https://cloud.google.com/compute/docs/machine-types
-options:
-  machineType: 'N1_HIGHCPU_8'
-
 timeout: 2000s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -61,7 +61,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --no-daemon assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
 
   # Run code quality checks
   - name: 'gcr.io/$PROJECT_ID/android:28'
@@ -71,7 +71,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --no-daemon checkCode 2> check-logs.txt || echo "fail" > build-status.txt
+        ./gradlew -PdisablePreDex checkCode 2> check-logs.txt || echo "fail" > build-status.txt
         cat check-logs.txt
 
   - name: 'gcr.io/$PROJECT_ID/android:28'
@@ -81,7 +81,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --no-daemon testStagingUnitTest 2> unit-test-logs.txt || echo "fail" > build-status.txt
+        ./gradlew -PdisablePreDex testStagingUnitTest 2> unit-test-logs.txt || echo "fail" > build-status.txt
         cat unit-test-logs.txt
 
   - name: 'gcr.io/$PROJECT_ID/android:28'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,7 +79,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --no-daemon assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex --no-daemon --debug assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
 
   # Run code quality checks
   - name: 'gcr.io/$PROJECT_ID/android:28'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -204,7 +204,6 @@ steps:
 options:
   env:
     - 'TERM=dumb'
-    - 'GRADLE_OPT=-Dorg.gradle.daemon=false'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY
   machineType: 'N1_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,7 +79,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --no-daemon --debug assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex --debug assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
 
   # Run code quality checks
   - name: 'gcr.io/$PROJECT_ID/android:28'
@@ -205,8 +205,9 @@ options:
   env:
     # Set gradle options manually to prevent gradle from using single use only daemon.
     # For more info : https://github.com/gradle/gradle/issues/11517
-    - 'GRADLE_OPTS=-XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant'
+#    - 'GRADLE_OPTS=-XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant'
     - 'TERM=dumb'
+    - 'GRADLE_OPT=-Dorg.gradle.daemon=false'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -208,4 +208,4 @@ options:
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY
 
-timeout: 1800s
+timeout: 3600s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -205,7 +205,7 @@ options:
   env:
     # Set gradle options manually to prevent gradle from using single use only daemon.
     # For more info : https://github.com/gradle/gradle/issues/11517
-    - 'GRADLE_OPTS=-Xmx4096m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant'
+    - 'GRADLE_OPTS=-XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant'
     - 'TERM=dumb'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,7 +79,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --no-daemon --debug assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex --no-daemon assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
 
   # Run code quality checks
   - name: 'gcr.io/$PROJECT_ID/android:28'
@@ -204,8 +204,7 @@ steps:
 options:
   env:
     - 'TERM=dumb'
-    - 'JAVA_TOOL_OPTIONS="-Xmx3g"'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY
 
-timeout: 3600s
+timeout: 1800s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,7 +79,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --no-daemon assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex --no-daemon --scan assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
 
   # Run code quality checks
   - name: 'gcr.io/$PROJECT_ID/android:28'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -171,7 +171,7 @@ steps:
   - name: 'gcr.io/$PROJECT_ID/android:base'
     id: &compress_cache 'Compress gradle build cache'
     waitFor:
-      - *update_status
+      - *assemble_debug
     args:
       - '-c'
       - |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,7 +22,7 @@
 #
 #  Copy cache --> Extract tar -->                      -------> Code quality -------> Unit tests ------------------------>
 #                                \                   /                                                                     \
-#  Copy .git dir ------------------> Build debug apks                                                                       Save reports to GCS --> Update CI status --> Compress gradle cache --> Save gradle cache to GCS
+#                                 > Build debug apks                                                                       Save reports to GCS --> Update CI status --> Compress gradle cache --> Save gradle cache to GCS
 #                                /                   \                                                                     /
 #  Fetch google-services.json -->                      --> Authorize Gcloud --> Build test apks --> Instrumented tests -->
 #
@@ -44,23 +44,6 @@ steps:
       - |
         tar zxf cache.tgz || echo "No cache found."
 
-  # Copy .git directory to workspace.
-  # This is needed by gitVersioner plugin for auto-generating version code and version name.
-  #
-  # TODO: Remove this step when .git can be explicitly included in the tarball using .gcloudignore
-  # https://github.com/GoogleCloudPlatform/cloud-builders/issues/401
-  - name: 'gcr.io/cloud-builders/git'
-    id: &create_git_dir 'Copy .git dir'
-    waitFor: [ '-' ]
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        git clone --branch master $_HEAD_REPO_URL tmp
-        rm -rf .git
-        mv tmp/.git .
-        rm -rf tmp
-
   - name: 'gcr.io/$PROJECT_ID/android:28'
     id: &config_google_services 'Load debug google-services.json'
     waitFor: [ '-' ]
@@ -74,7 +57,6 @@ steps:
     id: &assemble_debug 'Assemble debug apks'
     waitFor:
       - *extract_build_cache
-      - *create_git_dir
       - *config_google_services
     args:
       - '-c'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -193,7 +193,7 @@ steps:
     args:
       - '-c'
       - |
-        tar zcf cache.tgz .gradle
+        tar zcf cache.tgz .gradle/caches .gradle/wrapper
 
   - name: 'gcr.io/cloud-builders/gsutil'
     id: &save_cache 'Save gradle cache to GCS'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,7 +79,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --debug assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex --no-daemon assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
 
   # Run code quality checks
   - name: 'gcr.io/$PROJECT_ID/android:28'
@@ -203,12 +203,10 @@ steps:
 
 options:
   env:
-    # Set gradle options manually to prevent gradle from using single use only daemon.
-    # For more info : https://github.com/gradle/gradle/issues/11517
-#    - 'GRADLE_OPTS=-XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant'
     - 'TERM=dumb'
     - 'GRADLE_OPT=-Dorg.gradle.daemon=false'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY
+  machineType: 'N1_HIGHCPU_8'
 
 timeout: 1800s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -203,6 +203,9 @@ steps:
 
 options:
   env:
+    # Set gradle options manually to prevent gradle from using single use only daemon.
+    # For more info : https://github.com/gradle/gradle/issues/11517
+    - 'GRADLE_OPTS=-Xmx4096m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant'
     - 'TERM=dumb'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,19 +30,19 @@
 steps:
 
   - name: 'gcr.io/cloud-builders/gsutil'
-    id: &copy_gradle_cache 'Copying gradle cache'
+    id: &copy_build_cache 'Copying build cache'
     waitFor: [ '-' ]
     # we use rsync and not cp so that this step doesn't fail the first time it's run
     args: [ 'rsync', 'gs://${_CACHE_BUCKET}/', './' ]
 
   - name: 'gcr.io/$PROJECT_ID/android:base'
-    id: &restore_gradle_cache 'Extracting tar'
+    id: &extract_build_cache 'Extracting tar'
     waitFor:
-      - *copy_gradle_cache
+      - *copy_build_cache
     args:
       - '-c'
       - |
-        tar zxf cache.tgz || echo "No cache found"
+        tar zxf cache.tgz || echo "No cache found."
 
   # Copy .git directory to workspace.
   # This is needed by gitVersioner plugin for auto-generating version code and version name.
@@ -73,7 +73,7 @@ steps:
   - name: 'gcr.io/$PROJECT_ID/android:28'
     id: &assemble_debug 'Assemble debug apks'
     waitFor:
-      - *restore_gradle_cache
+      - *extract_build_cache
       - *create_git_dir
       - *config_google_services
     args:
@@ -187,7 +187,7 @@ steps:
         fi
 
   - name: 'gcr.io/$PROJECT_ID/android:base'
-    id: &build_cache 'Compress gradle build cache'
+    id: &compress_cache 'Compress gradle build cache'
     waitFor:
       - *update_status
     args:
@@ -198,7 +198,7 @@ steps:
   - name: 'gcr.io/cloud-builders/gsutil'
     id: &save_cache 'Save gradle cache to GCS'
     waitFor:
-      - *build_cache
+      - *compress_cache
     args: [ 'cp', 'cache.tgz', 'gs://${_CACHE_BUCKET}/cache.tgz' ]
 
 options:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,10 +22,11 @@
 #
 #  Copy cache --> Extract tar -->                      -------> Code quality -------> Unit tests ------------------------>
 #                                \                   /                                                                     \
-#                                 > Build debug apks                                                                       Save reports to GCS --> Update CI status --> Compress gradle cache --> Save gradle cache to GCS
+#                                 > Build debug apks                                                                       Save reports to GCS --> Update CI status
 #                                /                   \                                                                     /
 #  Fetch google-services.json -->                      --> Authorize Gcloud --> Build test apks --> Instrumented tests -->
-#
+#                                                      \
+#                                                       --> Compress gradle cache --> Save gradle cache to GCS
 
 steps:
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -203,6 +203,8 @@ steps:
 
 options:
   env:
+    - 'TERM=dumb'
+    - 'JAVA_TOOL_OPTIONS="-Xmx3g"'
     - 'GRADLE_USER_HOME=/workspace/.gradle'
   logging: GCS_ONLY
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,7 +79,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex --no-daemon --scan assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex --no-daemon --debug assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
 
   # Run code quality checks
   - name: 'gcr.io/$PROJECT_ID/android:28'

--- a/gnd/build.gradle
+++ b/gnd/build.gradle
@@ -84,12 +84,16 @@ android {
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
         }
         debug {
+            ext.enableCrashlytics = false
+            ext.alwaysUpdateBuildId = false
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             FirebasePerformance {
                 instrumentationEnabled false
             }
         }
         staging {
+            ext.enableCrashlytics = false
+            ext.alwaysUpdateBuildId = false
             signingConfig signingConfigs.staging
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             FirebasePerformance {


### PR DESCRIPTION
Things done:

- Use machine with multiple CPUs and high memory
- Remove `copying .git` step as the bug is now fixed
- Improve ids
- Disable crashlytics plugin for non-release builds
- Update `save cache` step to only cache relevant files

This also introduced < 1 min queue time as now the build depends on availability of high configuration machines.
But this gap is more than compensated by the fact that each gradle step is now 8 times faster.

@gino-m PTAL?