### PR TITLE
[BUG] Fix NPE when navigating from offline fragment to home fragment

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/HomeScreenViewModel.java
@@ -43,6 +43,7 @@ import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.common.SharedViewModel;
 import com.google.android.gnd.ui.map.MapFeature;
 import com.google.android.gnd.ui.map.MapPin;
+import com.google.android.gnd.ui.map.MapProvider;
 import com.google.common.collect.ImmutableList;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
@@ -61,6 +62,7 @@ public class HomeScreenViewModel extends AbstractViewModel {
   @Hot(replays = true)
   public final MutableLiveData<Boolean> isObservationButtonVisible = new MutableLiveData<>(false);
 
+  private final MapProvider mapProvider;
   private final ProjectRepository projectRepository;
   private final Navigator navigator;
   private final FeatureRepository featureRepository;
@@ -97,10 +99,12 @@ public class HomeScreenViewModel extends AbstractViewModel {
 
   @Inject
   HomeScreenViewModel(
+      MapProvider mapProvider,
       ProjectRepository projectRepository,
       FeatureRepository featureRepository,
       Navigator navigator,
       Schedulers schedulers) {
+    this.mapProvider = mapProvider;
     this.projectRepository = projectRepository;
     this.featureRepository = featureRepository;
     this.navigator = navigator;
@@ -226,9 +230,9 @@ public class HomeScreenViewModel extends AbstractViewModel {
     bottomSheetState.setValue(BottomSheetState.visible(feature));
   }
 
-  public void onAddFeatureBtnClick(Point location) {
+  public void onAddFeatureBtnClick() {
     // TODO: Pause location updates while dialog is open.
-    addFeatureDialogRequests.onNext(location);
+    addFeatureDialogRequests.onNext(mapProvider.getTargetPoint());
   }
 
   public void onBottomSheetHidden() {

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
@@ -22,6 +22,7 @@ import static com.google.android.gnd.util.ImmutableSetCollector.toImmutableSet;
 import static java8.util.stream.StreamSupport.stream;
 
 import android.content.res.Resources;
+import androidx.annotation.ColorRes;
 import androidx.annotation.Dimension;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
@@ -97,6 +98,19 @@ public class MapContainerViewModel extends AbstractViewModel {
 
   @Hot(replays = true)
   private final MutableLiveData<Action> selectMapTypeClicks = new MutableLiveData<>();
+
+  @Hot(replays = true)
+  private final MutableLiveData<Point> confirmButtonClicks = new MutableLiveData<>();
+
+  @Hot(replays = true)
+  private final MutableLiveData<Action> cancelButtonClicks = new MutableLiveData<>();
+
+  @Hot(replays = true)
+  private final MutableLiveData<Boolean> locationLockEnabled = new MutableLiveData<>();
+
+  @Hot(replays = true)
+  private final MutableLiveData<Integer> featureAddButtonBackgroundTint =
+      new MutableLiveData<>(R.color.colorGrey500);
 
   private final LiveData<ImmutableSet<String>> mbtilesFilePaths;
   private final LiveData<Integer> iconTint;
@@ -364,6 +378,22 @@ public class MapContainerViewModel extends AbstractViewModel {
     moveFeaturesVisibility.postValue(viewMode == Mode.REPOSITION ? VISIBLE : GONE);
   }
 
+  public void confirmButtonClicked() {
+    confirmButtonClicks.postValue(getCameraPosition().getValue().getTarget());
+  }
+
+  public void cancelButtonClicked() {
+    cancelButtonClicks.postValue(Action.create());
+  }
+
+  public LiveData<Point> getConfirmButtonClicks() {
+    return confirmButtonClicks;
+  }
+
+  public LiveData<Action> getCancelButtonClicks() {
+    return cancelButtonClicks;
+  }
+
   public LiveData<Integer> getMapControlsVisibility() {
     return mapControlsVisibility;
   }
@@ -383,6 +413,22 @@ public class MapContainerViewModel extends AbstractViewModel {
   /** Called when a feature is (de)selected. */
   public void setSelectedFeature(Optional<Feature> selectedFeature) {
     this.selectedFeature.onNext(selectedFeature);
+  }
+
+  public LiveData<Boolean> getLocationLockEnabled() {
+    return locationLockEnabled;
+  }
+
+  public void setLocationLockEnabled(boolean enabled) {
+    locationLockEnabled.postValue(enabled);
+  }
+
+  public void setFeatureButtonBackgroundTint(@ColorRes int colorRes) {
+    featureAddButtonBackgroundTint.postValue(colorRes);
+  }
+
+  public LiveData<Integer> getFeatureAddButtonBackgroundTint() {
+    return featureAddButtonBackgroundTint;
   }
 
   public enum Mode {

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/MapProvider.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/MapProvider.java
@@ -18,6 +18,7 @@ package com.google.android.gnd.ui.map;
 
 import android.util.Pair;
 import androidx.fragment.app.Fragment;
+import com.google.android.gnd.model.feature.Point;
 import com.google.common.collect.ImmutableList;
 import io.reactivex.Single;
 
@@ -38,6 +39,8 @@ public interface MapProvider {
 
   // TODO(#714): Use enum instead of int to represent basemap types.
   void setMapType(int mapType);
+
+  Point getTargetPoint();
 
   ImmutableList<Pair<Integer, String>> getMapTypes();
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapProvider.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/map/gms/GoogleMapsMapProvider.java
@@ -19,6 +19,7 @@ package com.google.android.gnd.ui.map.gms;
 import android.util.Pair;
 import androidx.fragment.app.Fragment;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.rx.annotations.Hot;
 import com.google.android.gnd.ui.MarkerIconFactory;
 import com.google.android.gnd.ui.map.MapAdapter;
@@ -84,6 +85,11 @@ public class GoogleMapsMapProvider implements MapProvider {
   @Override
   public void setMapType(int mapType) {
     map.getValue().setMapType(mapType);
+  }
+
+  @Override
+  public Point getTargetPoint() {
+    return map.getValue().getCameraTarget();
   }
 
   @Override

--- a/gnd/src/main/res/layout/map_home_layout.xml
+++ b/gnd/src/main/res/layout/map_home_layout.xml
@@ -21,6 +21,7 @@
   xmlns:tools="http://schemas.android.com/tools">
 
   <data>
+    <import type="androidx.core.content.ContextCompat" />
     <variable
       name="viewModel"
       type="com.google.android.gnd.ui.home.mapcontainer.MapContainerViewModel" />
@@ -63,6 +64,7 @@
       android:id="@+id/location_lock_btn"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:enabled="@{viewModel.getLocationLockEnabled()}"
       android:onClick="@{() -> viewModel.onLocationLockClick()}"
       app:srcCompat="@drawable/ic_gps_lock"
       app:tint="@{viewModel.getIconTint()}"
@@ -76,12 +78,14 @@
       android:id="@+id/add_feature_btn"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:onClick="@{() -> homeScreenViewModel.onAddFeatureBtnClick()}"
       android:visibility="@{homeScreenViewModel.getAddFeatureButtonVisibility()}"
       app:fabSize="normal"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:srcCompat="@drawable/ic_add"
       app:tint="@color/colorBackground"
+      app:backgroundTintList="@{ContextCompat.getColorStateList(context, viewModel.getFeatureAddButtonBackgroundTint())}"
       app:useCompatPadding="true" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/gnd/src/main/res/layout/map_move_feature_layout.xml
+++ b/gnd/src/main/res/layout/map_move_feature_layout.xml
@@ -55,6 +55,7 @@
       app:layout_constraintBottom_toTopOf="@+id/confirm_button"
       app:layout_constraintEnd_toEndOf="parent"
       app:srcCompat="@drawable/ic_baseline_cancel_24"
+      android:onClick="@{() -> viewModel.cancelButtonClicked()}"
       app:tint="@color/colorBackground"
       app:useCompatPadding="true" />
 
@@ -66,6 +67,7 @@
       app:fabSize="normal"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
+      android:onClick="@{() -> viewModel.confirmButtonClicked()}"
       app:srcCompat="@drawable/ic_baseline_check_24"
       app:tint="@color/colorBackground"
       app:useCompatPadding="true" />


### PR DESCRIPTION
Fixes NPE while binding click listeners to buttons by converting them to data binding.

Steps to reproduce the bug:
 * Open the app and select offline areas from the drawer menu
 * Press back button or up arrow to move back to home screen
 * Notice the NPE in the stack trace

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->


<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
