### PR TITLE
chore: update db version

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -27,7 +27,7 @@ public final class Config {
 
   // Local db settings.
   // TODO(#128): Reset version to 1 before releasing.
-  public static final int DB_VERSION = 84;
+  public static final int DB_VERSION = 85;
   public static final String DB_NAME = "gnd.db";
 
   // Firebase Cloud Firestore settings.


### PR DESCRIPTION
When I attempted to run the app, I got an error about the db schema
changing and the version not being updated. I suppose a change got
pushed at some point that didn't have a corresponding db version bump.
This change simply bumps the db version to fix the issue.