### PR TITLE
Downgrade compile and target SDK version to avoid ANR problem in Dev build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,9 +103,9 @@ tasks.dependencyUpdates {
 }
 
 ext {
-    androidCompileSdk = 30
+    androidCompileSdk = 28
     androidMinSdk = 16
-    androidTargetSdk = 30
+    androidTargetSdk = 26
 
     gmsMapsVersion = '17.0.1'
 }


### PR DESCRIPTION
The strict mode doesn't seem to work well when there are many GeoJsonLayer on the map that results in a lot of setting listener calls to Maps SDK.

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

