### PR TITLE
refactor: rename OfflineBaseMapSource -> BaseMap

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/model/Project.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/Project.java
@@ -17,7 +17,7 @@
 package com.google.android.gnd.model;
 
 import androidx.annotation.NonNull;
-import com.google.android.gnd.model.basemap.OfflineBaseMapSource;
+import com.google.android.gnd.model.basemap.BaseMap;
 import com.google.android.gnd.model.layer.Layer;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -38,7 +38,7 @@ public abstract class Project {
   protected abstract ImmutableMap<String, Layer> getLayerMap();
 
   @NonNull
-  public abstract ImmutableList<OfflineBaseMapSource> getOfflineBaseMapSources();
+  public abstract ImmutableList<BaseMap> getBaseMaps();
 
   public ImmutableList<Layer> getLayers() {
     return getLayerMap().values().asList();
@@ -73,10 +73,10 @@ public abstract class Project {
 
     public abstract Builder setAcl(ImmutableMap<String, String> acl);
 
-    public abstract ImmutableList.Builder<OfflineBaseMapSource> offlineBaseMapSourcesBuilder();
+    public abstract ImmutableList.Builder<BaseMap> baseMapsBuilder();
 
-    public Builder addOfflineBaseMapSource(OfflineBaseMapSource source) {
-      offlineBaseMapSourcesBuilder().add(source);
+    public Builder addBaseMap(BaseMap source) {
+      baseMapsBuilder().add(source);
       return this;
     }
 

--- a/gnd/src/main/java/com/google/android/gnd/model/basemap/BaseMap.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/basemap/BaseMap.java
@@ -23,32 +23,32 @@ import org.apache.commons.io.FilenameUtils;
 
 /** Represents a possible source for offline base map data. */
 @AutoValue
-public abstract class OfflineBaseMapSource {
+public abstract class BaseMap {
 
-  public enum OfflineBaseMapSourceType {
+  public enum BaseMapType {
     MBTILES_FOOTPRINTS,
     TILED_WEB_MAP,
     UNKNOWN
   }
 
-  public static OfflineBaseMapSourceType typeFromExtension(String url) {
+  public static BaseMapType typeFromExtension(String url) {
     switch (FilenameUtils.getExtension(url)) {
       case "geojson":
-        return OfflineBaseMapSourceType.MBTILES_FOOTPRINTS;
+        return BaseMapType.MBTILES_FOOTPRINTS;
       case "png":
-        return OfflineBaseMapSourceType.TILED_WEB_MAP;
+        return BaseMapType.TILED_WEB_MAP;
       default:
-        return OfflineBaseMapSourceType.UNKNOWN;
+        return BaseMapType.UNKNOWN;
     }
   }
 
   @NonNull
   public abstract URL getUrl();
 
-  public abstract OfflineBaseMapSourceType getType();
+  public abstract BaseMapType getType();
 
   public static Builder builder() {
-    return new AutoValue_OfflineBaseMapSource.Builder();
+    return new AutoValue_BaseMap.Builder();
   }
 
   @AutoValue.Builder
@@ -56,8 +56,8 @@ public abstract class OfflineBaseMapSource {
 
     public abstract Builder setUrl(@NonNull URL newUrl);
 
-    public abstract Builder setType(OfflineBaseMapSourceType type);
+    public abstract Builder setType(BaseMapType type);
 
-    public abstract OfflineBaseMapSource build();
+    public abstract BaseMap build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStoreModule.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/LocalDataStoreModule.java
@@ -18,6 +18,7 @@ package com.google.android.gnd.persistence.local;
 
 import com.google.android.gnd.persistence.local.room.LocalDatabase;
 import com.google.android.gnd.persistence.local.room.RoomLocalDataStore;
+import com.google.android.gnd.persistence.local.room.dao.BaseMapDao;
 import com.google.android.gnd.persistence.local.room.dao.FeatureDao;
 import com.google.android.gnd.persistence.local.room.dao.FeatureMutationDao;
 import com.google.android.gnd.persistence.local.room.dao.FieldDao;
@@ -27,7 +28,6 @@ import com.google.android.gnd.persistence.local.room.dao.MultipleChoiceDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationMutationDao;
 import com.google.android.gnd.persistence.local.room.dao.OfflineAreaDao;
-import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.OptionDao;
 import com.google.android.gnd.persistence.local.room.dao.ProjectDao;
 import com.google.android.gnd.persistence.local.room.dao.TileSourceDao;
@@ -104,8 +104,8 @@ public abstract class LocalDataStoreModule {
   }
 
   @Provides
-  static OfflineBaseMapSourceDao offlineBaseMapSourceDao(LocalDatabase localDatabase) {
-    return localDatabase.offlineBaseMapSourceDao();
+  static BaseMapDao baseMapDao(LocalDatabase localDatabase) {
+    return localDatabase.baseMapDao();
   }
 
   @Provides

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/LocalDatabase.java
@@ -32,11 +32,12 @@ import com.google.android.gnd.persistence.local.room.dao.MultipleChoiceDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationDao;
 import com.google.android.gnd.persistence.local.room.dao.ObservationMutationDao;
 import com.google.android.gnd.persistence.local.room.dao.OfflineAreaDao;
-import com.google.android.gnd.persistence.local.room.dao.OfflineBaseMapSourceDao;
+import com.google.android.gnd.persistence.local.room.dao.BaseMapDao;
 import com.google.android.gnd.persistence.local.room.dao.OptionDao;
 import com.google.android.gnd.persistence.local.room.dao.ProjectDao;
 import com.google.android.gnd.persistence.local.room.dao.TileSourceDao;
 import com.google.android.gnd.persistence.local.room.dao.UserDao;
+import com.google.android.gnd.persistence.local.room.entity.BaseMapEntity;
 import com.google.android.gnd.persistence.local.room.entity.FeatureEntity;
 import com.google.android.gnd.persistence.local.room.entity.FeatureMutationEntity;
 import com.google.android.gnd.persistence.local.room.entity.FieldEntity;
@@ -46,7 +47,6 @@ import com.google.android.gnd.persistence.local.room.entity.MultipleChoiceEntity
 import com.google.android.gnd.persistence.local.room.entity.ObservationEntity;
 import com.google.android.gnd.persistence.local.room.entity.ObservationMutationEntity;
 import com.google.android.gnd.persistence.local.room.entity.OfflineAreaEntity;
-import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapSourceEntity;
 import com.google.android.gnd.persistence.local.room.entity.OptionEntity;
 import com.google.android.gnd.persistence.local.room.entity.ProjectEntity;
 import com.google.android.gnd.persistence.local.room.entity.TileSourceEntity;
@@ -77,7 +77,7 @@ import com.google.android.gnd.persistence.local.room.models.TileEntityState;
       MultipleChoiceEntity.class,
       OptionEntity.class,
       ProjectEntity.class,
-      OfflineBaseMapSourceEntity.class,
+      BaseMapEntity.class,
       ObservationEntity.class,
       ObservationMutationEntity.class,
       TileSourceEntity.class,
@@ -117,7 +117,7 @@ public abstract class LocalDatabase extends RoomDatabase {
 
   public abstract ProjectDao projectDao();
 
-  public abstract OfflineBaseMapSourceDao offlineBaseMapSourceDao();
+  public abstract BaseMapDao baseMapDao();
 
   public abstract ObservationDao observationDao();
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/BaseMapDao.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/dao/BaseMapDao.java
@@ -18,11 +18,11 @@ package com.google.android.gnd.persistence.local.room.dao;
 
 import androidx.room.Dao;
 import androidx.room.Query;
-import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapSourceEntity;
+import com.google.android.gnd.persistence.local.room.entity.BaseMapEntity;
 import io.reactivex.Completable;
 
 @Dao
-public interface OfflineBaseMapSourceDao extends BaseDao<OfflineBaseMapSourceEntity> {
+public interface BaseMapDao extends BaseDao<BaseMapEntity> {
 
   @Query("DELETE FROM offline_base_map_source WHERE project_id = :projectId")
   Completable deleteByProjectId(String projectId);

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/BaseMapEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/BaseMapEntity.java
@@ -23,8 +23,8 @@ import androidx.room.Entity;
 import androidx.room.ForeignKey;
 import androidx.room.Index;
 import androidx.room.PrimaryKey;
-import com.google.android.gnd.model.basemap.OfflineBaseMapSource;
-import com.google.android.gnd.model.basemap.OfflineBaseMapSource.OfflineBaseMapSourceType;
+import com.google.android.gnd.model.basemap.BaseMap;
+import com.google.android.gnd.model.basemap.BaseMap.BaseMapType;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.AutoValue.CopyAnnotations;
 import java.net.MalformedURLException;
@@ -40,11 +40,11 @@ import java.net.URL;
             childColumns = "project_id", // NOPMD
             onDelete = ForeignKey.CASCADE),
     indices = {@Index("project_id")}) // NOPMD
-public abstract class OfflineBaseMapSourceEntity {
+public abstract class BaseMapEntity {
 
-  public static OfflineBaseMapSource toModel(OfflineBaseMapSourceEntity source)
+  public static BaseMap toModel(BaseMapEntity source)
       throws MalformedURLException {
-    return OfflineBaseMapSource.builder()
+    return BaseMap.builder()
         .setUrl(new URL(source.getUrl()))
         .setType(entityToModelType(source))
         .build();
@@ -69,53 +69,53 @@ public abstract class OfflineBaseMapSourceEntity {
   @CopyAnnotations
   @NonNull
   @ColumnInfo(name = "type")
-  public abstract OfflineBaseMapSourceEntityType getType();
+  public abstract BaseMapEntityType getType();
 
-  public enum OfflineBaseMapSourceEntityType {
+  public enum BaseMapEntityType {
     GEOJSON,
     IMAGE,
     UNKNOWN
   }
 
-  private static OfflineBaseMapSourceEntityType modelToEntityType(OfflineBaseMapSource source) {
+  private static BaseMapEntityType modelToEntityType(BaseMap source) {
     switch (source.getType()) {
       case TILED_WEB_MAP:
-        return OfflineBaseMapSourceEntityType.IMAGE;
+        return BaseMapEntityType.IMAGE;
       case MBTILES_FOOTPRINTS:
-        return OfflineBaseMapSourceEntityType.GEOJSON;
+        return BaseMapEntityType.GEOJSON;
       default:
-        return OfflineBaseMapSourceEntityType.UNKNOWN;
+        return BaseMapEntityType.UNKNOWN;
     }
   }
 
-  private static OfflineBaseMapSourceType entityToModelType(OfflineBaseMapSourceEntity source) {
+  private static BaseMapType entityToModelType(BaseMapEntity source) {
     switch (source.getType()) {
       case IMAGE:
-        return OfflineBaseMapSourceType.TILED_WEB_MAP;
+        return BaseMapType.TILED_WEB_MAP;
       case GEOJSON:
-        return OfflineBaseMapSourceType.MBTILES_FOOTPRINTS;
+        return BaseMapType.MBTILES_FOOTPRINTS;
       default:
-        return OfflineBaseMapSourceType.UNKNOWN;
+        return BaseMapType.UNKNOWN;
     }
   }
 
-  public static OfflineBaseMapSourceEntity fromModel(
-      String projectId, OfflineBaseMapSource source) {
+  public static BaseMapEntity fromModel(
+      String projectId, BaseMap source) {
 
-    return OfflineBaseMapSourceEntity.builder()
+    return BaseMapEntity.builder()
         .setProjectId(projectId)
         .setUrl(source.getUrl().toString())
         .setType(modelToEntityType(source))
         .build();
   }
 
-  public static OfflineBaseMapSourceEntity create(
-      @Nullable Integer id, String projectId, String url, OfflineBaseMapSourceEntityType type) {
+  public static BaseMapEntity create(
+      @Nullable Integer id, String projectId, String url, BaseMapEntityType type) {
     return builder().setId(id).setProjectId(projectId).setUrl(url).setType(type).build();
   }
 
   public static Builder builder() {
-    return new AutoValue_OfflineBaseMapSourceEntity.Builder();
+    return new AutoValue_BaseMapEntity.Builder();
   }
 
   @AutoValue.Builder
@@ -127,8 +127,8 @@ public abstract class OfflineBaseMapSourceEntity {
 
     public abstract Builder setUrl(@NonNull String newUrl);
 
-    public abstract Builder setType(OfflineBaseMapSourceEntityType type);
+    public abstract Builder setType(BaseMapEntityType type);
 
-    public abstract OfflineBaseMapSourceEntity build();
+    public abstract BaseMapEntity build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/ProjectEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/ProjectEntity.java
@@ -80,10 +80,10 @@ public abstract class ProjectEntity {
       LayerEntity layerEntity = layerEntityAndRelations.layerEntity;
       projectBuilder.putLayer(layerEntity.getId(), LayerEntity.toLayer(layerEntityAndRelations));
     }
-    for (OfflineBaseMapSourceEntity source :
-        projectEntityAndRelations.offlineBaseMapSourceEntityAndRelations) {
+    for (BaseMapEntity source :
+        projectEntityAndRelations.baseMapEntityAndRelations) {
       try {
-        projectBuilder.addOfflineBaseMapSource(OfflineBaseMapSourceEntity.toModel(source));
+        projectBuilder.addBaseMap(BaseMapEntity.toModel(source));
       } catch (MalformedURLException e) {
         Timber.d("Skipping basemap source with malformed URL %s", source.getUrl());
       }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/relations/ProjectEntityAndRelations.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/relations/ProjectEntityAndRelations.java
@@ -18,8 +18,8 @@ package com.google.android.gnd.persistence.local.room.relations;
 
 import androidx.room.Embedded;
 import androidx.room.Relation;
+import com.google.android.gnd.persistence.local.room.entity.BaseMapEntity;
 import com.google.android.gnd.persistence.local.room.entity.LayerEntity;
-import com.google.android.gnd.persistence.local.room.entity.OfflineBaseMapSourceEntity;
 import com.google.android.gnd.persistence.local.room.entity.ProjectEntity;
 import java.util.List;
 
@@ -38,6 +38,6 @@ public class ProjectEntityAndRelations {
   @Relation(
       parentColumn = "id",
       entityColumn = "project_id",
-      entity = OfflineBaseMapSourceEntity.class)
-  public List<OfflineBaseMapSourceEntity> offlineBaseMapSourceEntityAndRelations;
+      entity = BaseMapEntity.class)
+  public List<BaseMapEntity> baseMapEntityAndRelations;
 }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/BaseMapNestedObject.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/BaseMapNestedObject.java
@@ -18,14 +18,14 @@ package com.google.android.gnd.persistence.remote.firestore.schema;
 
 import androidx.annotation.Nullable;
 
-class OfflineBaseMapSourceNestedObject {
+class BaseMapNestedObject {
   @Nullable private String url;
 
   @SuppressWarnings("unused")
-  OfflineBaseMapSourceNestedObject() {}
+  BaseMapNestedObject() {}
 
   @SuppressWarnings("unused")
-  OfflineBaseMapSourceNestedObject(@Nullable String url) {
+  BaseMapNestedObject(@Nullable String url) {
     this.url = url;
   }
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ProjectConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ProjectConverter.java
@@ -16,11 +16,11 @@
 
 package com.google.android.gnd.persistence.remote.firestore.schema;
 
-import static com.google.android.gnd.model.basemap.OfflineBaseMapSource.typeFromExtension;
+import static com.google.android.gnd.model.basemap.BaseMap.typeFromExtension;
 import static com.google.android.gnd.util.Localization.getLocalizedMessage;
 
 import com.google.android.gnd.model.Project;
-import com.google.android.gnd.model.basemap.OfflineBaseMapSource;
+import com.google.android.gnd.model.basemap.BaseMap;
 import com.google.android.gnd.persistence.remote.DataStoreException;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -44,22 +44,22 @@ class ProjectConverter {
           pd.getLayers(), (id, obj) -> project.putLayer(id, LayerConverter.toLayer(id, obj)));
     }
     project.setAcl(ImmutableMap.copyOf(pd.getAcl()));
-    if (pd.getOfflineBaseMapSources() != null) {
+    if (pd.getBaseMaps() != null) {
       convertOfflineBaseMapSources(pd, project);
     }
     return project.build();
   }
 
   private static void convertOfflineBaseMapSources(ProjectDocument pd, Project.Builder project) {
-    for (OfflineBaseMapSourceNestedObject src : pd.getOfflineBaseMapSources()) {
+    for (BaseMapNestedObject src : pd.getBaseMaps()) {
       if (src.getUrl() == null) {
         Timber.d("Skipping base map source in project with missing URL");
         continue;
       }
       try {
         URL url = new URL(src.getUrl());
-        project.addOfflineBaseMapSource(
-            OfflineBaseMapSource.builder()
+        project.addBaseMap(
+            BaseMap.builder()
                 .setUrl(url)
                 .setType(typeFromExtension(src.getUrl()))
                 .build());

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ProjectDocument.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/ProjectDocument.java
@@ -32,7 +32,7 @@ class ProjectDocument {
 
   @Nullable private Map<String, String> acl;
 
-  @Nullable private List<OfflineBaseMapSourceNestedObject> offlineBaseMapSources;
+  @Nullable private List<BaseMapNestedObject> baseMaps;
 
   @SuppressWarnings("unused")
   public ProjectDocument() {}
@@ -43,12 +43,12 @@ class ProjectDocument {
       @Nullable Map<String, String> description,
       @Nullable Map<String, LayerNestedObject> layers,
       @Nullable Map<String, String> acl,
-      @Nullable List<OfflineBaseMapSourceNestedObject> offlineBaseMapSources) {
+      @Nullable List<BaseMapNestedObject> baseMaps) {
     this.title = title;
     this.description = description;
     this.layers = layers;
     this.acl = acl;
-    this.offlineBaseMapSources = offlineBaseMapSources;
+    this.baseMaps = baseMaps;
   }
 
   @Nullable
@@ -72,7 +72,7 @@ class ProjectDocument {
   }
 
   @Nullable
-  public List<OfflineBaseMapSourceNestedObject> getOfflineBaseMapSources() {
-    return offlineBaseMapSources;
+  public List<BaseMapNestedObject> getBaseMaps() {
+    return baseMaps;
   }
 }


### PR DESCRIPTION
Renames `OfflineBaseMapSource` to `BaseMap`

This part of a few class renames we'll perform in relation to offline base maps functionality in order to make the code clearer.