### PR TITLE
[GCB] Revert cache save step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -173,7 +173,7 @@ steps:
   - name: 'gcr.io/$PROJECT_ID/android:base'
     id: &compress_cache 'Compress gradle build cache'
     waitFor:
-      - *assemble_debug
+      - *update_status
     args:
       - '-c'
       - |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,11 +22,10 @@
 #
 #  Copy cache --> Extract tar -->                      -------> Code quality -------> Unit tests ------------------------>
 #                                \                   /                                                                     \
-#                                 > Build debug apks                                                                       Save reports to GCS --> Update CI status
+#                                 > Build debug apks                                                                       Save reports to GCS --> Update CI status --> Compress gradle cache --> Save gradle cache to GCS
 #                                /                   \                                                                     /
 #  Fetch google-services.json -->                      --> Authorize Gcloud --> Build test apks --> Instrumented tests -->
-#                                                      \
-#                                                       --> Compress gradle cache --> Save gradle cache to GCS
+#
 
 steps:
 


### PR DESCRIPTION
Prevents failing of remote build because of concurrent modification error.

`tar: .gradle/caches/build-cache-1: file changed as we read it`

@gino-m  PTAL?

Contributes to #922. 
