### PR TITLE
Skip to home screen if terms of service is missing after signing in

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
@@ -41,6 +41,7 @@ import com.google.android.gnd.ui.common.SharedViewModel;
 import com.google.android.gnd.ui.home.HomeScreenFragmentDirections;
 import com.google.android.gnd.ui.signin.SignInFragmentDirections;
 import io.reactivex.Completable;
+import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import java8.util.Optional;
 import javax.inject.Inject;
@@ -162,6 +163,11 @@ public class MainViewModel extends AbstractViewModel {
     return Observable.just(SignInFragmentDirections.showSignInScreen());
   }
 
+  /**
+   * @return {@link NavDirections} to {@link com.google.android.gnd.ui.home.HomeScreenFragment} if
+   *     the ToS is already accepted or if it is missing from remote config. Else returns {@link
+   *     NavDirections} to {@link com.google.android.gnd.ui.tos.TermsOfServiceFragment}.
+   */
   private Observable<NavDirections> onSignedIn() {
     hideProgressDialog();
     if (termsOfServiceRepository.isTermsOfServiceAccepted()) {
@@ -172,6 +178,7 @@ public class MainViewModel extends AbstractViewModel {
           .map(TermsOfService::getText)
           .map(text -> SignInFragmentDirections.showTermsOfService().setTermsOfServiceText(text))
           .cast(NavDirections.class)
+          .switchIfEmpty(Maybe.just(HomeScreenFragmentDirections.showHomeScreen()))
           .toObservable();
     }
   }

--- a/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/MainViewModel.java
@@ -163,11 +163,6 @@ public class MainViewModel extends AbstractViewModel {
     return Observable.just(SignInFragmentDirections.showSignInScreen());
   }
 
-  /**
-   * @return {@link NavDirections} to {@link com.google.android.gnd.ui.home.HomeScreenFragment} if
-   *     the ToS is already accepted or if it is missing from remote config. Else returns {@link
-   *     NavDirections} to {@link com.google.android.gnd.ui.tos.TermsOfServiceFragment}.
-   */
   private Observable<NavDirections> onSignedIn() {
     hideProgressDialog();
     if (termsOfServiceRepository.isTermsOfServiceAccepted()) {

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -42,7 +42,7 @@ public class FakeData {
   public static final String LAYER_NO_FORM_COLOR = "#00ff00";
 
   public static final TermsOfService TEST_TERMS_OF_SERVICE =
-      TermsOfService.builder().setId("1").setText("Test Terms").build();
+      TermsOfService.builder().setId(TERMS_OF_SERVICE_ID).setText(TERMS_OF_SERVICE).build();
 
   public static final User TEST_USER =
       User.builder().setId("user_id").setEmail("user@gmail.com").setDisplayName("User").build();

--- a/gnd/src/sharedTest/java/com/google/android/gnd/persistence/remote/FakeRemoteDataStore.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/persistence/remote/FakeRemoteDataStore.java
@@ -37,6 +37,7 @@ import io.reactivex.Maybe;
 import io.reactivex.Single;
 import java.util.Collections;
 import java.util.List;
+import java8.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -60,11 +61,7 @@ public class FakeRemoteDataStore implements RemoteDataStore {
           .setAcl(ImmutableMap.of(FakeData.TEST_USER.getEmail(), "contributor"))
           .build();
 
-  private final TermsOfService testTermsOfService =
-      TermsOfService.builder()
-          .setId(FakeData.TERMS_OF_SERVICE_ID)
-          .setText(FakeData.TERMS_OF_SERVICE)
-          .build();
+  private Optional<TermsOfService> termsOfService = Optional.of(FakeData.TEST_TERMS_OF_SERVICE);
 
   private final Project testProjectWithNoLayers =
       Project.newBuilder()
@@ -111,9 +108,13 @@ public class FakeRemoteDataStore implements RemoteDataStore {
     return Single.just(getTestProject());
   }
 
+  public void setTermsOfService(Optional<TermsOfService> termsOfService) {
+    this.termsOfService = termsOfService;
+  }
+
   @Override
   public @Cold Maybe<TermsOfService> loadTermsOfService() {
-    return Maybe.just(testTermsOfService);
+    return termsOfService.isEmpty() ? Maybe.empty() : Maybe.just(termsOfService.get());
   }
 
   @Override

--- a/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
@@ -22,6 +22,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import android.content.SharedPreferences;
 import androidx.navigation.NavDirections;
+import com.google.android.gnd.persistence.remote.FakeRemoteDataStore;
 import com.google.android.gnd.repository.TermsOfServiceRepository;
 import com.google.android.gnd.repository.UserRepository;
 import com.google.android.gnd.system.auth.FakeAuthenticationManager;
@@ -33,6 +34,7 @@ import com.google.android.gnd.ui.signin.SignInFragmentDirections;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import io.reactivex.observers.TestObserver;
 import java.util.NoSuchElementException;
+import java8.util.Optional;
 import javax.inject.Inject;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +47,7 @@ import org.robolectric.shadows.ShadowToast;
 public class MainViewModelTest extends BaseHiltTest {
 
   @Inject FakeAuthenticationManager fakeAuthenticationManager;
+  @Inject FakeRemoteDataStore fakeRemoteDataStore;
   @Inject MainViewModel viewModel;
   @Inject Navigator navigator;
   @Inject SharedPreferences sharedPreferences;
@@ -136,6 +139,20 @@ public class MainViewModelTest extends BaseHiltTest {
   }
 
   @Test
+  public void testSignInStateChanged_onSignedIn_whenTosMissing() {
+    tosRepository.setTermsOfServiceAccepted(false);
+    fakeRemoteDataStore.setTermsOfService(Optional.empty());
+
+    fakeAuthenticationManager.setUser(TEST_USER);
+    fakeAuthenticationManager.signIn();
+
+    verifyProgressDialogVisible(false);
+    verifyNavigationRequested(HomeScreenFragmentDirections.showHomeScreen());
+    verifyUserSaved();
+    assertThat(tosRepository.isTermsOfServiceAccepted()).isFalse();
+  }
+
+  @Test
   public void testSignInStateChanged_onSignInError() {
     setupUserPreferences();
 
@@ -147,20 +164,5 @@ public class MainViewModelTest extends BaseHiltTest {
     verifyUserPreferencesCleared();
     verifyUserNotSaved();
     assertThat(tosRepository.isTermsOfServiceAccepted()).isFalse();
-  }
-
-  @Test
-  public void testSignInStateChanged_onSignedIn_whenTosMissing() {
-    when(mockTosRepository.isTermsOfServiceAccepted()).thenReturn(false);
-    when(mockUserRepository.saveUser(any(User.class))).thenReturn(Completable.complete());
-    when(mockTosRepository.getTermsOfService()).thenReturn(Maybe.empty());
-
-    fakeAuthenticationManager.setUser(TEST_USER);
-    fakeAuthenticationManager.signIn();
-
-    assertProgressDialogVisible(false);
-    assertNavigate(HomeScreenFragmentDirections.showHomeScreen());
-    Mockito.verify(mockUserRepository, times(1)).saveUser(TEST_USER);
-    Mockito.verify(mockTosRepository, times(0)).setTermsOfServiceAccepted(anyBoolean());
   }
 }

--- a/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
@@ -146,4 +146,19 @@ public class MainViewModelTest extends BaseHiltTest {
     Mockito.verify(mockUserRepository, times(1)).clearUserPreferences();
     Mockito.verify(mockTosRepository, times(1)).setTermsOfServiceAccepted(false);
   }
+
+  @Test
+  public void testSignInStateChanged_onSignedIn_whenTosMissing() {
+    when(mockTosRepository.isTermsOfServiceAccepted()).thenReturn(false);
+    when(mockUserRepository.saveUser(any(User.class))).thenReturn(Completable.complete());
+    when(mockTosRepository.getTermsOfService()).thenReturn(Maybe.empty());
+
+    fakeAuthenticationManager.setUser(TEST_USER);
+    fakeAuthenticationManager.signIn();
+
+    assertProgressDialogVisible(false);
+    assertNavigate(HomeScreenFragmentDirections.showHomeScreen());
+    Mockito.verify(mockUserRepository, times(1)).saveUser(TEST_USER);
+    Mockito.verify(mockTosRepository, times(0)).setTermsOfServiceAccepted(anyBoolean());
+  }
 }

--- a/gnd/src/test/java/com/google/android/gnd/repository/TermsOfServiceRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/TermsOfServiceRepositoryTest.java
@@ -21,7 +21,9 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.android.gnd.BaseHiltTest;
 import com.google.android.gnd.FakeData;
 import com.google.android.gnd.model.TermsOfService;
+import com.google.android.gnd.persistence.remote.FakeRemoteDataStore;
 import dagger.hilt.android.testing.HiltAndroidTest;
+import java8.util.Optional;
 import javax.inject.Inject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,10 +33,13 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class TermsOfServiceRepositoryTest extends BaseHiltTest {
 
+  @Inject FakeRemoteDataStore fakeRemoteDataStore;
   @Inject TermsOfServiceRepository termsOfServiceRepository;
 
   @Test
   public void testGetTermsOfService() {
+    fakeRemoteDataStore.setTermsOfService(Optional.of(FakeData.TEST_TERMS_OF_SERVICE));
+
     termsOfServiceRepository
         .getTermsOfService()
         .test()
@@ -43,6 +48,13 @@ public class TermsOfServiceRepositoryTest extends BaseHiltTest {
                 .setId(FakeData.TERMS_OF_SERVICE_ID)
                 .setText(FakeData.TERMS_OF_SERVICE)
                 .build());
+  }
+
+  @Test
+  public void testGetTermsOfService_whenMissing_doesNotThrowException() {
+    fakeRemoteDataStore.setTermsOfService(Optional.empty());
+
+    termsOfServiceRepository.getTermsOfService().test().assertNoValues().assertComplete();
   }
 
   @Test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1032 

<!-- PR description. -->
Skips the terms of service fragment if the document under "/config/tos" is missing in firestore.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

Verified by removing the document from firebase and running the app locally.

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
