### PR TITLE
refactor: rename OfflineBasemap -> OfflineArea

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/model/basemap/OfflineArea.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/basemap/OfflineArea.java
@@ -21,7 +21,7 @@ import com.google.auto.value.AutoValue;
 
 /** An area is a contiguous set of tiles that form a geodesic rectangle. */
 @AutoValue
-public abstract class OfflineBaseMap {
+public abstract class OfflineArea {
 
   public abstract String getId();
 
@@ -41,7 +41,7 @@ public abstract class OfflineBaseMap {
   }
 
   public static Builder newBuilder() {
-    return new AutoValue_OfflineBaseMap.Builder();
+    return new AutoValue_OfflineArea.Builder();
   }
 
   @AutoValue.Builder
@@ -55,6 +55,6 @@ public abstract class OfflineBaseMap {
 
     public abstract Builder setName(String name);
 
-    public abstract OfflineBaseMap build();
+    public abstract OfflineArea build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStore.java
@@ -19,7 +19,7 @@ package com.google.android.gnd.persistence.local;
 import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.User;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
+import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.FeatureMutation;
@@ -193,18 +193,18 @@ public interface LocalDataStore {
    * the area into the local data store.
    */
   @Cold
-  Completable insertOrUpdateOfflineArea(OfflineBaseMap area);
+  Completable insertOrUpdateOfflineArea(OfflineArea area);
 
   /** Returns all queued, failed, and completed offline areas from the local data store. */
   @Cold(terminates = false)
-  Flowable<ImmutableList<OfflineBaseMap>> getOfflineAreasOnceAndStream();
+  Flowable<ImmutableList<OfflineArea>> getOfflineAreasOnceAndStream();
 
   /** Delete an offline area and any associated tiles that are no longer needed. */
   @Cold
   Completable deleteOfflineArea(String offlineAreaId);
 
   /** Returns the offline area with the specified id. */
-  Single<OfflineBaseMap> getOfflineAreaById(String id);
+  Single<OfflineArea> getOfflineAreaById(String id);
 
   /**
    * Update the area count of an existing tile source in the local data store with the area count of

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStoreModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStoreModule.java
@@ -26,7 +26,7 @@ import com.google.android.gnd.persistence.local.room.dao.LayerDao;
 import com.google.android.gnd.persistence.local.room.dao.MultipleChoiceDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationMutationDao;
-import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapDao;
+import com.google.android.gnd.persistence.local.room.dao.OfflineAreaDao;
 import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.OptionDao;
 import com.google.android.gnd.persistence.local.room.dao.ProjectDao;
@@ -99,7 +99,7 @@ public abstract class LocalDataStoreModule {
   }
 
   @Provides
-  static OfflineBaseMapDao offlineAreaDao(LocalDatabase localDatabase) {
+  static OfflineAreaDao offlineAreaDao(LocalDatabase localDatabase) {
     return localDatabase.offlineAreaDao();
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
@@ -31,7 +31,7 @@ import com.google.android.gnd.persistence.local.room.dao.LayerDao;
 import com.google.android.gnd.persistence.local.room.dao.MultipleChoiceDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationMutationDao;
-import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapDao;
+import com.google.android.gnd.persistence.local.room.dao.OfflineAreaDao;
 import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.OptionDao;
 import com.google.android.gnd.persistence.local.room.dao.ProjectDao;
@@ -45,7 +45,7 @@ import com.google.android.gnd.persistence.local.room.entity.LayerEntity;
 import com.google.android.gnd.persistence.local.room.entity.MultipleChoiceEntity;
 import com.google.android.gnd.persistence.local.room.entity.ObservationEntity;
 import com.google.android.gnd.persistence.local.room.entity.ObservationMutationEntity;
-import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapEntity;
+import com.google.android.gnd.persistence.local.room.entity.OfflineAreaEntity;
 import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapSourceEntity;
 import com.google.android.gnd.persistence.local.room.entity.OptionEntity;
 import com.google.android.gnd.persistence.local.room.entity.ProjectEntity;
@@ -57,7 +57,7 @@ import com.google.android.gnd.persistence.local.room.models.FieldEntityType;
 import com.google.android.gnd.persistence.local.room.models.MultipleChoiceEntityType;
 import com.google.android.gnd.persistence.local.room.models.MutationEntitySyncStatus;
 import com.google.android.gnd.persistence.local.room.models.MutationEntityType;
-import com.google.android.gnd.persistence.local.room.models.OfflineBaseMapEntityState;
+import com.google.android.gnd.persistence.local.room.models.OfflineAreaEntityState;
 import com.google.android.gnd.persistence.local.room.models.TileEntityState;
 
 /**
@@ -81,7 +81,7 @@ import com.google.android.gnd.persistence.local.room.models.TileEntityState;
       ObservationEntity.class,
       ObservationMutationEntity.class,
       TileSourceEntity.class,
-      OfflineBaseMapEntity.class,
+      OfflineAreaEntity.class,
       UserEntity.class
     },
     version = Config.DB_VERSION,
@@ -95,7 +95,7 @@ import com.google.android.gnd.persistence.local.room.models.TileEntityState;
   JsonArrayTypeConverter.class,
   JsonObjectTypeConverter.class,
   MutationEntitySyncStatus.class,
-  OfflineBaseMapEntityState.class,
+  OfflineAreaEntityState.class,
   StyleTypeConverter.class,
   TileEntityState.class
 })
@@ -125,7 +125,7 @@ public abstract class LocalDatabase extends RoomDatabase {
 
   public abstract TileSourceDao tileSourceDao();
 
-  public abstract OfflineBaseMapDao offlineAreaDao();
+  public abstract OfflineAreaDao offlineAreaDao();
 
   public abstract UserDao userDao();
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -29,7 +29,7 @@ import com.google.android.gnd.model.Mutation.SyncStatus;
 import com.google.android.gnd.model.Mutation.Type;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.User;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
+import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.model.feature.Feature;
 import com.google.android.gnd.model.feature.FeatureMutation;
@@ -54,7 +54,7 @@ import com.google.android.gnd.persistence.local.room.dao.LayerDao;
 import com.google.android.gnd.persistence.local.room.dao.MultipleChoiceDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationMutationDao;
-import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapDao;
+import com.google.android.gnd.persistence.local.room.dao.OfflineAreaDao;
 import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.OptionDao;
 import com.google.android.gnd.persistence.local.room.dao.ProjectDao;
@@ -69,7 +69,7 @@ import com.google.android.gnd.persistence.local.room.entity.LayerEntity;
 import com.google.android.gnd.persistence.local.room.entity.MultipleChoiceEntity;
 import com.google.android.gnd.persistence.local.room.entity.ObservationEntity;
 import com.google.android.gnd.persistence.local.room.entity.ObservationMutationEntity;
-import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapEntity;
+import com.google.android.gnd.persistence.local.room.entity.OfflineAreaEntity;
 import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapSourceEntity;
 import com.google.android.gnd.persistence.local.room.entity.OptionEntity;
 import com.google.android.gnd.persistence.local.room.entity.ProjectEntity;
@@ -118,7 +118,8 @@ public class RoomLocalDataStore implements LocalDataStore {
   @Inject ObservationMutationDao observationMutationDao;
   @Inject TileSourceDao tileSourceDao;
   @Inject UserDao userDao;
-  @Inject OfflineBaseMapDao offlineBaseMapDao;
+  @Inject
+  OfflineAreaDao offlineAreaDao;
   @Inject OfflineBaseMapSourceDao offlineBaseMapSourceDao;
   @Inject Schedulers schedulers;
   @Inject FileUtil fileUtil;
@@ -666,36 +667,36 @@ public class RoomLocalDataStore implements LocalDataStore {
   }
 
   @Override
-  public Completable insertOrUpdateOfflineArea(OfflineBaseMap area) {
-    return offlineBaseMapDao
-        .insertOrUpdate(OfflineBaseMapEntity.fromArea(area))
+  public Completable insertOrUpdateOfflineArea(OfflineArea area) {
+    return offlineAreaDao
+        .insertOrUpdate(OfflineAreaEntity.fromArea(area))
         .subscribeOn(schedulers.io());
   }
 
   @Override
-  public Flowable<ImmutableList<OfflineBaseMap>> getOfflineAreasOnceAndStream() {
-    return offlineBaseMapDao
+  public Flowable<ImmutableList<OfflineArea>> getOfflineAreasOnceAndStream() {
+    return offlineAreaDao
         .findAllOnceAndStream()
-        .map(areas -> stream(areas).map(OfflineBaseMapEntity::toArea).collect(toImmutableList()))
+        .map(areas -> stream(areas).map(OfflineAreaEntity::toArea).collect(toImmutableList()))
         .subscribeOn(schedulers.io());
   }
 
   @Override
-  public Single<OfflineBaseMap> getOfflineAreaById(String id) {
-    return offlineBaseMapDao
+  public Single<OfflineArea> getOfflineAreaById(String id) {
+    return offlineAreaDao
         .findById(id)
-        .map(OfflineBaseMapEntity::toArea)
+        .map(OfflineAreaEntity::toArea)
         .toSingle()
         .subscribeOn(schedulers.io());
   }
 
   @Override
   public Completable deleteOfflineArea(String id) {
-    return offlineBaseMapDao
+    return offlineAreaDao
         .findById(id)
         .toSingle()
         .doOnSubscribe(__ -> Timber.d("Deleting offline area: %s", id))
-        .flatMapCompletable(offlineBaseMapDao::delete)
+        .flatMapCompletable(offlineAreaDao::delete)
         .subscribeOn(schedulers.io());
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/OfflineAreaDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/OfflineAreaDao.java
@@ -18,17 +18,17 @@ package com.google.android.gnd.persistence.local.room.dao;
 
 import androidx.room.Dao;
 import androidx.room.Query;
-import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapEntity;
+import com.google.android.gnd.persistence.local.room.entity.OfflineAreaEntity;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import java.util.List;
 
-/** Provides read/write operations for writing {@link OfflineBaseMapEntity} to the local db. */
+/** Provides read/write operations for writing {@link OfflineAreaEntity} to the local db. */
 @Dao
-public interface OfflineBaseMapDao extends BaseDao<OfflineBaseMapEntity> {
+public interface OfflineAreaDao extends BaseDao<OfflineAreaEntity> {
   @Query("SELECT * FROM offline_base_map")
-  Flowable<List<OfflineBaseMapEntity>> findAllOnceAndStream();
+  Flowable<List<OfflineAreaEntity>> findAllOnceAndStream();
 
   @Query("SELECT * FROM offline_base_map WHERE id = :id")
-  Maybe<OfflineBaseMapEntity> findById(String id);
+  Maybe<OfflineAreaEntity> findById(String id);
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OfflineAreaEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/OfflineAreaEntity.java
@@ -22,14 +22,14 @@ import androidx.room.Entity;
 import androidx.room.PrimaryKey;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
-import com.google.android.gnd.persistence.local.room.models.OfflineBaseMapEntityState;
+import com.google.android.gnd.model.basemap.OfflineArea;
+import com.google.android.gnd.persistence.local.room.models.OfflineAreaEntityState;
 import com.google.auto.value.AutoValue;
 
-/** Represents a {@link OfflineBaseMap} in the local data store. */
+/** Represents a {@link OfflineArea} in the local data store. */
 @AutoValue
 @Entity(tableName = "offline_base_map")
-public abstract class OfflineBaseMapEntity {
+public abstract class OfflineAreaEntity {
   @AutoValue.CopyAnnotations
   @NonNull
   @PrimaryKey
@@ -44,7 +44,7 @@ public abstract class OfflineBaseMapEntity {
   @AutoValue.CopyAnnotations
   @NonNull
   @ColumnInfo(name = "state")
-  public abstract OfflineBaseMapEntityState getState();
+  public abstract OfflineAreaEntityState getState();
 
   @AutoValue.CopyAnnotations
   @ColumnInfo(name = "north")
@@ -62,66 +62,66 @@ public abstract class OfflineBaseMapEntity {
   @ColumnInfo(name = "west")
   public abstract double getWest();
 
-  public static OfflineBaseMap toArea(OfflineBaseMapEntity offlineBaseMapEntity) {
-    LatLng northEast = new LatLng(offlineBaseMapEntity.getNorth(), offlineBaseMapEntity.getEast());
-    LatLng southWest = new LatLng(offlineBaseMapEntity.getSouth(), offlineBaseMapEntity.getWest());
+  public static OfflineArea toArea(OfflineAreaEntity offlineAreaEntity) {
+    LatLng northEast = new LatLng(offlineAreaEntity.getNorth(), offlineAreaEntity.getEast());
+    LatLng southWest = new LatLng(offlineAreaEntity.getSouth(), offlineAreaEntity.getWest());
     LatLngBounds bounds = new LatLngBounds(southWest, northEast);
 
-    return OfflineBaseMap.newBuilder()
-        .setId(offlineBaseMapEntity.getId())
+    return OfflineArea.newBuilder()
+        .setId(offlineAreaEntity.getId())
         .setBounds(bounds)
-        .setState(toAreaState(offlineBaseMapEntity.getState()))
-        .setName(offlineBaseMapEntity.getName())
+        .setState(toAreaState(offlineAreaEntity.getState()))
+        .setName(offlineAreaEntity.getName())
         .build();
   }
 
-  private static OfflineBaseMap.State toAreaState(OfflineBaseMapEntityState state) {
+  private static OfflineArea.State toAreaState(OfflineAreaEntityState state) {
     switch (state) {
       case PENDING:
-        return OfflineBaseMap.State.PENDING;
+        return OfflineArea.State.PENDING;
       case IN_PROGRESS:
-        return OfflineBaseMap.State.IN_PROGRESS;
+        return OfflineArea.State.IN_PROGRESS;
       case DOWNLOADED:
-        return OfflineBaseMap.State.DOWNLOADED;
+        return OfflineArea.State.DOWNLOADED;
       case FAILED:
-        return OfflineBaseMap.State.FAILED;
+        return OfflineArea.State.FAILED;
       default:
         throw new IllegalArgumentException("Unknown area state: " + state);
     }
   }
 
-  public static OfflineBaseMapEntity fromArea(OfflineBaseMap offlineBaseMap) {
-    OfflineBaseMapEntity.Builder entity =
-        OfflineBaseMapEntity.builder()
-            .setId(offlineBaseMap.getId())
-            .setState(toEntityState(offlineBaseMap.getState()))
-            .setName(offlineBaseMap.getName())
-            .setNorth(offlineBaseMap.getBounds().northeast.latitude)
-            .setEast(offlineBaseMap.getBounds().northeast.longitude)
-            .setSouth(offlineBaseMap.getBounds().southwest.latitude)
-            .setWest(offlineBaseMap.getBounds().southwest.longitude);
+  public static OfflineAreaEntity fromArea(OfflineArea offlineArea) {
+    OfflineAreaEntity.Builder entity =
+        OfflineAreaEntity.builder()
+            .setId(offlineArea.getId())
+            .setState(toEntityState(offlineArea.getState()))
+            .setName(offlineArea.getName())
+            .setNorth(offlineArea.getBounds().northeast.latitude)
+            .setEast(offlineArea.getBounds().northeast.longitude)
+            .setSouth(offlineArea.getBounds().southwest.latitude)
+            .setWest(offlineArea.getBounds().southwest.longitude);
     return entity.build();
   }
 
-  private static OfflineBaseMapEntityState toEntityState(OfflineBaseMap.State state) {
+  private static OfflineAreaEntityState toEntityState(OfflineArea.State state) {
     switch (state) {
       case PENDING:
-        return OfflineBaseMapEntityState.PENDING;
+        return OfflineAreaEntityState.PENDING;
       case IN_PROGRESS:
-        return OfflineBaseMapEntityState.IN_PROGRESS;
+        return OfflineAreaEntityState.IN_PROGRESS;
       case FAILED:
-        return OfflineBaseMapEntityState.FAILED;
+        return OfflineAreaEntityState.FAILED;
       case DOWNLOADED:
-        return OfflineBaseMapEntityState.DOWNLOADED;
+        return OfflineAreaEntityState.DOWNLOADED;
       default:
-        return OfflineBaseMapEntityState.UNKNOWN;
+        return OfflineAreaEntityState.UNKNOWN;
     }
   }
 
-  public static OfflineBaseMapEntity create(
+  public static OfflineAreaEntity create(
       String id,
       String name,
-      OfflineBaseMapEntityState state,
+      OfflineAreaEntityState state,
       double north,
       double east,
       double south,
@@ -138,7 +138,7 @@ public abstract class OfflineBaseMapEntity {
   }
 
   public static Builder builder() {
-    return new AutoValue_OfflineBaseMapEntity.Builder();
+    return new AutoValue_OfflineAreaEntity.Builder();
   }
 
   @AutoValue.Builder
@@ -148,7 +148,7 @@ public abstract class OfflineBaseMapEntity {
 
     public abstract Builder setName(String newName);
 
-    public abstract Builder setState(OfflineBaseMapEntityState newState);
+    public abstract Builder setState(OfflineAreaEntityState newState);
 
     public abstract Builder setNorth(double coordinate);
 
@@ -158,6 +158,6 @@ public abstract class OfflineBaseMapEntity {
 
     public abstract Builder setWest(double coordinate);
 
-    public abstract OfflineBaseMapEntity build();
+    public abstract OfflineAreaEntity build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/models/OfflineAreaEntityState.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/models/OfflineAreaEntityState.java
@@ -19,14 +19,14 @@ package com.google.android.gnd.persistence.local.room.models;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.room.TypeConverter;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
+import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.persistence.local.room.IntEnum;
 
 /**
  * A database representation of OfflineArea download states. Mirrors the states specified by the
- * model {@link OfflineBaseMap}
+ * model {@link OfflineArea}
  */
-public enum OfflineBaseMapEntityState implements IntEnum {
+public enum OfflineAreaEntityState implements IntEnum {
   UNKNOWN(0),
   PENDING(1),
   IN_PROGRESS(2),
@@ -35,7 +35,7 @@ public enum OfflineBaseMapEntityState implements IntEnum {
 
   private final int intValue;
 
-  OfflineBaseMapEntityState(int intValue) {
+  OfflineAreaEntityState(int intValue) {
     this.intValue = intValue;
   }
 
@@ -44,13 +44,13 @@ public enum OfflineBaseMapEntityState implements IntEnum {
   }
 
   @TypeConverter
-  public static int toInt(@Nullable OfflineBaseMapEntityState value) {
+  public static int toInt(@Nullable OfflineAreaEntityState value) {
     return IntEnum.toInt(value, UNKNOWN);
   }
 
   @NonNull
   @TypeConverter
-  public static OfflineBaseMapEntityState fromInt(int intValue) {
+  public static OfflineAreaEntityState fromInt(int intValue) {
     return IntEnum.fromInt(values(), intValue, UNKNOWN);
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/common/ViewModelModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/common/ViewModelModule.java
@@ -35,9 +35,9 @@ import com.google.android.gnd.ui.home.mapcontainer.FeatureRepositionViewModel;
 import com.google.android.gnd.ui.home.mapcontainer.MapContainerViewModel;
 import com.google.android.gnd.ui.home.mapcontainer.PolygonDrawingViewModel;
 import com.google.android.gnd.ui.observationdetails.ObservationDetailsViewModel;
-import com.google.android.gnd.ui.offlinebasemap.OfflineBaseMapsViewModel;
-import com.google.android.gnd.ui.offlinebasemap.selector.OfflineBaseMapSelectorViewModel;
-import com.google.android.gnd.ui.offlinebasemap.viewer.OfflineBaseMapViewerViewModel;
+import com.google.android.gnd.ui.offlinebasemap.OfflineAreasViewModel;
+import com.google.android.gnd.ui.offlinebasemap.selector.OfflineAreaSelectorViewModel;
+import com.google.android.gnd.ui.offlinebasemap.viewer.OfflineAreaViewerViewModel;
 import com.google.android.gnd.ui.projectselector.ProjectSelectorViewModel;
 import com.google.android.gnd.ui.signin.SignInViewModel;
 import com.google.android.gnd.ui.syncstatus.SyncStatusViewModel;
@@ -70,8 +70,8 @@ public abstract class ViewModelModule {
 
   @Binds
   @IntoMap
-  @ViewModelKey(OfflineBaseMapSelectorViewModel.class)
-  abstract ViewModel bindOfflineAreaSelectorViewModel(OfflineBaseMapSelectorViewModel viewModel);
+  @ViewModelKey(OfflineAreaSelectorViewModel.class)
+  abstract ViewModel bindOfflineAreaSelectorViewModel(OfflineAreaSelectorViewModel viewModel);
 
   @Binds
   @IntoMap
@@ -80,13 +80,13 @@ public abstract class ViewModelModule {
 
   @Binds
   @IntoMap
-  @ViewModelKey(OfflineBaseMapsViewModel.class)
-  abstract ViewModel bindOfflineAreasViewModel(OfflineBaseMapsViewModel viewModel);
+  @ViewModelKey(OfflineAreasViewModel.class)
+  abstract ViewModel bindOfflineAreasViewModel(OfflineAreasViewModel viewModel);
 
   @Binds
   @IntoMap
-  @ViewModelKey(OfflineBaseMapViewerViewModel.class)
-  abstract ViewModel bindOfflineAreaViewerViewModel(OfflineBaseMapViewerViewModel viewModel);
+  @ViewModelKey(OfflineAreaViewerViewModel.class)
+  abstract ViewModel bindOfflineAreaViewerViewModel(OfflineAreaViewerViewModel viewModel);
 
   @Binds
   @IntoMap

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
@@ -39,7 +39,7 @@ import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.model.feature.PointFeature;
 import com.google.android.gnd.model.feature.PolygonFeature;
 import com.google.android.gnd.repository.FeatureRepository;
-import com.google.android.gnd.repository.OfflineBaseMapRepository;
+import com.google.android.gnd.repository.OfflineAreaRepository;
 import com.google.android.gnd.repository.ProjectRepository;
 import com.google.android.gnd.rx.BooleanOrError;
 import com.google.android.gnd.rx.Event;
@@ -139,7 +139,7 @@ public class MapContainerViewModel extends AbstractViewModel {
       ProjectRepository projectRepository,
       FeatureRepository featureRepository,
       LocationManager locationManager,
-      OfflineBaseMapRepository offlineBaseMapRepository) {
+      OfflineAreaRepository offlineAreaRepository) {
     // THIS SHOULD NOT BE CALLED ON CONFIG CHANGE
     this.resources = resources;
     this.projectRepository = projectRepository;
@@ -195,7 +195,7 @@ public class MapContainerViewModel extends AbstractViewModel {
 
     this.mbtilesFilePaths =
         LiveDataReactiveStreams.fromPublisher(
-            offlineBaseMapRepository
+            offlineAreaRepository
                 .getDownloadedTileSourcesOnceAndStream()
                 .map(set -> stream(set).map(TileSource::getPath).collect(toImmutableSet())));
     disposeOnClear(projectRepository.getActiveProject().subscribe(this::onProjectChange));

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/OfflineAreaListAdapter.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/OfflineAreaListAdapter.java
@@ -22,24 +22,24 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.gnd.databinding.OfflineBaseMapListItemBinding;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
+import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.common.collect.ImmutableList;
 
-class OfflineBaseMapListAdapter extends RecyclerView.Adapter<OfflineBaseMapListAdapter.ViewHolder> {
+class OfflineAreaListAdapter extends RecyclerView.Adapter<OfflineAreaListAdapter.ViewHolder> {
   private final Navigator navigator;
-  private ImmutableList<OfflineBaseMap> offlineBaseMaps;
+  private ImmutableList<OfflineArea> offlineAreas;
 
   public static class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
     public OfflineBaseMapListItemBinding binding;
     public int position;
-    private ImmutableList<OfflineBaseMap> areas;
+    private ImmutableList<OfflineArea> areas;
     private final Navigator navigator;
 
     ViewHolder(
         OfflineBaseMapListItemBinding binding,
-        ImmutableList<OfflineBaseMap> areas,
+        ImmutableList<OfflineArea> areas,
         Navigator navigator) {
       super(binding.getRoot());
       this.binding = binding;
@@ -52,41 +52,41 @@ class OfflineBaseMapListAdapter extends RecyclerView.Adapter<OfflineBaseMapListA
     public void onClick(View v) {
       if (areas.size() > 0) {
         String id = areas.get(position).getId();
-        navigator.navigate(OfflineBaseMapsFragmentDirections.viewOfflineArea(id));
+        navigator.navigate(OfflineAreasFragmentDirections.viewOfflineArea(id));
       }
     }
   }
 
-  OfflineBaseMapListAdapter(Navigator navigator) {
-    offlineBaseMaps = ImmutableList.of();
+  OfflineAreaListAdapter(Navigator navigator) {
+    offlineAreas = ImmutableList.of();
     this.navigator = navigator;
   }
 
   @NonNull
   @Override
-  public OfflineBaseMapListAdapter.ViewHolder onCreateViewHolder(
+  public OfflineAreaListAdapter.ViewHolder onCreateViewHolder(
       @NonNull ViewGroup parent, int viewType) {
     OfflineBaseMapListItemBinding offlineAreasListItemBinding =
         OfflineBaseMapListItemBinding.inflate(
             LayoutInflater.from(parent.getContext()), parent, false);
 
-    return new ViewHolder(offlineAreasListItemBinding, offlineBaseMaps, navigator);
+    return new ViewHolder(offlineAreasListItemBinding, offlineAreas, navigator);
   }
 
   @Override
   public void onBindViewHolder(@NonNull ViewHolder viewHolder, int position) {
-    viewHolder.areas = offlineBaseMaps;
-    viewHolder.binding.offlineAreaName.setText(offlineBaseMaps.get(position).getName());
+    viewHolder.areas = offlineAreas;
+    viewHolder.binding.offlineAreaName.setText(offlineAreas.get(position).getName());
     viewHolder.position = position;
   }
 
   @Override
   public int getItemCount() {
-    return offlineBaseMaps.size();
+    return offlineAreas.size();
   }
 
-  void update(ImmutableList<OfflineBaseMap> offlineBaseMaps) {
-    this.offlineBaseMaps = offlineBaseMaps;
+  void update(ImmutableList<OfflineArea> offlineAreas) {
+    this.offlineAreas = offlineAreas;
     notifyDataSetChanged();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/OfflineAreasFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/OfflineAreasFragment.java
@@ -36,19 +36,19 @@ import javax.inject.Inject;
  * need or access the UI used to select and download a new area to the device.
  */
 @AndroidEntryPoint
-public class OfflineBaseMapsFragment extends AbstractFragment {
+public class OfflineAreasFragment extends AbstractFragment {
   @Inject Navigator navigator;
 
-  private OfflineBaseMapListAdapter offlineBaseMapListAdapter;
-  private OfflineBaseMapsViewModel viewModel;
+  private OfflineAreaListAdapter offlineAreaListAdapter;
+  private OfflineAreasViewModel viewModel;
 
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    viewModel = getViewModel(OfflineBaseMapsViewModel.class);
-    offlineBaseMapListAdapter = new OfflineBaseMapListAdapter(navigator);
+    viewModel = getViewModel(OfflineAreasViewModel.class);
+    offlineAreaListAdapter = new OfflineAreaListAdapter(navigator);
 
-    viewModel.getOfflineAreas().observe(this, offlineBaseMapListAdapter::update);
+    viewModel.getOfflineAreas().observe(this, offlineAreaListAdapter::update);
   }
 
   @Override
@@ -66,7 +66,7 @@ public class OfflineBaseMapsFragment extends AbstractFragment {
     RecyclerView recyclerView = binding.offlineAreasList;
     recyclerView.setHasFixedSize(true);
     recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
-    recyclerView.setAdapter(offlineBaseMapListAdapter);
+    recyclerView.setAdapter(offlineAreaListAdapter);
 
     return binding.getRoot();
   }

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/OfflineAreasViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/OfflineAreasViewModel.java
@@ -19,8 +19,8 @@ package com.google.android.gnd.ui.offlinebasemap;
 import android.view.View;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
-import com.google.android.gnd.repository.OfflineBaseMapRepository;
+import com.google.android.gnd.model.basemap.OfflineArea;
+import com.google.android.gnd.repository.OfflineAreaRepository;
 import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.common.collect.ImmutableList;
@@ -31,18 +31,18 @@ import timber.log.Timber;
 /**
  * View model for the offline area manager fragment. Handles the current list of downloaded areas.
  */
-public class OfflineBaseMapsViewModel extends AbstractViewModel {
+public class OfflineAreasViewModel extends AbstractViewModel {
 
-  private final LiveData<ImmutableList<OfflineBaseMap>> offlineAreas;
+  private final LiveData<ImmutableList<OfflineArea>> offlineAreas;
   private final LiveData<Integer> noAreasMessageVisibility;
 
   private final Navigator navigator;
 
   @Inject
-  OfflineBaseMapsViewModel(Navigator navigator, OfflineBaseMapRepository offlineBaseMapRepository) {
+  OfflineAreasViewModel(Navigator navigator, OfflineAreaRepository offlineAreaRepository) {
     this.navigator = navigator;
-    Flowable<ImmutableList<OfflineBaseMap>> offlineAreas =
-        offlineBaseMapRepository
+    Flowable<ImmutableList<OfflineArea>> offlineAreas =
+        offlineAreaRepository
             .getOfflineAreasOnceAndStream()
             .doOnError(
                 throwable ->
@@ -58,14 +58,14 @@ public class OfflineBaseMapsViewModel extends AbstractViewModel {
 
   /** Navigate to the offline area selector UI from the offline basemaps UI. */
   public void showOfflineAreaSelector() {
-    navigator.navigate(OfflineBaseMapsFragmentDirections.showOfflineAreaSelector());
+    navigator.navigate(OfflineAreasFragmentDirections.showOfflineAreaSelector());
   }
 
   /**
    * Returns the current list of downloaded offline basemaps available for viewing. If an unexpected
    * error accessing the local store is encountered, emits an empty list, circumventing the error.
    */
-  LiveData<ImmutableList<OfflineBaseMap>> getOfflineAreas() {
+  LiveData<ImmutableList<OfflineArea>> getOfflineAreas() {
     return offlineAreas;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/selector/OfflineAreaSelectorFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/selector/OfflineAreaSelectorFragment.java
@@ -33,26 +33,26 @@ import com.google.android.gnd.ui.common.AbstractMapViewerFragment;
 import com.google.android.gnd.ui.common.EphemeralPopups;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.map.MapFragment;
-import com.google.android.gnd.ui.offlinebasemap.selector.OfflineBaseMapSelectorViewModel.DownloadMessage;
+import com.google.android.gnd.ui.offlinebasemap.selector.OfflineAreaSelectorViewModel.DownloadMessage;
 import dagger.hilt.android.AndroidEntryPoint;
 import javax.inject.Inject;
 
 @AndroidEntryPoint
-public class OfflineBaseMapSelectorFragment extends AbstractMapViewerFragment {
+public class OfflineAreaSelectorFragment extends AbstractMapViewerFragment {
 
   @Inject Navigator navigator;
   @Inject EphemeralPopups popups;
 
-  private OfflineBaseMapSelectorViewModel viewModel;
+  private OfflineAreaSelectorViewModel viewModel;
 
-  public static OfflineBaseMapSelectorFragment newInstance() {
-    return new OfflineBaseMapSelectorFragment();
+  public static OfflineAreaSelectorFragment newInstance() {
+    return new OfflineAreaSelectorFragment();
   }
 
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    viewModel = getViewModel(OfflineBaseMapSelectorViewModel.class);
+    viewModel = getViewModel(OfflineAreaSelectorViewModel.class);
     viewModel.getDownloadMessages().observe(this, e -> e.ifUnhandled(this::onDownloadMessage));
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/selector/OfflineAreaSelectorViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/selector/OfflineAreaSelectorViewModel.java
@@ -22,11 +22,11 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gnd.R;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
-import com.google.android.gnd.model.basemap.OfflineBaseMap.State;
+import com.google.android.gnd.model.basemap.OfflineArea;
+import com.google.android.gnd.model.basemap.OfflineArea.State;
 import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.persistence.uuid.OfflineUuidGenerator;
-import com.google.android.gnd.repository.OfflineBaseMapRepository;
+import com.google.android.gnd.repository.OfflineAreaRepository;
 import com.google.android.gnd.rx.Event;
 import com.google.android.gnd.rx.Nil;
 import com.google.android.gnd.rx.annotations.Hot;
@@ -38,14 +38,14 @@ import io.reactivex.processors.PublishProcessor;
 import javax.inject.Inject;
 import timber.log.Timber;
 
-public class OfflineBaseMapSelectorViewModel extends AbstractViewModel {
+public class OfflineAreaSelectorViewModel extends AbstractViewModel {
 
   enum DownloadMessage {
     STARTED,
     FAILURE
   }
 
-  @Hot private final FlowableProcessor<OfflineBaseMap> downloadClicks = PublishProcessor.create();
+  @Hot private final FlowableProcessor<OfflineArea> downloadClicks = PublishProcessor.create();
   @Hot private final FlowableProcessor<Nil> remoteTileRequests = PublishProcessor.create();
   private final LiveData<Event<DownloadMessage>> messages;
   private final Flowable<ImmutableList<TileSource>> remoteTileSources;
@@ -54,16 +54,16 @@ public class OfflineBaseMapSelectorViewModel extends AbstractViewModel {
   private final Resources resources;
 
   @Inject
-  OfflineBaseMapSelectorViewModel(
-      OfflineBaseMapRepository offlineBaseMapRepository,
+  OfflineAreaSelectorViewModel(
+      OfflineAreaRepository offlineAreaRepository,
       OfflineUuidGenerator offlineUuidGenerator,
       Resources resources) {
     this.messages =
         LiveDataReactiveStreams.fromPublisher(
             downloadClicks.switchMapSingle(
                 baseMap ->
-                    offlineBaseMapRepository
-                        .addAreaAndEnqueue(baseMap)
+                    offlineAreaRepository
+                        .addOfflineAreaAndEnqueue(baseMap)
                         .toSingleDefault(DownloadMessage.STARTED)
                         .onErrorReturn(this::onEnqueueError)
                         .map(Event::create)));
@@ -71,7 +71,7 @@ public class OfflineBaseMapSelectorViewModel extends AbstractViewModel {
     this.resources = resources;
     this.remoteTileSources =
             remoteTileRequests.switchMapSingle(
-                __ -> offlineBaseMapRepository.getTileSources());
+                __ -> offlineAreaRepository.getTileSources());
   }
 
   private DownloadMessage onEnqueueError(Throwable e) {
@@ -94,7 +94,7 @@ public class OfflineBaseMapSelectorViewModel extends AbstractViewModel {
     }
 
     downloadClicks.onNext(
-        OfflineBaseMap.newBuilder()
+        OfflineArea.newBuilder()
             .setBounds(viewport)
             .setId(offlineUuidGenerator.generateUuid())
             .setState(State.PENDING)

--- a/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/viewer/OfflineAreaViewerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/offlinebasemap/viewer/OfflineAreaViewerFragment.java
@@ -23,7 +23,7 @@ import android.view.ViewGroup;
 import androidx.annotation.Nullable;
 import com.google.android.gnd.MainActivity;
 import com.google.android.gnd.databinding.OfflineBaseMapViewerFragBinding;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
+import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.ui.common.AbstractMapViewerFragment;
 import com.google.android.gnd.ui.common.Navigator;
 import com.google.android.gnd.ui.map.MapFragment;
@@ -35,21 +35,21 @@ import javax.inject.Inject;
  * device.
  */
 @AndroidEntryPoint
-public class OfflineBaseMapViewerFragment extends AbstractMapViewerFragment {
+public class OfflineAreaViewerFragment extends AbstractMapViewerFragment {
 
   @Inject Navigator navigator;
 
-  private OfflineBaseMapViewerViewModel viewModel;
+  private OfflineAreaViewerViewModel viewModel;
 
   @Inject
-  public OfflineBaseMapViewerFragment() {}
+  public OfflineAreaViewerFragment() {}
 
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    OfflineBaseMapViewerFragmentArgs args =
-        OfflineBaseMapViewerFragmentArgs.fromBundle(getArguments());
-    viewModel = getViewModel(OfflineBaseMapViewerViewModel.class);
+    OfflineAreaViewerFragmentArgs args =
+        OfflineAreaViewerFragmentArgs.fromBundle(getArguments());
+    viewModel = getViewModel(OfflineAreaViewerViewModel.class);
     viewModel.loadOfflineArea(args);
     viewModel.getOfflineArea().observe(this, this::panMap);
   }
@@ -72,8 +72,8 @@ public class OfflineBaseMapViewerFragment extends AbstractMapViewerFragment {
     map.disableGestures();
   }
 
-  private void panMap(OfflineBaseMap offlineBaseMap) {
-    getMapFragment().setViewport(offlineBaseMap.getBounds());
+  private void panMap(OfflineArea offlineArea) {
+    getMapFragment().setViewport(offlineArea.getBounds());
   }
 
   /** Removes the area associated with this fragment from the user's device. */

--- a/gnd/src/main/java/com/google/android/gnd/ui/syncstatus/SyncStatusViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/syncstatus/SyncStatusViewModel.java
@@ -29,7 +29,7 @@ import com.google.android.gnd.repository.ProjectRepository;
 import com.google.android.gnd.rx.annotations.Cold;
 import com.google.android.gnd.ui.common.AbstractViewModel;
 import com.google.android.gnd.ui.common.Navigator;
-import com.google.android.gnd.ui.offlinebasemap.OfflineBaseMapsFragmentDirections;
+import com.google.android.gnd.ui.offlinebasemap.OfflineAreasFragmentDirections;
 import com.google.common.collect.ImmutableList;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
@@ -84,7 +84,7 @@ public class SyncStatusViewModel extends AbstractViewModel {
   }
 
   public void showOfflineAreaSelector() {
-    navigator.navigate(OfflineBaseMapsFragmentDirections.showOfflineAreaSelector());
+    navigator.navigate(OfflineAreasFragmentDirections.showOfflineAreaSelector());
   }
 
   @Cold(replays = true, terminates = false)

--- a/gnd/src/main/res/layout/offline_base_map_selector_frag.xml
+++ b/gnd/src/main/res/layout/offline_base_map_selector_frag.xml
@@ -23,7 +23,7 @@
   <data>
     <variable
       name="viewModel"
-      type="com.google.android.gnd.ui.offlinebasemap.selector.OfflineBaseMapSelectorViewModel" />
+      type="com.google.android.gnd.ui.offlinebasemap.selector.OfflineAreaSelectorViewModel" />
   </data>
 
   <FrameLayout

--- a/gnd/src/main/res/layout/offline_base_map_viewer_frag.xml
+++ b/gnd/src/main/res/layout/offline_base_map_viewer_frag.xml
@@ -22,7 +22,7 @@
   <data>
     <variable
       name="viewModel"
-      type="com.google.android.gnd.ui.offlinebasemap.viewer.OfflineBaseMapViewerViewModel" />
+      type="com.google.android.gnd.ui.offlinebasemap.viewer.OfflineAreaViewerViewModel" />
   </data>
 
   <androidx.constraintlayout.widget.ConstraintLayout

--- a/gnd/src/main/res/layout/offline_base_maps_frag.xml
+++ b/gnd/src/main/res/layout/offline_base_maps_frag.xml
@@ -23,7 +23,7 @@
   <data>
     <variable
       name="viewModel"
-      type="com.google.android.gnd.ui.offlinebasemap.OfflineBaseMapsViewModel" />
+      type="com.google.android.gnd.ui.offlinebasemap.OfflineAreasViewModel" />
   </data>
 
   <androidx.constraintlayout.widget.ConstraintLayout

--- a/gnd/src/main/res/navigation/nav_graph.xml
+++ b/gnd/src/main/res/navigation/nav_graph.xml
@@ -86,7 +86,7 @@
     tools:layout="@layout/sync_status_frag"></fragment>
   <fragment
     android:id="@+id/offline_areas_fragment"
-    android:name="com.google.android.gnd.ui.offlinebasemap.OfflineBaseMapsFragment"
+    android:name="com.google.android.gnd.ui.offlinebasemap.OfflineAreasFragment"
     android:label="@string/offline_base_maps"
     tools:layout="@layout/offline_base_maps_frag">
     <action
@@ -101,7 +101,7 @@
   </fragment>
   <fragment
     android:id="@+id/offline_area_selector_fragment"
-    android:name="com.google.android.gnd.ui.offlinebasemap.selector.OfflineBaseMapSelectorFragment"
+    android:name="com.google.android.gnd.ui.offlinebasemap.selector.OfflineAreaSelectorFragment"
     android:label="@string/offline_base_map_selector"
     tools:layout="@layout/offline_base_map_selector_frag">
     <action
@@ -110,7 +110,7 @@
   </fragment>
   <fragment
     android:id="@+id/offline_area_viewer_fragment"
-    android:name="com.google.android.gnd.ui.offlinebasemap.viewer.OfflineBaseMapViewerFragment"
+    android:name="com.google.android.gnd.ui.offlinebasemap.viewer.OfflineAreaViewerFragment"
     android:label="@string/offline_base_map_viewer_title"
     tools:layout="@layout/offline_base_map_viewer_frag">
     <argument

--- a/gnd/src/test/java/com/google/android/gnd/persistence/local/LocalDataStoreTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/persistence/local/LocalDataStoreTest.java
@@ -26,7 +26,7 @@ import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Mutation.SyncStatus;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.User;
-import com.google.android.gnd.model.basemap.OfflineBaseMap;
+import com.google.android.gnd.model.basemap.OfflineArea;
 import com.google.android.gnd.model.basemap.tile.TileSource;
 import com.google.android.gnd.model.basemap.tile.TileSource.State;
 import com.google.android.gnd.model.feature.Feature;
@@ -177,11 +177,11 @@ public class LocalDataStoreTest extends BaseHiltTest {
           .setBasemapReferenceCount(1)
           .build();
 
-  private static final OfflineBaseMap TEST_OFFLINE_AREA =
-      OfflineBaseMap.newBuilder()
+  private static final OfflineArea TEST_OFFLINE_AREA =
+      OfflineArea.newBuilder()
           .setId("id_1")
           .setBounds(LatLngBounds.builder().include(new LatLng(0.0, 0.0)).build())
-          .setState(OfflineBaseMap.State.PENDING)
+          .setState(OfflineArea.State.PENDING)
           .setName("Test Area")
           .build();
 


### PR DESCRIPTION
Rename `OfflineBaseMap` to `OfflineArea`.

This is the first in a few class renames we'll perform in relation to offline base maps functionality in order to make the code clearer.