### PR TITLE
[Cleanup] Refactor Photo & MultipleChoice VMs

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -59,24 +59,6 @@
       <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
       <option name="JD_KEEP_EMPTY_RETURN" value="false" />
     </JavaCodeStyleSettings>
-    <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
-    </JetCodeStyleSettings>
     <Objective-C>
       <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
       <option name="INDENT_C_STRUCT_MEMBERS" value="2" />

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
@@ -19,18 +19,34 @@ package com.google.android.gnd.model.observation;
 import static java8.util.stream.StreamSupport.stream;
 
 import com.google.android.gnd.model.form.Field;
+import com.google.android.gnd.model.form.MultipleChoice;
 import com.google.android.gnd.model.form.Option;
 import java.util.List;
 import java8.util.Optional;
 import java8.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 
 /** User responses to a select-one (radio) or select-multiple (checkbox) field. */
 public class MultipleChoiceResponse implements Response {
 
-  private List<String> choices;
+  private final MultipleChoice multipleChoice;
+  private final List<String> choices;
 
-  public MultipleChoiceResponse(List<String> choices) {
+  public MultipleChoiceResponse(MultipleChoice multipleChoice, List<String> choices) {
+    this.multipleChoice = multipleChoice;
     this.choices = choices;
+  }
+
+  public static Optional<Response> fromList(MultipleChoice multipleChoice, List<String> codes) {
+    if (codes.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(new MultipleChoiceResponse(multipleChoice, codes));
+    }
+  }
+
+  public MultipleChoice getMultipleChoice() {
+    return multipleChoice;
   }
 
   public List<String> getChoices() {
@@ -78,16 +94,9 @@ public class MultipleChoiceResponse implements Response {
     return choices.hashCode();
   }
 
+  @NotNull
   @Override
   public String toString() {
     return stream(choices).sorted().collect(Collectors.joining(","));
-  }
-
-  public static Optional<Response> fromList(List<String> codes) {
-    if (codes.isEmpty()) {
-      return Optional.empty();
-    } else {
-      return Optional.of(new MultipleChoiceResponse(codes));
-    }
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
@@ -30,11 +30,11 @@ import org.jetbrains.annotations.NotNull;
 public class MultipleChoiceResponse implements Response {
 
   private final MultipleChoice multipleChoice;
-  private final List<String> choices;
+  private final List<String> selectedOptionIds;
 
-  public MultipleChoiceResponse(MultipleChoice multipleChoice, List<String> choices) {
+  public MultipleChoiceResponse(MultipleChoice multipleChoice, List<String> selectedOptionIds) {
     this.multipleChoice = multipleChoice;
-    this.choices = choices;
+    this.selectedOptionIds = selectedOptionIds;
   }
 
   public static Optional<Response> fromList(MultipleChoice multipleChoice, List<String> codes) {
@@ -49,16 +49,16 @@ public class MultipleChoiceResponse implements Response {
     return multipleChoice;
   }
 
-  public List<String> getChoices() {
-    return choices;
+  public List<String> getSelectedOptionIds() {
+    return selectedOptionIds;
   }
 
   public Optional<String> getFirstId() {
-    return stream(choices).findFirst();
+    return stream(selectedOptionIds).findFirst();
   }
 
   public boolean isSelected(Option option) {
-    return choices.contains(option.getId());
+    return selectedOptionIds.contains(option.getId());
   }
 
   public String getSummaryText(Field field) {
@@ -67,7 +67,7 @@ public class MultipleChoiceResponse implements Response {
 
   // TODO: Make these inner classes non-static and access Form directly.
   public String getDetailsText(Field field) {
-    return stream(choices)
+    return stream(selectedOptionIds)
         .map(field.getMultipleChoice()::getOptionById)
         .filter(Optional::isPresent)
         .map(Optional::get)
@@ -78,25 +78,25 @@ public class MultipleChoiceResponse implements Response {
 
   @Override
   public boolean isEmpty() {
-    return choices.isEmpty();
+    return selectedOptionIds.isEmpty();
   }
 
   @Override
   public boolean equals(Object obj) {
     if (obj instanceof MultipleChoiceResponse) {
-      return choices.equals(((MultipleChoiceResponse) obj).choices);
+      return selectedOptionIds.equals(((MultipleChoiceResponse) obj).selectedOptionIds);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return choices.hashCode();
+    return selectedOptionIds.hashCode();
   }
 
   @NotNull
   @Override
   public String toString() {
-    return stream(choices).sorted().collect(Collectors.joining(","));
+    return stream(selectedOptionIds).sorted().collect(Collectors.joining(","));
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/MultipleChoiceResponse.java
@@ -18,7 +18,6 @@ package com.google.android.gnd.model.observation;
 
 import static java8.util.stream.StreamSupport.stream;
 
-import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.form.MultipleChoice;
 import com.google.android.gnd.model.form.Option;
 import java.util.List;
@@ -61,14 +60,14 @@ public class MultipleChoiceResponse implements Response {
     return selectedOptionIds.contains(option.getId());
   }
 
-  public String getSummaryText(Field field) {
-    return getDetailsText(field);
+  public String getSummaryText() {
+    return getDetailsText();
   }
 
   // TODO: Make these inner classes non-static and access Form directly.
-  public String getDetailsText(Field field) {
+  public String getDetailsText() {
     return stream(selectedOptionIds)
-        .map(field.getMultipleChoice()::getOptionById)
+        .map(getMultipleChoice()::getOptionById)
         .filter(Optional::isPresent)
         .map(Optional::get)
         .map(Option::getLabel)

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/NumberResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/NumberResponse.java
@@ -34,12 +34,12 @@ public class NumberResponse implements Response {
   }
 
   @Override
-  public String getSummaryText(Field field) {
+  public String getSummaryText() {
     return number;
   }
 
   @Override
-  public String getDetailsText(Field field) {
+  public String getDetailsText() {
     return number;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/Response.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/Response.java
@@ -22,9 +22,9 @@ import java8.util.Optional;
 /** A user-provided response to a single {@link Field}. */
 public interface Response {
 
-  String getSummaryText(Field field);
+  String getSummaryText();
 
-  String getDetailsText(Field field);
+  String getDetailsText();
 
   static String toString(Optional<Response> response) {
     return response.map(Response::toString).orElse("");

--- a/gnd/src/main/java/com/google/android/gnd/model/observation/TextResponse.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/observation/TextResponse.java
@@ -34,12 +34,12 @@ public class TextResponse implements Response {
   }
 
   @Override
-  public String getSummaryText(Field field) {
+  public String getSummaryText() {
     return text;
   }
 
   @Override
-  public String getDetailsText(Field field) {
+  public String getDetailsText() {
     return text;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseJsonConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseJsonConverter.java
@@ -69,10 +69,11 @@ class ResponseJsonConverter {
         return TextResponse.fromString((String) obj);
       case MULTIPLE_CHOICE:
         if (obj == JSONObject.NULL) {
-          return MultipleChoiceResponse.fromList(Collections.emptyList());
+          return MultipleChoiceResponse.fromList(
+              field.getMultipleChoice(), Collections.emptyList());
         }
         DataStoreException.checkType(JSONArray.class, obj);
-        return MultipleChoiceResponse.fromList(toList((JSONArray) obj));
+        return MultipleChoiceResponse.fromList(field.getMultipleChoice(), toList((JSONArray) obj));
       case NUMBER:
         if (JSONObject.NULL == obj) {
           return NumberResponse.fromNumber("");

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseJsonConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/converter/ResponseJsonConverter.java
@@ -54,7 +54,7 @@ class ResponseJsonConverter {
 
   private static Object toJsonArray(MultipleChoiceResponse response) {
     JSONArray array = new JSONArray();
-    forEach(response.getChoices(), array::put);
+    forEach(response.getSelectedOptionIds(), array::put);
     return array;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverter.java
@@ -23,6 +23,7 @@ import static java8.util.stream.StreamSupport.stream;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.form.Form;
+import com.google.android.gnd.model.form.MultipleChoice;
 import com.google.android.gnd.model.observation.MultipleChoiceResponse;
 import com.google.android.gnd.model.observation.NumberResponse;
 import com.google.android.gnd.model.observation.Observation;
@@ -93,7 +94,7 @@ class ObservationConverter {
         putTextResponse(fieldId, obj, responses);
         break;
       case MULTIPLE_CHOICE:
-        putMultipleChoiceResponse(fieldId, obj, responses);
+        putMultipleChoiceResponse(fieldId, field.getMultipleChoice(), obj, responses);
         break;
       case NUMBER:
         putNumberResponse(fieldId, obj, responses);
@@ -117,10 +118,10 @@ class ObservationConverter {
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   private static void putMultipleChoiceResponse(
-      String fieldId, Object obj, ResponseMap.Builder responses) {
+      String fieldId, MultipleChoice multipleChoice, Object obj, Builder responses) {
     List values = (List) DataStoreException.checkType(List.class, obj);
     stream(values).forEach(v -> DataStoreException.checkType(String.class, v));
-    MultipleChoiceResponse.fromList((List<String>) values)
+    MultipleChoiceResponse.fromList(multipleChoice, (List<String>) values)
         .ifPresent(r -> responses.putResponse(fieldId, r));
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationMutationConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationMutationConverter.java
@@ -83,7 +83,7 @@ class ObservationMutationConverter {
     if (response instanceof TextResponse) {
       return ((TextResponse) response).getText();
     } else if (response instanceof MultipleChoiceResponse) {
-      return ((MultipleChoiceResponse) response).getChoices();
+      return ((MultipleChoiceResponse) response).getSelectedOptionIds();
     } else if (response instanceof NumberResponse) {
       return ((NumberResponse) response).getValue();
     } else {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AbstractFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AbstractFieldViewModel.java
@@ -68,7 +68,7 @@ public class AbstractFieldViewModel extends AbstractViewModel {
   }
 
   private Single<String> getDetailsText(Optional<Response> responseOptional) {
-    return Single.just(responseOptional.map(response -> response.getDetailsText(field)).orElse(""));
+    return Single.just(responseOptional.map(Response::getDetailsText).orElse(""));
   }
 
   /** Checks if the current response is valid and updates error value. */

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AbstractFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/AbstractFieldViewModel.java
@@ -65,7 +65,7 @@ public class AbstractFieldViewModel extends AbstractViewModel {
   }
 
   @Cold(stateful = true, terminates = false)
-  protected Flowable<String> getDetailsTextFlowable() {
+  protected final Flowable<String> getDetailsTextFlowable() {
     return responseSubject
         .distinctUntilChanged()
         .map(responseOptional -> responseOptional.map(Response::getDetailsText).orElse(""));

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -46,7 +46,6 @@ import com.google.android.gnd.model.form.Form;
 import com.google.android.gnd.model.form.MultipleChoice;
 import com.google.android.gnd.model.form.Option;
 import com.google.android.gnd.model.observation.MultipleChoiceResponse;
-import com.google.android.gnd.model.observation.TextResponse;
 import com.google.android.gnd.ui.common.AbstractFragment;
 import com.google.android.gnd.ui.common.BackPressListener;
 import com.google.android.gnd.ui.common.EphemeralPopups;
@@ -263,7 +262,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
               // TODO: Do not set response if already handled.
               Field field = fieldViewModel.getField();
               if (map.containsKey(field)) {
-                fieldViewModel.setResponse(TextResponse.fromString(map.get(field)));
+                fieldViewModel.updateResponse(map.get(field));
               }
             });
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -192,7 +192,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
           break;
         case UNKNOWN:
         default:
-          Timber.d(element.getType() + " form elements not yet supported");
+          Timber.e("%s form elements not yet supported", element.getType());
           break;
       }
     }
@@ -222,7 +222,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
             .setContext(requireContext())
             .setTitle(field.getLabel())
             .setMultipleChoice(multipleChoice)
-            .setCurrentValue(response)
+            .setCurrentResponse(response)
             .setValueConsumer(consumer)
             .build()
             .createDialog();
@@ -231,7 +231,7 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
             .setContext(requireContext())
             .setTitle(field.getLabel())
             .setMultipleChoice(multipleChoice)
-            .setCurrentValue(response)
+            .setCurrentResponse(response)
             .setValueConsumer(consumer)
             .build()
             .createDialog();

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/EditObservationFragment.java
@@ -44,8 +44,8 @@ import com.google.android.gnd.model.form.Element;
 import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.form.Form;
 import com.google.android.gnd.model.form.MultipleChoice;
+import com.google.android.gnd.model.form.Option;
 import com.google.android.gnd.model.observation.MultipleChoiceResponse;
-import com.google.android.gnd.model.observation.Response;
 import com.google.android.gnd.model.observation.TextResponse;
 import com.google.android.gnd.ui.common.AbstractFragment;
 import com.google.android.gnd.ui.common.BackPressListener;
@@ -53,6 +53,7 @@ import com.google.android.gnd.ui.common.EphemeralPopups;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.common.TwoLineToolbar;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
+import com.google.common.collect.ImmutableList;
 import dagger.hilt.android.AndroidEntryPoint;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -207,14 +208,14 @@ public class EditObservationFragment extends AbstractFragment implements BackPre
                 createDialog(
                         viewModel.getField(),
                         viewModel.getCurrentResponse(),
-                        viewModel::setResponse)
+                        viewModel::updateResponse)
                     .show());
   }
 
   private AlertDialog createDialog(
       Field field,
       Optional<MultipleChoiceResponse> response,
-      Consumer<Optional<Response>> consumer) {
+      Consumer<ImmutableList<Option>> consumer) {
     MultipleChoice multipleChoice = requireNonNull(field.getMultipleChoice());
     switch (multipleChoice.getCardinality()) {
       case SELECT_MULTIPLE:

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/MultiSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/MultiSelectDialogFactory.java
@@ -54,7 +54,7 @@ abstract class MultiSelectDialogFactory extends SelectDialogFactory {
   @Override
   public void initSelectedState() {
     checkedItems = new boolean[size()];
-    getCurrentValue().ifPresent(this::updateCurrentSelectedItems);
+    getCurrentResponse().ifPresent(this::updateCurrentSelectedItems);
   }
 
   private void updateCurrentSelectedItems(MultipleChoiceResponse response) {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/MultipleChoiceFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/MultipleChoiceFieldViewModel.java
@@ -17,6 +17,7 @@
 package com.google.android.gnd.ui.editobservation;
 
 import static com.google.android.gnd.util.ImmutableListCollector.toImmutableList;
+import static java8.util.Objects.requireNonNull;
 import static java8.util.stream.StreamSupport.stream;
 
 import android.app.Application;
@@ -56,7 +57,7 @@ public class MultipleChoiceFieldViewModel extends AbstractFieldViewModel {
   public void updateResponse(ImmutableList<Option> options) {
     setResponse(
         MultipleChoiceResponse.fromList(
-            getField().getMultipleChoice(),
+            requireNonNull(getField().getMultipleChoice()),
             stream(options).map(Option::getId).collect(toImmutableList())));
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/MultipleChoiceFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/MultipleChoiceFieldViewModel.java
@@ -16,11 +16,16 @@
 
 package com.google.android.gnd.ui.editobservation;
 
+import static com.google.android.gnd.util.ImmutableListCollector.toImmutableList;
+import static java8.util.stream.StreamSupport.stream;
+
 import android.app.Application;
 import androidx.lifecycle.MutableLiveData;
+import com.google.android.gnd.model.form.Option;
 import com.google.android.gnd.model.observation.MultipleChoiceResponse;
 import com.google.android.gnd.rx.Nil;
 import com.google.android.gnd.rx.annotations.Hot;
+import com.google.common.collect.ImmutableList;
 import java8.util.Optional;
 import javax.inject.Inject;
 
@@ -46,5 +51,12 @@ public class MultipleChoiceFieldViewModel extends AbstractFieldViewModel {
     return getResponse().getValue() == null
         ? Optional.empty()
         : getResponse().getValue().map(response -> (MultipleChoiceResponse) response);
+  }
+
+  public void updateResponse(ImmutableList<Option> options) {
+    setResponse(
+        MultipleChoiceResponse.fromList(
+            getField().getMultipleChoice(),
+            stream(options).map(Option::getId).collect(toImmutableList())));
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
@@ -78,7 +78,7 @@ public class PhotoFieldViewModel extends AbstractFieldViewModel {
     if (response == null) {
       destinationPath.onNext(EMPTY_PATH);
     } else {
-      destinationPath.onNext(response.getDetailsText(field));
+      destinationPath.onNext(response.getDetailsText());
     }
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
@@ -22,6 +22,7 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import androidx.lifecycle.MutableLiveData;
 import com.google.android.gnd.model.form.Field;
+import com.google.android.gnd.model.observation.TextResponse;
 import com.google.android.gnd.repository.UserMediaRepository;
 import com.google.android.gnd.rx.annotations.Hot;
 import javax.inject.Inject;
@@ -70,5 +71,9 @@ public class PhotoFieldViewModel extends AbstractFieldViewModel {
 
   public LiveData<Boolean> isEditable() {
     return editable;
+  }
+
+  public void updateResponse(String value) {
+    setResponse(TextResponse.fromString(value));
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/PhotoFieldViewModel.java
@@ -18,30 +18,18 @@ package com.google.android.gnd.ui.editobservation;
 
 import android.app.Application;
 import android.net.Uri;
-import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import androidx.lifecycle.MutableLiveData;
 import com.google.android.gnd.model.form.Field;
-import com.google.android.gnd.model.form.Field.Type;
-import com.google.android.gnd.model.observation.Response;
 import com.google.android.gnd.repository.UserMediaRepository;
 import com.google.android.gnd.rx.annotations.Hot;
-import io.reactivex.processors.BehaviorProcessor;
-import io.reactivex.processors.FlowableProcessor;
-import java8.util.Optional;
 import javax.inject.Inject;
-import timber.log.Timber;
 
 public class PhotoFieldViewModel extends AbstractFieldViewModel {
 
-  private static final String EMPTY_PATH = "";
-
-  @Hot(replays = true)
-  private final FlowableProcessor<String> destinationPath = BehaviorProcessor.create();
-
   private final LiveData<Uri> uri;
-  public final LiveData<Boolean> photoPresent;
+  private final LiveData<Boolean> photoPresent;
 
   @Hot(replays = true)
   private final MutableLiveData<Field> showDialogClicks = new MutableLiveData<>();
@@ -53,33 +41,15 @@ public class PhotoFieldViewModel extends AbstractFieldViewModel {
   PhotoFieldViewModel(UserMediaRepository userMediaRepository, Application application) {
     super(application);
     this.photoPresent =
-        LiveDataReactiveStreams.fromPublisher(destinationPath.map(path -> !path.isEmpty()));
+        LiveDataReactiveStreams.fromPublisher(
+            getDetailsTextFlowable().map(path -> !path.isEmpty()));
     this.uri =
         LiveDataReactiveStreams.fromPublisher(
-            destinationPath.switchMapSingle(userMediaRepository::getDownloadUrl));
+            getDetailsTextFlowable().switchMapSingle(userMediaRepository::getDownloadUrl));
   }
 
   public LiveData<Uri> getUri() {
     return uri;
-  }
-
-  @Override
-  public void setResponse(Optional<Response> response) {
-    super.setResponse(response);
-    updateField(response.isPresent() ? response.get() : null, getField());
-  }
-
-  public void updateField(@Nullable Response response, Field field) {
-    if (field.getType() != Type.PHOTO) {
-      Timber.e("Not a photo type field: %s", field.getType());
-      return;
-    }
-
-    if (response == null) {
-      destinationPath.onNext(EMPTY_PATH);
-    } else {
-      destinationPath.onNext(response.getDetailsText());
-    }
   }
 
   public void onShowPhotoSelectorDialog() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SelectDialogFactory.java
@@ -88,7 +88,7 @@ public abstract class SelectDialogFactory {
 
   public abstract MultipleChoice getMultipleChoice();
 
-  public abstract Optional<MultipleChoiceResponse> getCurrentValue();
+  public abstract Optional<MultipleChoiceResponse> getCurrentResponse();
 
   public abstract Consumer<Optional<Response>> getValueConsumer();
 
@@ -100,7 +100,7 @@ public abstract class SelectDialogFactory {
 
     public abstract B setMultipleChoice(MultipleChoice multipleChoice);
 
-    public abstract B setCurrentValue(Optional<MultipleChoiceResponse> response);
+    public abstract B setCurrentResponse(Optional<MultipleChoiceResponse> response);
 
     public abstract B setValueConsumer(Consumer<Optional<Response>> consumer);
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SelectDialogFactory.java
@@ -16,7 +16,6 @@
 
 package com.google.android.gnd.ui.editobservation;
 
-import static com.google.android.gnd.util.ImmutableListCollector.toImmutableList;
 import static java8.util.stream.StreamSupport.stream;
 
 import android.content.Context;
@@ -25,7 +24,6 @@ import com.google.android.gnd.R;
 import com.google.android.gnd.model.form.MultipleChoice;
 import com.google.android.gnd.model.form.Option;
 import com.google.android.gnd.model.observation.MultipleChoiceResponse;
-import com.google.android.gnd.model.observation.Response;
 import com.google.common.collect.ImmutableList;
 import java8.util.Optional;
 import java8.util.function.Consumer;
@@ -48,13 +46,6 @@ public abstract class SelectDialogFactory {
     return stream(getMultipleChoice().getOptions()).map(Option::getLabel).toArray(String[]::new);
   }
 
-  /** Returns the selected item(s) as a {@link Response}. */
-  protected Optional<Response> onCreateResponse() {
-    return MultipleChoiceResponse.fromList(
-        getMultipleChoice(),
-        stream(getSelectedOptions()).map(Option::getId).collect(toImmutableList()));
-  }
-
   // TODO: Replace with modal bottom sheet.
   protected AlertDialog.Builder createDialogBuilder() {
     return new AlertDialog.Builder(getContext())
@@ -62,7 +53,7 @@ public abstract class SelectDialogFactory {
         .setTitle(getTitle())
         .setPositiveButton(
             R.string.apply_multiple_choice_changes,
-            (dialog, which) -> getValueConsumer().accept(onCreateResponse()))
+            (dialog, which) -> getValueConsumer().accept(getSelectedOptions()))
         .setNegativeButton(R.string.cancel, (dialog, which) -> {});
   }
 
@@ -90,7 +81,7 @@ public abstract class SelectDialogFactory {
 
   public abstract Optional<MultipleChoiceResponse> getCurrentResponse();
 
-  public abstract Consumer<Optional<Response>> getValueConsumer();
+  public abstract Consumer<ImmutableList<Option>> getValueConsumer();
 
   public abstract static class Builder<B> {
 
@@ -102,6 +93,6 @@ public abstract class SelectDialogFactory {
 
     public abstract B setCurrentResponse(Optional<MultipleChoiceResponse> response);
 
-    public abstract B setValueConsumer(Consumer<Optional<Response>> consumer);
+    public abstract B setValueConsumer(Consumer<ImmutableList<Option>> consumer);
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SelectDialogFactory.java
@@ -51,6 +51,7 @@ public abstract class SelectDialogFactory {
   /** Returns the selected item(s) as a {@link Response}. */
   protected Optional<Response> onCreateResponse() {
     return MultipleChoiceResponse.fromList(
+        getMultipleChoice(),
         stream(getSelectedOptions()).map(Option::getId).collect(toImmutableList()));
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SingleSelectDialogFactory.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/editobservation/SingleSelectDialogFactory.java
@@ -50,7 +50,7 @@ abstract class SingleSelectDialogFactory extends SelectDialogFactory {
   @Override
   protected void initSelectedState() {
     checkedItem =
-        getCurrentValue()
+        getCurrentResponse()
             .flatMap(MultipleChoiceResponse::getFirstId)
             .flatMap(getMultipleChoice()::getIndex)
             .orElse(-1);

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/featuredetails/ObservationListItemViewHolder.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/featuredetails/ObservationListItemViewHolder.java
@@ -70,7 +70,7 @@ class ObservationListItemViewHolder extends RecyclerView.ViewHolder {
             newFieldTextView(field.getLabel(), R.style.ObservationListText_FieldLabel));
         binding.fieldValueRow.addView(
             newFieldTextView(
-                response.map(r -> r.getSummaryText(field)).orElse(""),
+                response.map(Response::getSummaryText).orElse(""),
                 R.style.ObservationListText_Field));
       } else {
         Timber.e("Unhandled element type: %s", elem.getType());

--- a/gnd/src/main/java/com/google/android/gnd/ui/observationdetails/ObservationDetailsFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/observationdetails/ObservationDetailsFragment.java
@@ -133,7 +133,7 @@ public class ObservationDetailsFragment extends AbstractFragment {
                 fieldBinding.fieldValue.setVisibility(View.GONE);
                 addPhotoField((ViewGroup) fieldBinding.getRoot(), field, response);
               } else {
-                fieldBinding.fieldValue.setText(response.getDetailsText(field));
+                fieldBinding.fieldValue.setText(response.getDetailsText());
               }
             });
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/observationdetails/ObservationDetailsFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/observationdetails/ObservationDetailsFragment.java
@@ -43,6 +43,7 @@ import com.google.android.gnd.ui.common.EphemeralPopups;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.editobservation.PhotoFieldViewModel;
 import dagger.hilt.android.AndroidEntryPoint;
+import java8.util.Optional;
 import javax.inject.Inject;
 import timber.log.Timber;
 
@@ -131,19 +132,19 @@ public class ObservationDetailsFragment extends AbstractFragment {
             response -> {
               if (field.getType() == Type.PHOTO) {
                 fieldBinding.fieldValue.setVisibility(View.GONE);
-                addPhotoField((ViewGroup) fieldBinding.getRoot(), field, response);
+                addPhotoField((ViewGroup) fieldBinding.getRoot(), response);
               } else {
                 fieldBinding.fieldValue.setText(response.getDetailsText());
               }
             });
   }
 
-  private void addPhotoField(ViewGroup container, Field field, Response response) {
-    PhotoFieldBinding photoFieldBinding = PhotoFieldBinding.inflate(getLayoutInflater());
+  private void addPhotoField(ViewGroup container, Response response) {
     PhotoFieldViewModel photoFieldViewModel = viewModelFactory.create(PhotoFieldViewModel.class);
+    photoFieldViewModel.setResponse(Optional.of(response));
+    PhotoFieldBinding photoFieldBinding = PhotoFieldBinding.inflate(getLayoutInflater());
     photoFieldBinding.setLifecycleOwner(this);
     photoFieldBinding.setViewModel(photoFieldViewModel);
-    photoFieldViewModel.updateField(response, field);
     container.addView(photoFieldBinding.getRoot());
   }
 

--- a/gnd/src/test/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverterTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/persistence/remote/firestore/schema/ObservationConverterTest.java
@@ -137,10 +137,11 @@ public class ObservationConverterTest {
                     ResponseMap.builder()
                         .putResponse("field1", new TextResponse("Text response"))
                         .putResponse(
-                            "field2", new MultipleChoiceResponse(ImmutableList.of("option2")))
+                            "field2", new MultipleChoiceResponse(null, ImmutableList.of("option2")))
                         .putResponse(
                             "field3",
-                            new MultipleChoiceResponse(ImmutableList.of("optionA", "optionB")))
+                            new MultipleChoiceResponse(
+                                null, ImmutableList.of("optionA", "optionB")))
                         .putResponse("field4", new TextResponse("Photo URL"))
                         .build())
                 .setCreated(AUDIT_INFO_1)


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Things done: 
 * Remove `field` from methods in `Response`
   * Add `mutipleChoice` parameter to `MultipleChoiceResponse`
   * Remove unused `field` from `Response` and its implementations
 * Cleanup `PhotoFieldViewModel`
    * Reuse `responseSubject` instead of creating a new flowable.
 * Minor naming improvements
 * Convert `debug` to `error` logging

Affected components:
 * All types of responses
 * Select fields
 * Photo fields

Changes verified by testing all affected components manually.

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
