### PR TITLE
[Unit tests] Cleanup tests and improve coverage for sign-in flow

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
@@ -69,8 +69,6 @@ public class MainViewModel extends AbstractViewModel {
   private final TermsOfServiceRepository termsOfServiceRepository;
   private final EphemeralPopups popups;
 
-  public Optional<TermsOfService> termsOfService = Optional.empty();
-
   @Inject
   public MainViewModel(
       ProjectRepository projectRepository,
@@ -173,17 +171,18 @@ public class MainViewModel extends AbstractViewModel {
     if (termsOfServiceRepository.isTermsOfServiceAccepted()) {
       return Observable.just(HomeScreenFragmentDirections.showHomeScreen());
     } else {
-      return termsOfServiceRepository
-          .getTermsOfService()
-          .onErrorResumeNext(this::onGetTermsOfServiceError)
+      return getRemoteTermsOfService()
           .map(TermsOfService::getText)
-          .map(this::onGetTermsOfServiceComplete)
+          .map(text -> SignInFragmentDirections.showTermsOfService().setTermsOfServiceText(text))
+          .cast(NavDirections.class)
           .toObservable();
     }
   }
 
-  private NavDirections onGetTermsOfServiceComplete(String termsOfServiceText) {
-    return SignInFragmentDirections.showTermsOfService().setTermsOfServiceText(termsOfServiceText);
+  private Maybe<TermsOfService> getRemoteTermsOfService() {
+    return termsOfServiceRepository
+        .getTermsOfService()
+        .onErrorResumeNext(this::onGetTermsOfServiceError);
   }
 
   /**

--- a/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
@@ -173,23 +173,21 @@ public class MainViewModel extends AbstractViewModel {
   }
 
   public Observable<NavDirections> onSignedIn() {
-    return termsOfServiceRepository
-        .getTermsOfService()
-        .onErrorResumeNext(this::onGetTermsOfServiceError)
-        .map(Optional::of)
-        .defaultIfEmpty(Optional.empty())
-        .map(this::onGetTermsOfServiceComplete)
-        .toObservable();
+    hideProgressDialog();
+    if (termsOfServiceRepository.isTermsOfServiceAccepted()) {
+      return Observable.just(HomeScreenFragmentDirections.showHomeScreen());
+    } else {
+      return termsOfServiceRepository
+          .getTermsOfService()
+          .onErrorResumeNext(this::onGetTermsOfServiceError)
+          .map(TermsOfService::getText)
+          .map(this::onGetTermsOfServiceComplete)
+          .toObservable();
+    }
   }
 
-  private NavDirections onGetTermsOfServiceComplete(Optional<TermsOfService> termsOfService) {
-    hideProgressDialog();
-    if (termsOfService.isEmpty() || termsOfServiceRepository.isTermsOfServiceAccepted()) {
-      return HomeScreenFragmentDirections.showHomeScreen();
-    } else {
-      return SignInFragmentDirections.showTermsOfService()
-          .setTermsOfServiceText(termsOfService.get().getText());
-    }
+  private NavDirections onGetTermsOfServiceComplete(String termsOfServiceText) {
+    return SignInFragmentDirections.showTermsOfService().setTermsOfServiceText(termsOfServiceText);
   }
 
   /**

--- a/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
@@ -67,7 +67,6 @@ public class MainViewModel extends AbstractViewModel {
   private final FeatureRepository featureRepository;
   private final UserRepository userRepository;
   private final TermsOfServiceRepository termsOfServiceRepository;
-  private final Navigator navigator;
   private final EphemeralPopups popups;
 
   public Optional<TermsOfService> termsOfService = Optional.empty();
@@ -86,7 +85,6 @@ public class MainViewModel extends AbstractViewModel {
     this.featureRepository = featureRepository;
     this.termsOfServiceRepository = termsOfServiceRepository;
     this.userRepository = userRepository;
-    this.navigator = navigator;
     this.popups = popups;
 
     // TODO: Move to background service.
@@ -134,16 +132,15 @@ public class MainViewModel extends AbstractViewModel {
     switch (signInState.state()) {
       case SIGNED_OUT:
         // TODO: Check auth status whenever fragments resumes.
-        onSignedOut();
-        break;
+        return onSignedOut();
       case SIGNING_IN:
         showProgressDialog();
         break;
       case SIGNED_IN:
         return onSignedIn();
       case ERROR:
-        onSignInError(signInState);
-        break;
+        Timber.d("Authentication error : %s", signInState.error());
+        return onSignInError();
       default:
         Timber.e("Unhandled state: %s", signInState.state());
         break;
@@ -159,20 +156,19 @@ public class MainViewModel extends AbstractViewModel {
     signInProgressDialogVisibility.postValue(false);
   }
 
-  private void onSignInError(SignInState signInState) {
-    Timber.d("Authentication error : %s", signInState.error());
+  private Observable<NavDirections> onSignInError() {
     popups.showError(R.string.sign_in_unsuccessful);
-    onSignedOut();
+    return onSignedOut();
   }
 
-  void onSignedOut() {
+  private Observable<NavDirections> onSignedOut() {
     hideProgressDialog();
     projectRepository.clearActiveProject();
     userRepository.clearUserPreferences();
-    navigator.navigate(SignInFragmentDirections.showSignInScreen());
+    return Observable.just(SignInFragmentDirections.showSignInScreen());
   }
 
-  public Observable<NavDirections> onSignedIn() {
+  private Observable<NavDirections> onSignedIn() {
     hideProgressDialog();
     if (termsOfServiceRepository.isTermsOfServiceAccepted()) {
       return Observable.just(HomeScreenFragmentDirections.showHomeScreen());

--- a/gnd/src/main/java/com/google/android/gnd/system/auth/SignInState.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/auth/SignInState.java
@@ -36,12 +36,12 @@ public class SignInState extends ValueOrError<User> {
     this.state = state;
   }
 
-  SignInState(User user) {
+  public SignInState(User user) {
     super(user, null);
     this.state = State.SIGNED_IN;
   }
 
-  SignInState(Throwable error) {
+  public SignInState(Throwable error) {
     super(null, error);
     this.state = State.ERROR;
   }

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -18,6 +18,7 @@ package com.google.android.gnd;
 
 import com.google.android.gnd.model.AuditInfo;
 import com.google.android.gnd.model.Project;
+import com.google.android.gnd.model.TermsOfService;
 import com.google.android.gnd.model.User;
 import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.model.feature.PointFeature;
@@ -38,6 +39,9 @@ public class FakeData {
   public static final String LAYER_NO_FORM_ID = "LAYER_NO_FORM_ID";
   public static final String LAYER_NO_FORM_NAME = "Fake name for layer with no form";
   public static final String LAYER_NO_FORM_COLOR = "#00ff00";
+
+  public static final TermsOfService TEST_TERMS_OF_SERVICE =
+      TermsOfService.builder().setId("1").setText("Test Terms").build();
 
   public static final User TEST_USER =
       User.builder().setId("user_id").setEmail("user@gmail.com").setDisplayName("User").build();

--- a/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.gnd.ui;
+package com.google.android.gnd;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -24,10 +24,6 @@ import static org.mockito.Mockito.when;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.navigation.NavDirections;
-import com.google.android.gnd.FakeData;
-import com.google.android.gnd.MainViewModel;
-import com.google.android.gnd.R;
-import com.google.android.gnd.TestObservers;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.TermsOfService;
 import com.google.android.gnd.model.User;
@@ -93,6 +89,7 @@ public class MainViewModelTest {
 
   @Inject Schedulers schedulers;
 
+  // TODO: Inject this dependency instead of instantiating manually.
   private FakeAuthenticationManager authenticationManager;
   private MainViewModel viewModel;
 

--- a/gnd/src/test/java/com/google/android/gnd/ui/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/MainViewModelTest.java
@@ -16,40 +16,47 @@
 
 package com.google.android.gnd.ui;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.navigation.NavDirections;
+import com.google.android.gnd.FakeData;
 import com.google.android.gnd.MainViewModel;
+import com.google.android.gnd.R;
+import com.google.android.gnd.TestObservers;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.TermsOfService;
-import com.google.android.gnd.model.form.Element;
-import com.google.android.gnd.model.form.Field;
-import com.google.android.gnd.model.form.Form;
-import com.google.android.gnd.model.layer.Layer;
-import com.google.android.gnd.model.layer.Style;
+import com.google.android.gnd.model.User;
 import com.google.android.gnd.persistence.local.LocalDatabaseModule;
-import com.google.android.gnd.persistence.local.LocalValueStore;
-import com.google.android.gnd.persistence.remote.RemoteDataStore;
 import com.google.android.gnd.repository.FeatureRepository;
 import com.google.android.gnd.repository.ProjectRepository;
 import com.google.android.gnd.repository.TermsOfServiceRepository;
 import com.google.android.gnd.repository.UserRepository;
 import com.google.android.gnd.rx.Schedulers;
 import com.google.android.gnd.rx.SchedulersModule;
+import com.google.android.gnd.rx.annotations.Hot;
 import com.google.android.gnd.system.auth.AuthenticationManager;
 import com.google.android.gnd.system.auth.SignInState;
 import com.google.android.gnd.system.auth.SignInState.State;
+import com.google.android.gnd.ui.common.EphemeralPopups;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.home.HomeScreenFragmentDirections;
 import com.google.android.gnd.ui.signin.SignInFragmentDirections;
-import com.google.common.collect.ImmutableList;
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import dagger.hilt.android.testing.HiltTestApplication;
 import dagger.hilt.android.testing.UninstallModules;
+import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.Subject;
 import java8.util.Optional;
 import javax.inject.Inject;
 import org.junit.Before;
@@ -57,122 +64,184 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @HiltAndroidTest
-@UninstallModules({SchedulersModule.class,
-    LocalDatabaseModule.class})
+@UninstallModules({SchedulersModule.class, LocalDatabaseModule.class})
 @Config(application = HiltTestApplication.class)
 @RunWith(RobolectricTestRunner.class)
 public class MainViewModelTest {
 
-  private static final TermsOfService TOS = TermsOfService.builder().setId("1")
-      .setText("Test Terms").build();
+  private static final TermsOfService TEST_TERMS_OF_SERVICE =
+      TermsOfService.builder().setId("1").setText("Test Terms").build();
 
-  private static final Observable<SignInState> SIGN_IN_STATE =
-      Observable.just(new SignInState(State.SIGNED_IN));
+  private static final User TEST_USER = FakeData.TEST_USER;
 
-  private static final Field TEST_FIELD =
-      Field.newBuilder()
-          .setId("field id")
-          .setIndex(1)
-          .setLabel("field label")
-          .setRequired(false)
-          .setType(Field.Type.TEXT_FIELD)
-          .build();
+  private static final Flowable<Optional<Project>> TEST_ACTIVE_PROJECT =
+      Flowable.just(Optional.of(FakeData.TEST_PROJECT));
 
-  private static final Form TEST_FORM =
-      Form.newBuilder()
-          .setId("form id")
-          .setElements(ImmutableList.of(Element.ofField(TEST_FIELD)))
-          .build();
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
+  @Rule public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+  @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
-  private static final Layer TEST_LAYER =
-      Layer.newBuilder()
-          .setId("layer id")
-          .setName("heading title")
-          .setDefaultStyle(Style.builder().setColor("000").build())
-          .setForm(TEST_FORM)
-          .build();
+  @Mock ProjectRepository mockProjectRepository;
+  @Mock FeatureRepository mockFeatureRepository;
+  @Mock UserRepository mockUserRepository;
+  @Mock TermsOfServiceRepository mockTosRepository;
+  @Mock EphemeralPopups mockPopups;
+  @Mock Navigator mockNavigator;
 
-  private static final Project TEST_PROJECT =
-      Project.newBuilder()
-          .setId("project id")
-          .setTitle("project 1")
-          .setDescription("foo description")
-          .putLayer("layer id", TEST_LAYER)
-          .build();
+  @Inject Schedulers schedulers;
 
-
-  private static final Flowable<Optional<Project>> TEST_ACTIVE_PROJECT  =
-      Flowable.just(Optional.of(TEST_PROJECT));
-
-  @Rule
-  public MockitoRule rule = MockitoJUnit.rule();
-  @Rule
-  public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
-  @Rule
-  public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
-
-  public MainViewModel mainViewModel;
-
-  @Mock
-  RemoteDataStore mockRemoteDataStore;
-
-  @Mock
-  AuthenticationManager mockAuthenticationManager;
-
-  @Mock
-  ProjectRepository mockProjectRepository;
-
-  @Mock
-  FeatureRepository mockFeatureRepository;
-  @Mock
-  UserRepository mockUserRepository;
-  @Mock
-  TermsOfServiceRepository mockTermsOfServiceRepository;
-
-  @Inject
-  Navigator navigator;
-  @Inject
-  LocalValueStore localValueStore;
-  @Inject
-  Schedulers schedulers;
+  private FakeAuthenticationManager authenticationManager;
+  private MainViewModel viewModel;
 
   @Before
   public void setup() {
     hiltRule.inject();
 
-    when(mockAuthenticationManager.getSignInState()).thenReturn(SIGN_IN_STATE);
+    // TODO: Add a test for syncFeatures
     when(mockProjectRepository.getActiveProject()).thenReturn(TEST_ACTIVE_PROJECT);
 
-    // returning empty terms of service by default.
-    when(mockRemoteDataStore.loadTermsOfService()).thenReturn(Maybe.empty());
-    mockProjectRepository = new ProjectRepository(null, null, mockRemoteDataStore, localValueStore);
+    authenticationManager = new FakeAuthenticationManager();
+    viewModel =
+        new MainViewModel(
+            mockProjectRepository,
+            mockFeatureRepository,
+            mockUserRepository,
+            mockTosRepository,
+            mockNavigator,
+            authenticationManager,
+            mockPopups,
+            schedulers);
+  }
 
-    mockTermsOfServiceRepository =
-        new TermsOfServiceRepository(
-            mockRemoteDataStore,
-            localValueStore);
-    mainViewModel = new MainViewModel(mockProjectRepository, mockFeatureRepository,
-        mockUserRepository,
-        mockTermsOfServiceRepository, navigator, mockAuthenticationManager, null, schedulers);
+  private void assertProgressDialogVisible(boolean visible) {
+    TestObservers.observeUntilFirstChange(viewModel.getSignInProgressDialogVisibility());
+    assertThat(viewModel.getSignInProgressDialogVisibility().getValue()).isEqualTo(visible);
+  }
+
+  private void assertNavigate(NavDirections navDirections) {
+    Mockito.verify(mockNavigator, times(1)).navigate(navDirections);
   }
 
   @Test
-  public void testSignedIn_emptyTermsOfService() {
-    mainViewModel.onSignedIn().test().assertValue(HomeScreenFragmentDirections.showHomeScreen());
+  public void testSignInStateChanged_onSignedOut() {
+    authenticationManager.signOut();
+
+    assertProgressDialogVisible(false);
+    assertNavigate(SignInFragmentDirections.showSignInScreen());
+    Mockito.verify(mockProjectRepository, times(1)).clearActiveProject();
+    Mockito.verify(mockUserRepository, times(1)).clearUserPreferences();
+    Mockito.verify(mockTosRepository, times(1)).setTermsOfServiceAccepted(false);
   }
 
   @Test
-  public void testSignedIn_filledTermsOfService() {
-    when(mockRemoteDataStore.loadTermsOfService()).thenReturn(Maybe.just(TOS));
-    mainViewModel.onSignedIn().test().assertValue(SignInFragmentDirections.showTermsOfService()
-        .setTermsOfServiceText(TOS.getText()));
+  public void testSignInStateChanged_onSigningIn() {
+    authenticationManager.signingIn();
+
+    assertProgressDialogVisible(true);
+    Mockito.verify(mockNavigator, times(0)).navigate(any());
+    Mockito.verify(mockTosRepository, times(1)).setTermsOfServiceAccepted(false);
   }
 
+  @Test
+  public void testSignInStateChanged_onSignedIn_whenTosAccepted() {
+    when(mockTosRepository.isTermsOfServiceAccepted()).thenReturn(true);
+    when(mockUserRepository.saveUser(any(User.class))).thenReturn(Completable.complete());
+
+    authenticationManager.signIn();
+
+    assertProgressDialogVisible(false);
+    assertNavigate(HomeScreenFragmentDirections.showHomeScreen());
+    Mockito.verify(mockUserRepository, times(1)).saveUser(TEST_USER);
+    Mockito.verify(mockTosRepository, times(0)).setTermsOfServiceAccepted(anyBoolean());
+  }
+
+  @Test
+  public void testSignInStateChanged_onSignedIn_whenTosNotAccepted() {
+    when(mockTosRepository.isTermsOfServiceAccepted()).thenReturn(false);
+    when(mockUserRepository.saveUser(any(User.class))).thenReturn(Completable.complete());
+    when(mockTosRepository.getTermsOfService()).thenReturn(Maybe.just(TEST_TERMS_OF_SERVICE));
+
+    authenticationManager.signIn();
+
+    assertProgressDialogVisible(false);
+    assertNavigate(
+        SignInFragmentDirections.showTermsOfService()
+            .setTermsOfServiceText(TEST_TERMS_OF_SERVICE.getText()));
+    Mockito.verify(mockUserRepository, times(1)).saveUser(TEST_USER);
+    Mockito.verify(mockTosRepository, times(0)).setTermsOfServiceAccepted(anyBoolean());
+  }
+
+  @Test
+  public void testSignInStateChanged_onSignedIn_whenTosNotAcceptedAndFailedToGetRemoteTos() {
+    when(mockTosRepository.isTermsOfServiceAccepted()).thenReturn(false);
+    when(mockUserRepository.saveUser(any(User.class))).thenReturn(Completable.complete());
+    when(mockTosRepository.getTermsOfService()).thenReturn(Maybe.error(new Exception("foo_error")));
+    TestObserver<Integer> testErrorObserver = viewModel.getUnrecoverableErrors().test();
+
+    authenticationManager.signIn();
+
+    assertProgressDialogVisible(false);
+    Mockito.verify(mockNavigator, times(0)).navigate(any());
+    Mockito.verify(mockUserRepository, times(1)).saveUser(TEST_USER);
+    testErrorObserver.assertValue(R.string.config_load_error);
+    Mockito.verify(mockTosRepository, times(0)).setTermsOfServiceAccepted(anyBoolean());
+  }
+
+  @Test
+  public void testSignInStateChanged_onSignInError() {
+    authenticationManager.error();
+
+    Mockito.verify(mockPopups, times(1)).showError(R.string.sign_in_unsuccessful);
+    assertProgressDialogVisible(false);
+    assertNavigate(SignInFragmentDirections.showSignInScreen());
+    Mockito.verify(mockProjectRepository, times(1)).clearActiveProject();
+    Mockito.verify(mockUserRepository, times(1)).clearUserPreferences();
+    Mockito.verify(mockTosRepository, times(1)).setTermsOfServiceAccepted(false);
+  }
+
+  private static class FakeAuthenticationManager implements AuthenticationManager {
+
+    @Hot(replays = true)
+    private final Subject<SignInState> behaviourSubject = BehaviorSubject.create();
+
+    @Override
+    public Observable<SignInState> getSignInState() {
+      return behaviourSubject;
+    }
+
+    @Override
+    public User getCurrentUser() {
+      return TEST_USER;
+    }
+
+    @Override
+    public void init() {
+      // do nothing
+    }
+
+    public void error() {
+      behaviourSubject.onNext(new SignInState(new Exception("sign-in error")));
+    }
+
+    public void signingIn() {
+      behaviourSubject.onNext(new SignInState(State.SIGNING_IN));
+    }
+
+    @Override
+    public void signIn() {
+      behaviourSubject.onNext(new SignInState(TEST_USER));
+    }
+
+    @Override
+    public void signOut() {
+      behaviourSubject.onNext(new SignInState(State.SIGNED_OUT));
+    }
+  }
 }
-

--- a/gnd/src/test/java/com/google/android/gnd/ui/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/MainViewModelTest.java
@@ -76,13 +76,9 @@ import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 public class MainViewModelTest {
 
-  private static final TermsOfService TEST_TERMS_OF_SERVICE =
-      TermsOfService.builder().setId("1").setText("Test Terms").build();
-
+  private static final TermsOfService TEST_TERMS_OF_SERVICE = FakeData.TEST_TERMS_OF_SERVICE;
+  private static final Optional<Project> TEST_ACTIVE_PROJECT = Optional.of(FakeData.TEST_PROJECT);
   private static final User TEST_USER = FakeData.TEST_USER;
-
-  private static final Flowable<Optional<Project>> TEST_ACTIVE_PROJECT =
-      Flowable.just(Optional.of(FakeData.TEST_PROJECT));
 
   @Rule public MockitoRule rule = MockitoJUnit.rule();
   @Rule public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
@@ -105,7 +101,7 @@ public class MainViewModelTest {
     hiltRule.inject();
 
     // TODO: Add a test for syncFeatures
-    when(mockProjectRepository.getActiveProject()).thenReturn(TEST_ACTIVE_PROJECT);
+    when(mockProjectRepository.getActiveProject()).thenReturn(Flowable.just(TEST_ACTIVE_PROJECT));
 
     authenticationManager = new FakeAuthenticationManager();
     viewModel =

--- a/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/BaseFeatureDetailsViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/BaseFeatureDetailsViewModelTest.java
@@ -41,7 +41,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-public class FeatureDetailsViewModelTest {
+/** Base test class for FeatureDetailsViewModel. */
+public class BaseFeatureDetailsViewModelTest {
 
   static final User TEST_USER_OWNER =
       FakeData.TEST_USER.toBuilder().setEmail("user1@gmail.com").build();
@@ -77,19 +78,11 @@ public class FeatureDetailsViewModelTest {
 
   FeatureDetailsViewModel viewModel;
 
-  static PointFeature createPointFeature() {
-    return createPointFeature(FakeData.TEST_USER);
-  }
-
   static PointFeature createPointFeature(User user) {
     return FakeData.TEST_POINT_FEATURE.toBuilder()
         .setProject(TEST_PROJECT)
         .setCreated(AuditInfo.now(user))
         .build();
-  }
-
-  static PolygonFeature createPolygonFeature() {
-    return createPolygonFeature(FakeData.TEST_USER);
   }
 
   static PolygonFeature createPolygonFeature(User user) {

--- a/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/DeleteMenuVisibilityTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/DeleteMenuVisibilityTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class DeleteMenuVisibilityTest extends FeatureDetailsViewModelTest {
+public class DeleteMenuVisibilityTest extends BaseFeatureDetailsViewModelTest {
 
   @Parameterized.Parameter() public User user;
 

--- a/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/MoveMenuVisibilityTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/MoveMenuVisibilityTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class MoveMenuVisibilityTest extends FeatureDetailsViewModelTest {
+public class MoveMenuVisibilityTest extends BaseFeatureDetailsViewModelTest {
 
   @Parameterized.Parameter() public User user;
 

--- a/gnd/src/test/java/com/google/android/gnd/ui/tos/TermsOfServiceViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/tos/TermsOfServiceViewModelTest.java
@@ -16,68 +16,43 @@
 
 package com.google.android.gnd.ui.tos;
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
-import com.google.android.gnd.persistence.local.LocalDatabaseModule;
-import com.google.android.gnd.persistence.local.LocalValueStore;
-import com.google.android.gnd.persistence.remote.RemoteDataStore;
 import com.google.android.gnd.repository.TermsOfServiceRepository;
-import com.google.android.gnd.rx.SchedulersModule;
 import com.google.android.gnd.ui.common.Navigator;
+import com.google.android.gnd.ui.home.HomeScreenFragmentDirections;
 import com.google.common.truth.Truth;
-import dagger.hilt.android.testing.HiltAndroidRule;
-import dagger.hilt.android.testing.HiltAndroidTest;
-import dagger.hilt.android.testing.HiltTestApplication;
-import dagger.hilt.android.testing.UninstallModules;
-import javax.inject.Inject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
-@HiltAndroidTest
-@UninstallModules({SchedulersModule.class, LocalDatabaseModule.class})
-@Config(application = HiltTestApplication.class)
-@RunWith(RobolectricTestRunner.class)
 public class TermsOfServiceViewModelTest {
 
   @Rule public MockitoRule rule = MockitoJUnit.rule();
 
-  @Rule public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+  @Mock Navigator mockNavigator;
+  @Mock TermsOfServiceRepository mockRepository;
 
-  public TermsOfServiceViewModel termsOfServiceViewModel;
-  @Rule public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
-  @Inject Navigator navigator;
-  @Inject LocalValueStore localValueStore;
-  @Mock RemoteDataStore mockRemoteDataStore;
-  private TermsOfServiceRepository termsOfServiceRepository;
+  private TermsOfServiceViewModel viewModel;
 
   @Before
   public void before() {
-    hiltRule.inject();
-    termsOfServiceRepository = new TermsOfServiceRepository(mockRemoteDataStore, localValueStore);
-    termsOfServiceViewModel = new TermsOfServiceViewModel(navigator, termsOfServiceRepository);
+    viewModel = new TermsOfServiceViewModel(mockNavigator, mockRepository);
   }
 
   @Test
-  public void testButtonClick() {
-    termsOfServiceViewModel.onButtonClicked();
-    Truth.assertThat(termsOfServiceRepository.isTermsOfServiceAccepted()).isTrue();
+  public void testOnButtonClicked() {
+    viewModel.onButtonClicked();
+    Mockito.verify(mockRepository, Mockito.times(1)).setTermsOfServiceAccepted(true);
+    Mockito.verify(mockNavigator, Mockito.times(1))
+        .navigate(HomeScreenFragmentDirections.showHomeScreen());
   }
 
   @Test
   public void testTermsOfServiceText() {
-    termsOfServiceViewModel.setTermsOfServiceText("Terms Text");
-    Truth.assertThat(termsOfServiceViewModel.getTermsOfServiceText()).isEqualTo("Terms Text");
-  }
-
-  @Test
-  public void testTermsOfServiceText_mismatch() {
-    termsOfServiceViewModel.setTermsOfServiceText("Terms");
-    Truth.assertThat(termsOfServiceViewModel.getTermsOfServiceText()).isNotEqualTo("Terms Text");
+    viewModel.setTermsOfServiceText("Terms Text");
+    Truth.assertThat(viewModel.getTermsOfServiceText()).isEqualTo("Terms Text");
   }
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #971

<!-- PR description. -->

Things done: 
 * Remove unused code
 * Cleanup TermsOfServiceViewModelTest
 * Cleanup MainViewModel
 * Remove inconsistent tests in MainViewModelTest and replace with exhaustive unit tests for user signin flow.
 * Fixes a bug in which the offline user is unable to use the app even if they are signed in and terms of service is accepted


<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

Changes verified by running the app manually and performing sign-in / sign-out operations.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
