### PR TITLE
[GCB] Run task "dependencyUpdates" only when running on master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ allprojects {
 }
 
 task checkCode(type: GradleBuild) {
-    tasks = ['checkstyle', 'lintDebug', 'pmd', 'dependencyUpdates']
+    tasks = ['checkstyle', 'lintDebug', 'pmd']
 }
 
 task clean(type: Delete) {

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -137,6 +137,9 @@ steps:
         # Update build status if running on master branch
         if [[ "${_PUSH_TO_MASTER}" ]]; then
 
+          # Check for updates
+          ./gradlew -PdisablePreDex dependencyUpdates
+
           # Gradle Dependencies Status
           if [[ -f gnd/build/reports/dependencyUpdates/report.json ]]; then
             python cloud-builder/generate_dependency_health_svg.py gnd/build/reports/dependencyUpdates/report.json dependency.svg


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
The generated reports are only used when the build is running against `master`.
So, run this task only when necessary.

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
