### PR TITLE
[Code health] Consolidate and rename test data

### DIFF
--- a/gnd/src/androidTest/java/com/google/android/gnd/AcceptTermsOfServiceTest.java
+++ b/gnd/src/androidTest/java/com/google/android/gnd/AcceptTermsOfServiceTest.java
@@ -24,6 +24,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.not;
 
+import com.google.android.gnd.persistence.remote.FakeRemoteDataStore;
 import com.google.android.gnd.system.auth.FakeAuthenticationManager;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import javax.inject.Inject;
@@ -33,11 +34,13 @@ import org.junit.Test;
 public class AcceptTermsOfServiceTest extends BaseMainActivityTest {
 
   @Inject FakeAuthenticationManager fakeAuthenticationManager;
+  @Inject FakeRemoteDataStore fakeRemoteDataStore;
 
   @Override
   public void setUp() {
     super.setUp();
     fakeAuthenticationManager.setUser(FakeData.USER);
+    fakeRemoteDataStore.setTestProject(FakeData.PROJECT);
   }
 
   // Given: a logged in user - with terms not accepted.

--- a/gnd/src/androidTest/java/com/google/android/gnd/AcceptTermsOfServiceTest.java
+++ b/gnd/src/androidTest/java/com/google/android/gnd/AcceptTermsOfServiceTest.java
@@ -37,7 +37,7 @@ public class AcceptTermsOfServiceTest extends BaseMainActivityTest {
   @Override
   public void setUp() {
     super.setUp();
-    fakeAuthenticationManager.setUser(FakeData.TEST_USER);
+    fakeAuthenticationManager.setUser(FakeData.USER);
   }
 
   // Given: a logged in user - with terms not accepted.

--- a/gnd/src/androidTest/java/com/google/android/gnd/AcceptTermsOfServiceTest.java
+++ b/gnd/src/androidTest/java/com/google/android/gnd/AcceptTermsOfServiceTest.java
@@ -58,7 +58,7 @@ public class AcceptTermsOfServiceTest extends BaseMainActivityTest {
     onView(withId(R.id.agreeButton)).check(matches(isEnabled()));
 
     // Verify that the terms text matched with fake data.
-    onView(withId(R.id.termsText)).check(matches(withText(FakeData.TERMS_OF_SERVICE)));
+    onView(withId(R.id.termsText)).check(matches(withText(FakeData.TERMS_OF_SERVICE.getText())));
 
     // Tap on the button
     onView(withId(R.id.agreeButton)).perform(click());

--- a/gnd/src/androidTest/java/com/google/android/gnd/AddFeatureTest.java
+++ b/gnd/src/androidTest/java/com/google/android/gnd/AddFeatureTest.java
@@ -84,7 +84,7 @@ public class AddFeatureTest extends BaseMainActivityTest {
     onView(withId(R.id.add_feature_btn)).perform(click());
 
     // Tap on the layer type.
-    onData(allOf(is(instanceOf(String.class)), is(FakeData.LAYER_WITH_NO_FORM.getName())))
+    onData(allOf(is(instanceOf(String.class)), is(FakeData.LAYER.getName())))
         .perform(click());
 
     // Tap on the crosshair at the centre of the map.
@@ -97,6 +97,6 @@ public class AddFeatureTest extends BaseMainActivityTest {
     // Verify that the feature title matches the layer title and that it is displayed.
     onView(withId(R.id.feature_title)).check(matches(isCompletelyDisplayed()));
     onView(withId(R.id.feature_title))
-        .check(matches(withText(FakeData.LAYER_WITH_NO_FORM.getName())));
+        .check(matches(withText(FakeData.LAYER.getName())));
   }
 }

--- a/gnd/src/androidTest/java/com/google/android/gnd/AddFeatureTest.java
+++ b/gnd/src/androidTest/java/com/google/android/gnd/AddFeatureTest.java
@@ -84,7 +84,8 @@ public class AddFeatureTest extends BaseMainActivityTest {
     onView(withId(R.id.add_feature_btn)).perform(click());
 
     // Tap on the layer type.
-    onData(allOf(is(instanceOf(String.class)), is(FakeData.LAYER_NO_FORM_NAME))).perform(click());
+    onData(allOf(is(instanceOf(String.class)), is(FakeData.LAYER_WITH_NO_FORM.getName())))
+        .perform(click());
 
     // Tap on the crosshair at the centre of the map.
     onView(withId(R.id.map_crosshairs)).perform(click());
@@ -95,6 +96,7 @@ public class AddFeatureTest extends BaseMainActivityTest {
 
     // Verify that the feature title matches the layer title and that it is displayed.
     onView(withId(R.id.feature_title)).check(matches(isCompletelyDisplayed()));
-    onView(withId(R.id.feature_title)).check(matches(withText(FakeData.LAYER_NO_FORM_NAME)));
+    onView(withId(R.id.feature_title))
+        .check(matches(withText(FakeData.LAYER_WITH_NO_FORM.getName())));
   }
 }

--- a/gnd/src/androidTest/java/com/google/android/gnd/AddFeatureTest.java
+++ b/gnd/src/androidTest/java/com/google/android/gnd/AddFeatureTest.java
@@ -42,7 +42,7 @@ public class AddFeatureTest extends BaseMainActivityTest {
   @Override
   public void setUp() {
     super.setUp();
-    fakeAuthenticationManager.setUser(FakeData.TEST_USER);
+    fakeAuthenticationManager.setUser(FakeData.USER);
   }
 
   // Given: a logged in user - with an active project with no map markers.

--- a/gnd/src/androidTest/java/com/google/android/gnd/SetPreferencesRule.java
+++ b/gnd/src/androidTest/java/com/google/android/gnd/SetPreferencesRule.java
@@ -52,7 +52,7 @@ class SetPreferencesRule extends TestWatcher {
     prefs
         .edit()
         .clear()
-        .putString(ACTIVE_PROJECT_ID_KEY, FakeData.PROJECT_WITH_LAYER_AND_NO_FORM.getId())
+        .putString(ACTIVE_PROJECT_ID_KEY, FakeData.PROJECT.getId())
         .apply();
   }
 }

--- a/gnd/src/androidTest/java/com/google/android/gnd/SetPreferencesRule.java
+++ b/gnd/src/androidTest/java/com/google/android/gnd/SetPreferencesRule.java
@@ -44,15 +44,15 @@ class SetPreferencesRule extends TestWatcher {
   public void starting(Description description) {
     super.starting(description);
 
-    SharedPreferences prefs = EntryPointAccessors.fromApplication(
-        ApplicationProvider.getApplicationContext(),
-        SetPreferencesRuleEntryPoint.class
-    ).preferenceStorage();
+    SharedPreferences prefs =
+        EntryPointAccessors.fromApplication(
+                ApplicationProvider.getApplicationContext(), SetPreferencesRuleEntryPoint.class)
+            .preferenceStorage();
 
     prefs
         .edit()
         .clear()
-        .putString(ACTIVE_PROJECT_ID_KEY, FakeData.PROJECT_ID_WITH_LAYER_AND_NO_FORM)
+        .putString(ACTIVE_PROJECT_ID_KEY, FakeData.PROJECT_WITH_LAYER_AND_NO_FORM.getId())
         .apply();
   }
 }

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -20,6 +20,7 @@ import com.google.android.gnd.model.AuditInfo;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.TermsOfService;
 import com.google.android.gnd.model.User;
+import com.google.android.gnd.model.feature.FeatureType;
 import com.google.android.gnd.model.feature.GeoJsonFeature;
 import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.model.feature.PointFeature;
@@ -27,22 +28,23 @@ import com.google.android.gnd.model.feature.PolygonFeature;
 import com.google.android.gnd.model.layer.Layer;
 import com.google.android.gnd.model.layer.Style;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java8.util.Optional;
 
 public class FakeData {
+  public static final TermsOfService TERMS_OF_SERVICE =
+      TermsOfService.builder()
+          .setId("TERMS_OF_SERVICE")
+          .setText("Fake Terms of Service text")
+          .build();
 
-  public static final String PROJECT_ID_WITH_LAYER_AND_NO_FORM = "FAKE_PROJECT_ID";
-  public static final String PROJECT_ID_WITH_NO_LAYERS = "FAKE_PROJECT_ID with no layers";
-  public static final String PROJECT_TITLE = "Fake project title";
-  public static final String PROJECT_DESCRIPTION = "Fake project description";
-  public static final String TERMS_OF_SERVICE_ID = "TERMS_ID";
-  public static final String TERMS_OF_SERVICE = "Fake Terms of Service";
-  public static final String LAYER_NO_FORM_ID = "LAYER_NO_FORM_ID";
-  public static final String LAYER_NO_FORM_NAME = "Fake name for layer with no form";
-  public static final String LAYER_NO_FORM_COLOR = "#00ff00";
-
-  public static final TermsOfService TEST_TERMS_OF_SERVICE =
-      TermsOfService.builder().setId("1").setText("Test Terms").build();
+  public static final Layer LAYER_WITH_NO_FORM =
+      Layer.newBuilder()
+          .setId("LAYER_WITH_NO_FORM")
+          .setName("Layer with no form")
+          .setDefaultStyle(Style.builder().setColor("#00ff00").build())
+          .setContributorsCanAdd(ImmutableList.of(FeatureType.POINT))
+          .build();
 
   public static final User TEST_USER =
       User.builder().setId("user_id").setEmail("user@gmail.com").setDisplayName("User").build();
@@ -56,6 +58,15 @@ public class FakeData {
           .setName("heading title")
           .setDefaultStyle(Style.builder().setColor("000").build())
           .setForm(Optional.empty())
+          .build();
+
+  public static final Project PROJECT_WITH_LAYER_AND_NO_FORM =
+      Project.newBuilder()
+          .setId("PROJECT_WITH_LAYER_AND_NO_FORM")
+          .setTitle("Layers and forms")
+          .setDescription("Project with layer and no form")
+          .putLayer(LAYER_WITH_NO_FORM.getId(), LAYER_WITH_NO_FORM)
+          .setAcl(ImmutableMap.of(FakeData.TEST_USER.getEmail(), "contributor"))
           .build();
 
   public static final Project TEST_PROJECT =

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -46,13 +46,13 @@ public class FakeData {
           .setContributorsCanAdd(ImmutableList.of(FeatureType.POINT))
           .build();
 
-  public static final User TEST_USER =
+  public static final User USER =
       User.builder().setId("user_id").setEmail("user@gmail.com").setDisplayName("User").build();
 
-  public static final User TEST_USER_2 =
+  public static final User USER_2 =
       User.builder().setId("user_id_2").setEmail("user2@gmail.com").setDisplayName("User2").build();
 
-  public static final Layer TEST_LAYER =
+  public static final Layer LAYER =
       Layer.newBuilder()
           .setId("layer id")
           .setName("heading title")
@@ -66,50 +66,50 @@ public class FakeData {
           .setTitle("Layers and forms")
           .setDescription("Project with layer and no form")
           .putLayer(LAYER_WITH_NO_FORM.getId(), LAYER_WITH_NO_FORM)
-          .setAcl(ImmutableMap.of(FakeData.TEST_USER.getEmail(), "contributor"))
+          .setAcl(ImmutableMap.of(FakeData.USER.getEmail(), "contributor"))
           .build();
 
-  public static final Project TEST_PROJECT =
+  public static final Project PROJECT =
       Project.newBuilder()
           .setId("project id")
           .setTitle("project 1")
           .setDescription("foo description")
-          .putLayer("layer id", TEST_LAYER)
+          .putLayer("layer id", LAYER)
           .build();
 
-  public static final PointFeature TEST_POINT_FEATURE =
+  public static final PointFeature POINT_FEATURE =
       PointFeature.newBuilder()
           .setId("feature id")
-          .setProject(TEST_PROJECT)
-          .setLayer(TEST_LAYER)
+          .setProject(PROJECT)
+          .setLayer(LAYER)
           .setPoint(Point.newBuilder().setLatitude(0.0).setLongitude(0.0).build())
-          .setCreated(AuditInfo.now(TEST_USER))
-          .setLastModified(AuditInfo.now(TEST_USER))
+          .setCreated(AuditInfo.now(USER))
+          .setLastModified(AuditInfo.now(USER))
           .build();
 
-  public static final ImmutableList<Point> TEST_POLYGON =
+  public static final ImmutableList<Point> VERTICES =
       ImmutableList.of(
           Point.newBuilder().setLatitude(0.0).setLongitude(0.0).build(),
           Point.newBuilder().setLatitude(10.0).setLongitude(10.0).build(),
           Point.newBuilder().setLatitude(20.0).setLongitude(20.0).build());
 
-  public static final PolygonFeature TEST_POLYGON_FEATURE =
+  public static final PolygonFeature POLYGON_FEATURE =
       PolygonFeature.builder()
           .setId("feature id")
-          .setProject(TEST_PROJECT)
-          .setLayer(TEST_LAYER)
-          .setVertices(TEST_POLYGON)
-          .setCreated(AuditInfo.now(TEST_USER))
-          .setLastModified(AuditInfo.now(TEST_USER))
+          .setProject(PROJECT)
+          .setLayer(LAYER)
+          .setVertices(VERTICES)
+          .setCreated(AuditInfo.now(USER))
+          .setLastModified(AuditInfo.now(USER))
           .build();
 
-  public static final GeoJsonFeature TEST_GEO_JSON_FEATURE =
+  public static final GeoJsonFeature GEO_JSON_FEATURE =
       GeoJsonFeature.newBuilder()
           .setId("feature id")
-          .setProject(TEST_PROJECT)
-          .setLayer(TEST_LAYER)
+          .setProject(PROJECT)
+          .setLayer(LAYER)
           .setGeoJsonString("some data string")
-          .setCreated(AuditInfo.now(TEST_USER))
-          .setLastModified(AuditInfo.now(TEST_USER))
+          .setCreated(AuditInfo.now(USER))
+          .setLastModified(AuditInfo.now(USER))
           .build();
 }

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -20,7 +20,6 @@ import com.google.android.gnd.model.AuditInfo;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.TermsOfService;
 import com.google.android.gnd.model.User;
-import com.google.android.gnd.model.feature.FeatureType;
 import com.google.android.gnd.model.feature.GeoJsonFeature;
 import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.model.feature.PointFeature;
@@ -30,6 +29,10 @@ import com.google.android.gnd.model.layer.Style;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+/**
+ * Shared test data constants. Tests are expected to override existing or set missing values when
+ * the specific value is relevant to the test.
+ */
 public class FakeData {
   public static final TermsOfService TERMS_OF_SERVICE =
       TermsOfService.builder()
@@ -37,12 +40,11 @@ public class FakeData {
           .setText("Fake Terms of Service text")
           .build();
 
-  public static final Layer LAYER_WITH_NO_FORM =
+  public static final Layer LAYER =
       Layer.newBuilder()
-          .setId("LAYER_WITH_NO_FORM")
-          .setName("Layer with no form")
+          .setId("LAYER")
+          .setName("Layer")
           .setDefaultStyle(Style.builder().setColor("#00ff00").build())
-          .setContributorsCanAdd(ImmutableList.of(FeatureType.POINT))
           .build();
 
   public static final User USER =
@@ -51,20 +53,19 @@ public class FakeData {
   public static final User USER_2 =
       User.builder().setId("user_id_2").setEmail("user2@gmail.com").setDisplayName("User2").build();
 
-  public static final Project PROJECT_WITH_LAYER_AND_NO_FORM =
+  public static final Project PROJECT =
       Project.newBuilder()
           .setId("PROJECT_WITH_LAYER_AND_NO_FORM")
-          .setTitle("Layers and forms")
-          .setDescription("Project with layer and no form")
-          .putLayer(LAYER_WITH_NO_FORM.getId(), LAYER_WITH_NO_FORM)
+          .setTitle("Project title")
+          .setDescription("Test project description")
           .setAcl(ImmutableMap.of(FakeData.USER.getEmail(), "contributor"))
           .build();
 
   public static final PointFeature POINT_FEATURE =
       PointFeature.newBuilder()
           .setId("feature id")
-          .setProject(PROJECT_WITH_LAYER_AND_NO_FORM)
-          .setLayer(LAYER_WITH_NO_FORM)
+          .setProject(PROJECT)
+          .setLayer(LAYER)
           .setPoint(Point.newBuilder().setLatitude(0.0).setLongitude(0.0).build())
           .setCreated(AuditInfo.now(USER))
           .setLastModified(AuditInfo.now(USER))
@@ -79,8 +80,8 @@ public class FakeData {
   public static final PolygonFeature POLYGON_FEATURE =
       PolygonFeature.builder()
           .setId("feature id")
-          .setProject(PROJECT_WITH_LAYER_AND_NO_FORM)
-          .setLayer(LAYER_WITH_NO_FORM)
+          .setProject(PROJECT)
+          .setLayer(LAYER)
           .setVertices(VERTICES)
           .setCreated(AuditInfo.now(USER))
           .setLastModified(AuditInfo.now(USER))
@@ -89,8 +90,8 @@ public class FakeData {
   public static final GeoJsonFeature GEO_JSON_FEATURE =
       GeoJsonFeature.newBuilder()
           .setId("feature id")
-          .setProject(PROJECT_WITH_LAYER_AND_NO_FORM)
-          .setLayer(LAYER_WITH_NO_FORM)
+          .setProject(PROJECT)
+          .setLayer(LAYER)
           .setGeoJsonString("some data string")
           .setCreated(AuditInfo.now(USER))
           .setLastModified(AuditInfo.now(USER))

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -29,7 +29,6 @@ import com.google.android.gnd.model.layer.Layer;
 import com.google.android.gnd.model.layer.Style;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java8.util.Optional;
 
 public class FakeData {
   public static final TermsOfService TERMS_OF_SERVICE =
@@ -52,14 +51,6 @@ public class FakeData {
   public static final User USER_2 =
       User.builder().setId("user_id_2").setEmail("user2@gmail.com").setDisplayName("User2").build();
 
-  public static final Layer LAYER =
-      Layer.newBuilder()
-          .setId("layer id")
-          .setName("heading title")
-          .setDefaultStyle(Style.builder().setColor("000").build())
-          .setForm(Optional.empty())
-          .build();
-
   public static final Project PROJECT_WITH_LAYER_AND_NO_FORM =
       Project.newBuilder()
           .setId("PROJECT_WITH_LAYER_AND_NO_FORM")
@@ -69,19 +60,11 @@ public class FakeData {
           .setAcl(ImmutableMap.of(FakeData.USER.getEmail(), "contributor"))
           .build();
 
-  public static final Project PROJECT =
-      Project.newBuilder()
-          .setId("project id")
-          .setTitle("project 1")
-          .setDescription("foo description")
-          .putLayer("layer id", LAYER)
-          .build();
-
   public static final PointFeature POINT_FEATURE =
       PointFeature.newBuilder()
           .setId("feature id")
-          .setProject(PROJECT)
-          .setLayer(LAYER)
+          .setProject(PROJECT_WITH_LAYER_AND_NO_FORM)
+          .setLayer(LAYER_WITH_NO_FORM)
           .setPoint(Point.newBuilder().setLatitude(0.0).setLongitude(0.0).build())
           .setCreated(AuditInfo.now(USER))
           .setLastModified(AuditInfo.now(USER))
@@ -96,8 +79,8 @@ public class FakeData {
   public static final PolygonFeature POLYGON_FEATURE =
       PolygonFeature.builder()
           .setId("feature id")
-          .setProject(PROJECT)
-          .setLayer(LAYER)
+          .setProject(PROJECT_WITH_LAYER_AND_NO_FORM)
+          .setLayer(LAYER_WITH_NO_FORM)
           .setVertices(VERTICES)
           .setCreated(AuditInfo.now(USER))
           .setLastModified(AuditInfo.now(USER))
@@ -106,8 +89,8 @@ public class FakeData {
   public static final GeoJsonFeature GEO_JSON_FEATURE =
       GeoJsonFeature.newBuilder()
           .setId("feature id")
-          .setProject(PROJECT)
-          .setLayer(LAYER)
+          .setProject(PROJECT_WITH_LAYER_AND_NO_FORM)
+          .setLayer(LAYER_WITH_NO_FORM)
           .setGeoJsonString("some data string")
           .setCreated(AuditInfo.now(USER))
           .setLastModified(AuditInfo.now(USER))

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -55,7 +55,7 @@ public class FakeData {
 
   public static final Project PROJECT =
       Project.newBuilder()
-          .setId("PROJECT_WITH_LAYER_AND_NO_FORM")
+          .setId("PROJECT")
           .setTitle("Project title")
           .setDescription("Test project description")
           .setAcl(ImmutableMap.of(FakeData.USER.getEmail(), "contributor"))

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -96,4 +96,6 @@ public class FakeData {
           .setCreated(AuditInfo.now(USER))
           .setLastModified(AuditInfo.now(USER))
           .build();
+
+  public static final Point POINT = Point.newBuilder().setLatitude(42.0).setLongitude(18.0).build();
 }

--- a/gnd/src/sharedTest/java/com/google/android/gnd/persistence/remote/FakeRemoteDataStore.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/persistence/remote/FakeRemoteDataStore.java
@@ -16,6 +16,7 @@
 
 package com.google.android.gnd.persistence.remote;
 
+import com.google.android.gnd.FakeData;
 import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.TermsOfService;
@@ -39,8 +40,10 @@ import javax.inject.Singleton;
 @Singleton
 public class FakeRemoteDataStore implements RemoteDataStore {
   private RemoteDataEvent<Feature> featureEvent;
-  private Project testProject;
-  private Optional<TermsOfService> termsOfService = Optional.empty();
+  // TODO(#1045): Allow default project to be initialized by tests.
+  private Project testProject = FakeData.PROJECT;
+  // TODO(#1045): Allow default ToS to be initialized by tests.
+  private Optional<TermsOfService> termsOfService = Optional.of(FakeData.TERMS_OF_SERVICE);
 
   @Inject
   FakeRemoteDataStore() {}

--- a/gnd/src/sharedTest/java/com/google/android/gnd/persistence/remote/FakeRemoteDataStore.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/persistence/remote/FakeRemoteDataStore.java
@@ -22,15 +22,11 @@ import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.TermsOfService;
 import com.google.android.gnd.model.User;
 import com.google.android.gnd.model.feature.Feature;
-import com.google.android.gnd.model.feature.FeatureType;
-import com.google.android.gnd.model.layer.Layer;
-import com.google.android.gnd.model.layer.Style;
 import com.google.android.gnd.model.observation.Observation;
 import com.google.android.gnd.rx.ValueOrError;
 import com.google.android.gnd.rx.annotations.Cold;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
@@ -42,40 +38,8 @@ import javax.inject.Singleton;
 
 @Singleton
 public class FakeRemoteDataStore implements RemoteDataStore {
-
-  private final Layer layerWithNoForm =
-      Layer.newBuilder()
-          .setId(FakeData.LAYER_NO_FORM_ID)
-          .setName(FakeData.LAYER_NO_FORM_NAME)
-          .setDefaultStyle(Style.builder().setColor(FakeData.LAYER_NO_FORM_COLOR).build())
-          .setContributorsCanAdd(ImmutableList.of(FeatureType.POINT))
-          .build();
-
-  private final Project testProjectWithLayerAndNoForm =
-      Project.newBuilder()
-          .setId(FakeData.PROJECT_ID_WITH_LAYER_AND_NO_FORM)
-          .setTitle(FakeData.PROJECT_TITLE)
-          .setDescription(FakeData.PROJECT_DESCRIPTION)
-          .putLayer(FakeData.LAYER_NO_FORM_ID, layerWithNoForm)
-          .setAcl(ImmutableMap.of(FakeData.TEST_USER.getEmail(), "contributor"))
-          .build();
-
-  private final TermsOfService testTermsOfService =
-      TermsOfService.builder()
-          .setId(FakeData.TERMS_OF_SERVICE_ID)
-          .setText(FakeData.TERMS_OF_SERVICE)
-          .build();
-
-  private final Project testProjectWithNoLayers =
-      Project.newBuilder()
-          .setId(FakeData.PROJECT_ID_WITH_NO_LAYERS)
-          .setTitle(FakeData.PROJECT_TITLE)
-          .setDescription(FakeData.PROJECT_DESCRIPTION)
-          .setAcl(ImmutableMap.of(FakeData.TEST_USER.getEmail(), "contributor"))
-          .build();
-
-  private String activeProjectId = FakeData.PROJECT_ID_WITH_LAYER_AND_NO_FORM;
   private RemoteDataEvent<Feature> featureEvent;
+  private Project testProject;
 
   @Inject
   FakeRemoteDataStore() {}
@@ -86,34 +50,23 @@ public class FakeRemoteDataStore implements RemoteDataStore {
    * <p>In that case, launch scenario manually using ActivityScenario.launch instead of using
    * ActivityScenarioRule.
    */
-  public void setActiveProjectId(String projectId) {
-    activeProjectId = projectId;
-  }
-
-  private Project getTestProject() {
-    switch (activeProjectId) {
-      case FakeData.PROJECT_ID_WITH_LAYER_AND_NO_FORM:
-        return testProjectWithLayerAndNoForm;
-      case FakeData.PROJECT_ID_WITH_NO_LAYERS:
-        return testProjectWithNoLayers;
-      default:
-        return null;
-    }
+  public void setTestProject(Project project) {
+    this.testProject = project;
   }
 
   @Override
   public Single<List<Project>> loadProjectSummaries(User user) {
-    return Single.just(Collections.singletonList(getTestProject()));
+    return Single.just(Collections.singletonList(testProject));
   }
 
   @Override
   public Single<Project> loadProject(String projectId) {
-    return Single.just(getTestProject());
+    return Single.just(testProject);
   }
 
   @Override
   public @Cold Maybe<TermsOfService> loadTermsOfService() {
-    return Maybe.just(testTermsOfService);
+    return Maybe.just(FakeData.TERMS_OF_SERVICE);
   }
 
   @Override

--- a/gnd/src/sharedTest/java/com/google/android/gnd/persistence/remote/FakeRemoteDataStore.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/persistence/remote/FakeRemoteDataStore.java
@@ -16,7 +16,6 @@
 
 package com.google.android.gnd.persistence.remote;
 
-import com.google.android.gnd.FakeData;
 import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Project;
 import com.google.android.gnd.model.TermsOfService;
@@ -41,7 +40,7 @@ import javax.inject.Singleton;
 public class FakeRemoteDataStore implements RemoteDataStore {
   private RemoteDataEvent<Feature> featureEvent;
   private Project testProject;
-  private Optional<TermsOfService> termsOfService = Optional.of(FakeData.TEST_TERMS_OF_SERVICE);
+  private Optional<TermsOfService> termsOfService = Optional.empty();
 
   @Inject
   FakeRemoteDataStore() {}

--- a/gnd/src/sharedTest/java/com/google/android/gnd/system/auth/FakeAuthenticationManager.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/system/auth/FakeAuthenticationManager.java
@@ -16,6 +16,7 @@
 
 package com.google.android.gnd.system.auth;
 
+import com.google.android.gnd.FakeData;
 import com.google.android.gnd.model.User;
 import com.google.android.gnd.rx.annotations.Hot;
 import com.google.android.gnd.system.auth.SignInState.State;
@@ -31,7 +32,8 @@ public class FakeAuthenticationManager implements AuthenticationManager {
   @Hot(replays = true)
   private final Subject<SignInState> behaviourSubject = BehaviorSubject.create();
 
-  private User user;
+  // TODO(#1045): Allow default user to be initialized by tests.
+  private User user = FakeData.USER;
 
   @Inject
   public FakeAuthenticationManager() {}

--- a/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
@@ -130,7 +130,8 @@ public class MainViewModelTest extends BaseHiltTest {
 
     verifyProgressDialogVisible(false);
     verifyNavigationRequested(
-        SignInFragmentDirections.showTermsOfService().setTermsOfServiceText(TERMS_OF_SERVICE));
+        SignInFragmentDirections.showTermsOfService()
+            .setTermsOfServiceText(TERMS_OF_SERVICE.getText()));
     verifyUserSaved();
     assertThat(tosRepository.isTermsOfServiceAccepted()).isFalse();
   }

--- a/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
@@ -116,6 +116,7 @@ public class MainViewModelTest extends BaseHiltTest {
   @Test
   public void testSignInStateChanged_onSignedIn_whenTosAccepted() {
     tosRepository.setTermsOfServiceAccepted(true);
+    fakeRemoteDataStore.setTermsOfService(Optional.of(TERMS_OF_SERVICE));
     fakeAuthenticationManager.setUser(USER);
     fakeAuthenticationManager.signIn();
 
@@ -128,6 +129,7 @@ public class MainViewModelTest extends BaseHiltTest {
   @Test
   public void testSignInStateChanged_onSignedIn_whenTosNotAccepted() {
     tosRepository.setTermsOfServiceAccepted(false);
+    fakeRemoteDataStore.setTermsOfService(Optional.of(TERMS_OF_SERVICE));
     fakeAuthenticationManager.setUser(USER);
     fakeAuthenticationManager.signIn();
 
@@ -144,7 +146,7 @@ public class MainViewModelTest extends BaseHiltTest {
     tosRepository.setTermsOfServiceAccepted(false);
     fakeRemoteDataStore.setTermsOfService(Optional.empty());
 
-    fakeAuthenticationManager.setUser(TEST_USER);
+    fakeAuthenticationManager.setUser(FakeData.USER);
     fakeAuthenticationManager.signIn();
 
     verifyProgressDialogVisible(false);

--- a/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
@@ -17,7 +17,7 @@
 package com.google.android.gnd;
 
 import static com.google.android.gnd.FakeData.TERMS_OF_SERVICE;
-import static com.google.android.gnd.FakeData.TEST_USER;
+import static com.google.android.gnd.FakeData.USER;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.SharedPreferences;
@@ -71,11 +71,11 @@ public class MainViewModelTest extends BaseHiltTest {
   }
 
   private void verifyUserSaved() {
-    userRepository.getUser(TEST_USER.getId()).test().assertResult(TEST_USER);
+    userRepository.getUser(USER.getId()).test().assertResult(USER);
   }
 
   private void verifyUserNotSaved() {
-    userRepository.getUser(TEST_USER.getId()).test().assertError(NoSuchElementException.class);
+    userRepository.getUser(USER.getId()).test().assertError(NoSuchElementException.class);
   }
 
   private void verifyProgressDialogVisible(boolean visible) {
@@ -113,7 +113,7 @@ public class MainViewModelTest extends BaseHiltTest {
   @Test
   public void testSignInStateChanged_onSignedIn_whenTosAccepted() {
     tosRepository.setTermsOfServiceAccepted(true);
-    fakeAuthenticationManager.setUser(TEST_USER);
+    fakeAuthenticationManager.setUser(USER);
     fakeAuthenticationManager.signIn();
 
     verifyProgressDialogVisible(false);
@@ -125,7 +125,7 @@ public class MainViewModelTest extends BaseHiltTest {
   @Test
   public void testSignInStateChanged_onSignedIn_whenTosNotAccepted() {
     tosRepository.setTermsOfServiceAccepted(false);
-    fakeAuthenticationManager.setUser(TEST_USER);
+    fakeAuthenticationManager.setUser(USER);
     fakeAuthenticationManager.signIn();
 
     verifyProgressDialogVisible(false);

--- a/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/MainViewModelTest.java
@@ -146,7 +146,7 @@ public class MainViewModelTest extends BaseHiltTest {
     tosRepository.setTermsOfServiceAccepted(false);
     fakeRemoteDataStore.setTermsOfService(Optional.empty());
 
-    fakeAuthenticationManager.setUser(FakeData.USER);
+    fakeAuthenticationManager.setUser(USER);
     fakeAuthenticationManager.signIn();
 
     verifyProgressDialogVisible(false);

--- a/gnd/src/test/java/com/google/android/gnd/repository/FeatureRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/FeatureRepositoryTest.java
@@ -308,13 +308,13 @@ public class FeatureRepositoryTest extends BaseHiltTest {
 
     FeatureMutation newMutation =
         featureRepository.newPolygonFeatureMutation(
-            "foo_project_id", "foo_layer_id", FakeData.TEST_POLYGON, testDate);
+            "foo_project_id", "foo_layer_id", FakeData.VERTICES, testDate);
 
     assertThat(newMutation.getId()).isNull();
     assertThat(newMutation.getFeatureId()).isEqualTo("TEST UUID");
     assertThat(newMutation.getProjectId()).isEqualTo("foo_project_id");
     assertThat(newMutation.getLayerId()).isEqualTo("foo_layer_id");
-    assertThat(newMutation.getNewPolygonVertices()).isEqualTo(FakeData.TEST_POLYGON);
+    assertThat(newMutation.getNewPolygonVertices()).isEqualTo(FakeData.VERTICES);
     assertThat(newMutation.getUserId()).isEqualTo(TEST_USER.getId());
     assertThat(newMutation.getClientTimestamp()).isEqualTo(testDate);
   }

--- a/gnd/src/test/java/com/google/android/gnd/repository/FeatureRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/FeatureRepositoryTest.java
@@ -26,20 +26,10 @@ import static org.mockito.Mockito.when;
 
 import com.google.android.gnd.BaseHiltTest;
 import com.google.android.gnd.FakeData;
-import com.google.android.gnd.model.AuditInfo;
 import com.google.android.gnd.model.Mutation;
 import com.google.android.gnd.model.Mutation.SyncStatus;
 import com.google.android.gnd.model.Mutation.Type;
-import com.google.android.gnd.model.Project;
-import com.google.android.gnd.model.User;
 import com.google.android.gnd.model.feature.FeatureMutation;
-import com.google.android.gnd.model.feature.Point;
-import com.google.android.gnd.model.feature.PointFeature;
-import com.google.android.gnd.model.form.Element;
-import com.google.android.gnd.model.form.Field;
-import com.google.android.gnd.model.form.Form;
-import com.google.android.gnd.model.layer.Layer;
-import com.google.android.gnd.model.layer.Style;
 import com.google.android.gnd.persistence.local.LocalDataStore;
 import com.google.android.gnd.persistence.local.LocalDataStoreModule;
 import com.google.android.gnd.persistence.local.room.models.MutationEntitySyncStatus;
@@ -48,7 +38,6 @@ import com.google.android.gnd.persistence.remote.NotFoundException;
 import com.google.android.gnd.persistence.remote.RemoteDataEvent;
 import com.google.android.gnd.persistence.sync.DataSyncWorkManager;
 import com.google.android.gnd.system.auth.FakeAuthenticationManager;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import dagger.hilt.android.testing.BindValue;
 import dagger.hilt.android.testing.HiltAndroidTest;
@@ -72,56 +61,6 @@ import org.robolectric.RobolectricTestRunner;
 @UninstallModules({LocalDataStoreModule.class})
 @RunWith(RobolectricTestRunner.class)
 public class FeatureRepositoryTest extends BaseHiltTest {
-
-  private static final User TEST_USER =
-      User.builder().setId("user id").setEmail("user@gmail.com").setDisplayName("user 1").build();
-
-  private static final AuditInfo TEST_AUDIT_INFO = AuditInfo.now(TEST_USER);
-
-  private static final Point TEST_POINT =
-      Point.newBuilder().setLatitude(110.0).setLongitude(-23.1).build();
-
-  private static final Field TEST_FIELD =
-      Field.newBuilder()
-          .setId("field id")
-          .setIndex(1)
-          .setLabel("field label")
-          .setRequired(false)
-          .setType(Field.Type.TEXT_FIELD)
-          .build();
-
-  private static final Form TEST_FORM =
-      Form.newBuilder()
-          .setId("form id")
-          .setElements(ImmutableList.of(Element.ofField(TEST_FIELD)))
-          .build();
-
-  private static final Layer TEST_LAYER =
-      Layer.newBuilder()
-          .setId("layer id")
-          .setName("heading title")
-          .setDefaultStyle(Style.builder().setColor("000").build())
-          .setForm(TEST_FORM)
-          .build();
-
-  private static final Project TEST_PROJECT =
-      Project.newBuilder()
-          .setId("project id")
-          .setTitle("project 1")
-          .setDescription("foo description")
-          .putLayer("layer id", TEST_LAYER)
-          .build();
-
-  private static final PointFeature TEST_FEATURE =
-      PointFeature.newBuilder()
-          .setId("feature id")
-          .setProject(TEST_PROJECT)
-          .setLayer(TEST_LAYER)
-          .setPoint(TEST_POINT)
-          .setCreated(TEST_AUDIT_INFO)
-          .setLastModified(TEST_AUDIT_INFO)
-          .build();
-
   @BindValue @Mock LocalDataStore mockLocalDataStore;
   @BindValue @Mock ProjectRepository mockProjectRepository;
   @BindValue @Mock DataSyncWorkManager mockWorkManager;
@@ -148,7 +87,7 @@ public class FeatureRepositoryTest extends BaseHiltTest {
     mockEnqueueSyncWorker();
 
     featureRepository
-        .applyAndEnqueue(TEST_FEATURE.toMutation(Type.CREATE, TEST_USER.getId()))
+        .applyAndEnqueue(FakeData.POINT_FEATURE.toMutation(Type.CREATE, FakeData.USER.getId()))
         .test()
         .assertNoErrors()
         .assertComplete();
@@ -156,10 +95,10 @@ public class FeatureRepositoryTest extends BaseHiltTest {
     FeatureMutation actual = captorFeatureMutation.getValue();
     assertThat(actual.getType()).isEqualTo(Mutation.Type.CREATE);
     assertThat(actual.getSyncStatus()).isEqualTo(SyncStatus.PENDING);
-    assertThat(actual.getFeatureId()).isEqualTo(TEST_FEATURE.getId());
+    assertThat(actual.getFeatureId()).isEqualTo(FakeData.POINT_FEATURE.getId());
 
     verify(mockLocalDataStore, times(1)).applyAndEnqueue(any(FeatureMutation.class));
-    verify(mockWorkManager, times(1)).enqueueSyncWorker(TEST_FEATURE.getId());
+    verify(mockWorkManager, times(1)).enqueueSyncWorker(FakeData.POINT_FEATURE.getId());
   }
 
   @Test
@@ -171,13 +110,13 @@ public class FeatureRepositoryTest extends BaseHiltTest {
         .applyAndEnqueue(any(FeatureMutation.class));
 
     featureRepository
-        .applyAndEnqueue(TEST_FEATURE.toMutation(Type.CREATE, TEST_USER.getId()))
+        .applyAndEnqueue(FakeData.POINT_FEATURE.toMutation(Type.CREATE, FakeData.USER.getId()))
         .test()
         .assertError(NullPointerException.class)
         .assertNotComplete();
 
     verify(mockLocalDataStore, times(1)).applyAndEnqueue(any(FeatureMutation.class));
-    verify(mockWorkManager, times(1)).enqueueSyncWorker(TEST_FEATURE.getId());
+    verify(mockWorkManager, times(1)).enqueueSyncWorker(FakeData.POINT_FEATURE.getId());
   }
 
   @Test
@@ -188,33 +127,37 @@ public class FeatureRepositoryTest extends BaseHiltTest {
         .thenReturn(Completable.error(new NullPointerException()));
 
     featureRepository
-        .applyAndEnqueue(TEST_FEATURE.toMutation(Type.CREATE, TEST_USER.getId()))
+        .applyAndEnqueue(FakeData.POINT_FEATURE.toMutation(Type.CREATE, FakeData.USER.getId()))
         .test()
         .assertError(NullPointerException.class)
         .assertNotComplete();
 
     verify(mockLocalDataStore, times(1)).applyAndEnqueue(any(FeatureMutation.class));
-    verify(mockWorkManager, times(1)).enqueueSyncWorker(TEST_FEATURE.getId());
+    verify(mockWorkManager, times(1)).enqueueSyncWorker(FakeData.POINT_FEATURE.getId());
   }
 
   @Test
   public void testSyncFeatures_loaded() {
-    fakeRemoteDataStore.streamFeatureOnce(RemoteDataEvent.loaded("entityId", TEST_FEATURE));
-    when(mockLocalDataStore.mergeFeature(TEST_FEATURE)).thenReturn(Completable.complete());
+    fakeRemoteDataStore.streamFeatureOnce(
+        RemoteDataEvent.loaded("entityId", FakeData.POINT_FEATURE));
+    when(mockLocalDataStore.mergeFeature(FakeData.POINT_FEATURE))
+        .thenReturn(Completable.complete());
 
-    featureRepository.syncFeatures(TEST_PROJECT).test().assertNoErrors().assertComplete();
+    featureRepository.syncFeatures(FakeData.PROJECT).test().assertNoErrors().assertComplete();
 
-    verify(mockLocalDataStore, times(1)).mergeFeature(TEST_FEATURE);
+    verify(mockLocalDataStore, times(1)).mergeFeature(FakeData.POINT_FEATURE);
   }
 
   @Test
   public void testSyncFeatures_modified() {
-    fakeRemoteDataStore.streamFeatureOnce(RemoteDataEvent.modified("entityId", TEST_FEATURE));
-    when(mockLocalDataStore.mergeFeature(TEST_FEATURE)).thenReturn(Completable.complete());
+    fakeRemoteDataStore.streamFeatureOnce(
+        RemoteDataEvent.modified("entityId", FakeData.POINT_FEATURE));
+    when(mockLocalDataStore.mergeFeature(FakeData.POINT_FEATURE))
+        .thenReturn(Completable.complete());
 
-    featureRepository.syncFeatures(TEST_PROJECT).test().assertNoErrors().assertComplete();
+    featureRepository.syncFeatures(FakeData.PROJECT).test().assertNoErrors().assertComplete();
 
-    verify(mockLocalDataStore, times(1)).mergeFeature(TEST_FEATURE);
+    verify(mockLocalDataStore, times(1)).mergeFeature(FakeData.POINT_FEATURE);
   }
 
   @Test
@@ -222,7 +165,7 @@ public class FeatureRepositoryTest extends BaseHiltTest {
     fakeRemoteDataStore.streamFeatureOnce(RemoteDataEvent.removed("entityId"));
     when(mockLocalDataStore.deleteFeature(anyString())).thenReturn(Completable.complete());
 
-    featureRepository.syncFeatures(TEST_PROJECT).test().assertComplete();
+    featureRepository.syncFeatures(FakeData.PROJECT).test().assertComplete();
 
     verify(mockLocalDataStore, times(1)).deleteFeature("entityId");
   }
@@ -230,18 +173,18 @@ public class FeatureRepositoryTest extends BaseHiltTest {
   @Test
   public void testSyncFeatures_error() {
     fakeRemoteDataStore.streamFeatureOnce(RemoteDataEvent.error(new Throwable("Foo error")));
-    featureRepository.syncFeatures(TEST_PROJECT).test().assertNoErrors().assertComplete();
+    featureRepository.syncFeatures(FakeData.PROJECT).test().assertNoErrors().assertComplete();
   }
 
   @Test
   public void testGetFeaturesOnceAndStream() {
-    when(mockLocalDataStore.getFeaturesOnceAndStream(TEST_PROJECT))
-        .thenReturn(Flowable.just(ImmutableSet.of(TEST_FEATURE)));
+    when(mockLocalDataStore.getFeaturesOnceAndStream(FakeData.PROJECT))
+        .thenReturn(Flowable.just(ImmutableSet.of(FakeData.POINT_FEATURE)));
 
     featureRepository
-        .getFeaturesOnceAndStream(TEST_PROJECT)
+        .getFeaturesOnceAndStream(FakeData.PROJECT)
         .test()
-        .assertValue(ImmutableSet.of(TEST_FEATURE));
+        .assertValue(ImmutableSet.of(FakeData.POINT_FEATURE));
   }
 
   @Test
@@ -257,53 +200,53 @@ public class FeatureRepositoryTest extends BaseHiltTest {
 
   @Test
   public void testGetFeature_projectPresent() {
-    when(mockProjectRepository.getProject(anyString())).thenReturn(Single.just(TEST_PROJECT));
-    when(mockLocalDataStore.getFeature(TEST_PROJECT, TEST_FEATURE.getId()))
-        .thenReturn(Maybe.just(TEST_FEATURE));
+    when(mockProjectRepository.getProject(anyString())).thenReturn(Single.just(FakeData.PROJECT));
+    when(mockLocalDataStore.getFeature(FakeData.PROJECT, FakeData.POINT_FEATURE.getId()))
+        .thenReturn(Maybe.just(FakeData.POINT_FEATURE));
 
     featureRepository
-        .getFeature(TEST_PROJECT.getId(), TEST_FEATURE.getId())
+        .getFeature(FakeData.PROJECT.getId(), FakeData.POINT_FEATURE.getId())
         .test()
-        .assertResult(TEST_FEATURE);
+        .assertResult(FakeData.POINT_FEATURE);
 
     featureRepository
-        .getFeature(TEST_FEATURE.toMutation(Type.UPDATE, "user_id"))
+        .getFeature(FakeData.POINT_FEATURE.toMutation(Type.UPDATE, "user_id"))
         .test()
-        .assertResult(TEST_FEATURE);
+        .assertResult(FakeData.POINT_FEATURE);
   }
 
   @Test
   public void testGetFeature_whenFeatureIsNotPresent() {
-    when(mockProjectRepository.getProject(anyString())).thenReturn(Single.just(TEST_PROJECT));
-    when(mockLocalDataStore.getFeature(TEST_PROJECT, TEST_FEATURE.getId()))
+    when(mockProjectRepository.getProject(anyString())).thenReturn(Single.just(FakeData.PROJECT));
+    when(mockLocalDataStore.getFeature(FakeData.PROJECT, FakeData.POINT_FEATURE.getId()))
         .thenReturn(Maybe.empty());
 
     featureRepository
-        .getFeature(TEST_PROJECT.getId(), TEST_FEATURE.getId())
+        .getFeature(FakeData.PROJECT.getId(), FakeData.POINT_FEATURE.getId())
         .test()
         .assertFailureAndMessage(NotFoundException.class, "Feature not found feature id");
   }
 
   @Test
   public void testNewFeature() {
-    fakeAuthenticationManager.setUser(TEST_USER);
+    fakeAuthenticationManager.setUser(FakeData.USER);
     Date testDate = new Date();
 
     FeatureMutation newMutation =
-        featureRepository.newMutation("foo_project_id", "foo_layer_id", TEST_POINT, testDate);
+        featureRepository.newMutation("foo_project_id", "foo_layer_id", FakeData.POINT, testDate);
 
     assertThat(newMutation.getId()).isNull();
     assertThat(newMutation.getFeatureId()).isEqualTo("TEST UUID");
     assertThat(newMutation.getProjectId()).isEqualTo("foo_project_id");
     assertThat(newMutation.getLayerId()).isEqualTo("foo_layer_id");
-    assertThat(newMutation.getNewLocation().get()).isEqualTo(TEST_POINT);
-    assertThat(newMutation.getUserId()).isEqualTo(TEST_USER.getId());
+    assertThat(newMutation.getNewLocation().get()).isEqualTo(FakeData.POINT);
+    assertThat(newMutation.getUserId()).isEqualTo(FakeData.USER.getId());
     assertThat(newMutation.getClientTimestamp()).isEqualTo(testDate);
   }
 
   @Test
   public void testNewPolygonFeature() {
-    fakeAuthenticationManager.setUser(TEST_USER);
+    fakeAuthenticationManager.setUser(FakeData.USER);
     Date testDate = new Date();
 
     FeatureMutation newMutation =
@@ -315,7 +258,7 @@ public class FeatureRepositoryTest extends BaseHiltTest {
     assertThat(newMutation.getProjectId()).isEqualTo("foo_project_id");
     assertThat(newMutation.getLayerId()).isEqualTo("foo_layer_id");
     assertThat(newMutation.getNewPolygonVertices()).isEqualTo(FakeData.VERTICES);
-    assertThat(newMutation.getUserId()).isEqualTo(TEST_USER.getId());
+    assertThat(newMutation.getUserId()).isEqualTo(FakeData.USER.getId());
     assertThat(newMutation.getClientTimestamp()).isEqualTo(testDate);
   }
 

--- a/gnd/src/test/java/com/google/android/gnd/repository/TermsOfServiceRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/TermsOfServiceRepositoryTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.android.gnd.BaseHiltTest;
 import com.google.android.gnd.FakeData;
-import com.google.android.gnd.model.TermsOfService;
 import com.google.android.gnd.persistence.remote.FakeRemoteDataStore;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import java8.util.Optional;
@@ -38,7 +37,7 @@ public class TermsOfServiceRepositoryTest extends BaseHiltTest {
 
   @Test
   public void testGetTermsOfService() {
-    fakeRemoteDataStore.setTermsOfService(Optional.of(FakeData.TEST_TERMS_OF_SERVICE));
+    fakeRemoteDataStore.setTermsOfService(Optional.of(FakeData.TERMS_OF_SERVICE));
 
     termsOfServiceRepository.getTermsOfService().test().assertResult(FakeData.TERMS_OF_SERVICE);
   }

--- a/gnd/src/test/java/com/google/android/gnd/repository/TermsOfServiceRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/TermsOfServiceRepositoryTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.android.gnd.BaseHiltTest;
 import com.google.android.gnd.FakeData;
-import com.google.android.gnd.model.TermsOfService;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import javax.inject.Inject;
 import org.junit.Test;
@@ -35,14 +34,7 @@ public class TermsOfServiceRepositoryTest extends BaseHiltTest {
 
   @Test
   public void testGetTermsOfService() {
-    termsOfServiceRepository
-        .getTermsOfService()
-        .test()
-        .assertResult(
-            TermsOfService.builder()
-                .setId(FakeData.TERMS_OF_SERVICE_ID)
-                .setText(FakeData.TERMS_OF_SERVICE)
-                .build());
+    termsOfServiceRepository.getTermsOfService().test().assertResult(FakeData.TERMS_OF_SERVICE);
   }
 
   @Test

--- a/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
@@ -52,7 +52,7 @@ public class UserRepositoryTest extends BaseHiltTest {
   @Test
   public void testGetUserRole() {
     Project project =
-        FakeData.PROJECT_WITH_LAYER_AND_NO_FORM.toBuilder()
+        FakeData.PROJECT.toBuilder()
             .setAcl(ImmutableMap.of(FakeData.USER.getEmail(), "contributor"))
             .build();
 

--- a/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
@@ -45,34 +45,34 @@ public class UserRepositoryTest extends BaseHiltTest {
   @Test
   public void testGetCurrentUser() {
     assertThat(userRepository.getCurrentUser()).isNull();
-    fakeAuthenticationManager.setUser(FakeData.TEST_USER);
-    assertThat(userRepository.getCurrentUser()).isEqualTo(FakeData.TEST_USER);
+    fakeAuthenticationManager.setUser(FakeData.USER);
+    assertThat(userRepository.getCurrentUser()).isEqualTo(FakeData.USER);
   }
 
   @Test
   public void testGetUserRole() {
     Project project =
-        FakeData.TEST_PROJECT.toBuilder()
-            .setAcl(ImmutableMap.of(FakeData.TEST_USER.getEmail(), "contributor"))
+        FakeData.PROJECT.toBuilder()
+            .setAcl(ImmutableMap.of(FakeData.USER.getEmail(), "contributor"))
             .build();
 
     // Current user is authorized as contributor
-    fakeAuthenticationManager.setUser(FakeData.TEST_USER);
+    fakeAuthenticationManager.setUser(FakeData.USER);
     assertThat(userRepository.getUserRole(project)).isEqualTo(Role.CONTRIBUTOR);
 
     // Current user is unauthorized
-    fakeAuthenticationManager.setUser(FakeData.TEST_USER_2);
+    fakeAuthenticationManager.setUser(FakeData.USER_2);
     assertThat(userRepository.getUserRole(project)).isEqualTo(Role.UNKNOWN);
   }
 
   @Test
   public void testSaveUser() {
     localDataStore
-        .getUser(FakeData.TEST_USER.getId())
+        .getUser(FakeData.USER.getId())
         .test()
         .assertFailure(NoSuchElementException.class);
-    userRepository.saveUser(FakeData.TEST_USER).test().assertComplete();
-    localDataStore.getUser(FakeData.TEST_USER.getId()).test().assertResult(FakeData.TEST_USER);
+    userRepository.saveUser(FakeData.USER).test().assertComplete();
+    localDataStore.getUser(FakeData.USER.getId()).test().assertResult(FakeData.USER);
   }
 
   @Test

--- a/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
@@ -44,6 +44,7 @@ public class UserRepositoryTest extends BaseHiltTest {
 
   @Test
   public void testGetCurrentUser() {
+    fakeAuthenticationManager.setUser(null);
     assertThat(userRepository.getCurrentUser()).isNull();
     fakeAuthenticationManager.setUser(FakeData.USER);
     assertThat(userRepository.getCurrentUser()).isEqualTo(FakeData.USER);

--- a/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
@@ -52,7 +52,7 @@ public class UserRepositoryTest extends BaseHiltTest {
   @Test
   public void testGetUserRole() {
     Project project =
-        FakeData.PROJECT.toBuilder()
+        FakeData.PROJECT_WITH_LAYER_AND_NO_FORM.toBuilder()
             .setAcl(ImmutableMap.of(FakeData.USER.getEmail(), "contributor"))
             .build();
 

--- a/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/repository/UserRepositoryTest.java
@@ -56,11 +56,11 @@ public class UserRepositoryTest extends BaseHiltTest {
             .setAcl(ImmutableMap.of(FakeData.USER.getEmail(), "contributor"))
             .build();
 
-    // Current user is authorized as contributor
+    // Current user is authorized as contributor.
     fakeAuthenticationManager.setUser(FakeData.USER);
     assertThat(userRepository.getUserRole(project)).isEqualTo(Role.CONTRIBUTOR);
 
-    // Current user is unauthorized
+    // Current user is unauthorized.
     fakeAuthenticationManager.setUser(FakeData.USER_2);
     assertThat(userRepository.getUserRole(project)).isEqualTo(Role.UNKNOWN);
   }

--- a/gnd/src/test/java/com/google/android/gnd/system/ApplicationErrorManagerTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/system/ApplicationErrorManagerTest.java
@@ -63,7 +63,7 @@ public class ApplicationErrorManagerTest extends BaseHiltTest {
       boolean isConsumed = (boolean) input[1];
       assertThat(errorManager.handleException(exception)).isEqualTo(isConsumed);
 
-      // Expect an error message if the error is consumed
+      // Expect an error message if the error is consumed.
       if (isConsumed) {
         errorManager.getExceptions().test().assertValue((String) input[2]);
       } else {

--- a/gnd/src/test/java/com/google/android/gnd/ui/common/FeatureHelperTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/common/FeatureHelperTest.java
@@ -17,7 +17,7 @@
 package com.google.android.gnd.ui.common;
 
 import static com.google.android.gnd.FakeData.GEO_JSON_FEATURE;
-import static com.google.android.gnd.FakeData.LAYER_WITH_NO_FORM;
+import static com.google.android.gnd.FakeData.LAYER;
 import static com.google.android.gnd.FakeData.POINT_FEATURE;
 import static com.google.android.gnd.FakeData.POLYGON_FEATURE;
 import static com.google.android.gnd.FakeData.USER;
@@ -111,7 +111,7 @@ public class FeatureHelperTest extends BaseHiltTest {
   public void testGetSubtitle() {
     PointFeature feature =
         POINT_FEATURE.toBuilder()
-            .setLayer(LAYER_WITH_NO_FORM.toBuilder().setName("some layer").build())
+            .setLayer(LAYER.toBuilder().setName("some layer").build())
             .build();
 
     assertThat(featureHelper.getSubtitle(Optional.of(feature))).isEqualTo("Layer: some layer");

--- a/gnd/src/test/java/com/google/android/gnd/ui/common/FeatureHelperTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/common/FeatureHelperTest.java
@@ -17,7 +17,7 @@
 package com.google.android.gnd.ui.common;
 
 import static com.google.android.gnd.FakeData.GEO_JSON_FEATURE;
-import static com.google.android.gnd.FakeData.LAYER;
+import static com.google.android.gnd.FakeData.LAYER_WITH_NO_FORM;
 import static com.google.android.gnd.FakeData.POINT_FEATURE;
 import static com.google.android.gnd.FakeData.POLYGON_FEATURE;
 import static com.google.android.gnd.FakeData.USER;
@@ -110,7 +110,9 @@ public class FeatureHelperTest extends BaseHiltTest {
   @Test
   public void testGetSubtitle() {
     PointFeature feature =
-        POINT_FEATURE.toBuilder().setLayer(LAYER.toBuilder().setName("some layer").build()).build();
+        POINT_FEATURE.toBuilder()
+            .setLayer(LAYER_WITH_NO_FORM.toBuilder().setName("some layer").build())
+            .build();
 
     assertThat(featureHelper.getSubtitle(Optional.of(feature))).isEqualTo("Layer: some layer");
   }

--- a/gnd/src/test/java/com/google/android/gnd/ui/common/FeatureHelperTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/common/FeatureHelperTest.java
@@ -16,11 +16,11 @@
 
 package com.google.android.gnd.ui.common;
 
-import static com.google.android.gnd.FakeData.TEST_GEO_JSON_FEATURE;
-import static com.google.android.gnd.FakeData.TEST_LAYER;
-import static com.google.android.gnd.FakeData.TEST_POINT_FEATURE;
-import static com.google.android.gnd.FakeData.TEST_POLYGON_FEATURE;
-import static com.google.android.gnd.FakeData.TEST_USER;
+import static com.google.android.gnd.FakeData.GEO_JSON_FEATURE;
+import static com.google.android.gnd.FakeData.LAYER;
+import static com.google.android.gnd.FakeData.POINT_FEATURE;
+import static com.google.android.gnd.FakeData.POLYGON_FEATURE;
+import static com.google.android.gnd.FakeData.USER;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.android.gnd.BaseHiltTest;
@@ -46,8 +46,8 @@ public class FeatureHelperTest extends BaseHiltTest {
   @Test
   public void testGetCreatedBy() {
     PointFeature feature =
-        TEST_POINT_FEATURE.toBuilder()
-            .setCreated(AuditInfo.now(TEST_USER.toBuilder().setDisplayName("Test User").build()))
+        POINT_FEATURE.toBuilder()
+            .setCreated(AuditInfo.now(USER.toBuilder().setDisplayName("Test User").build()))
             .build();
 
     assertThat(featureHelper.getCreatedBy(Optional.of(feature))).isEqualTo("Added by Test User");
@@ -65,13 +65,13 @@ public class FeatureHelperTest extends BaseHiltTest {
 
   @Test
   public void testGetLabel_whenCaptionIsEmptyAndFeatureIsPoint() {
-    PointFeature feature = TEST_POINT_FEATURE.toBuilder().setCaption("").build();
+    PointFeature feature = POINT_FEATURE.toBuilder().setCaption("").build();
     assertThat(featureHelper.getLabel(Optional.of(feature))).isEqualTo("Point");
   }
 
   @Test
   public void testGetLabel_whenCaptionIsEmptyAndFeatureIsPolygon() {
-    PolygonFeature feature = TEST_POLYGON_FEATURE.toBuilder().setCaption("").build();
+    PolygonFeature feature = POLYGON_FEATURE.toBuilder().setCaption("").build();
     assertThat(featureHelper.getLabel(Optional.of(feature))).isEqualTo("Polygon");
   }
 
@@ -80,20 +80,20 @@ public class FeatureHelperTest extends BaseHiltTest {
     JSONObject propertiesJson = new JSONObject().put("id", "foo id").put("caption", "");
     JSONObject jsonObject = new JSONObject().put("properties", propertiesJson);
     GeoJsonFeature feature =
-        TEST_GEO_JSON_FEATURE.toBuilder().setGeoJsonString(jsonObject.toString()).build();
+        GEO_JSON_FEATURE.toBuilder().setGeoJsonString(jsonObject.toString()).build();
 
     assertThat(featureHelper.getLabel(Optional.of(feature))).isEqualTo("Polygon foo id");
   }
 
   @Test
   public void testGetLabel_whenCaptionIsPresentAndFeatureIsPoint() {
-    PointFeature feature = TEST_POINT_FEATURE.toBuilder().setCaption("point caption").build();
+    PointFeature feature = POINT_FEATURE.toBuilder().setCaption("point caption").build();
     assertThat(featureHelper.getLabel(Optional.of(feature))).isEqualTo("point caption");
   }
 
   @Test
   public void testGetLabel_whenCaptionIsPresentAndFeatureIsPolygon() {
-    PolygonFeature feature = TEST_POLYGON_FEATURE.toBuilder().setCaption("polygon caption").build();
+    PolygonFeature feature = POLYGON_FEATURE.toBuilder().setCaption("polygon caption").build();
     assertThat(featureHelper.getLabel(Optional.of(feature))).isEqualTo("polygon caption");
   }
 
@@ -102,7 +102,7 @@ public class FeatureHelperTest extends BaseHiltTest {
     JSONObject propertiesJson = new JSONObject().put("id", "foo id").put("caption", "foo caption");
     JSONObject jsonObject = new JSONObject().put("properties", propertiesJson);
     GeoJsonFeature feature =
-        TEST_GEO_JSON_FEATURE.toBuilder().setGeoJsonString(jsonObject.toString()).build();
+        GEO_JSON_FEATURE.toBuilder().setGeoJsonString(jsonObject.toString()).build();
 
     assertThat(featureHelper.getLabel(Optional.of(feature))).isEqualTo("foo caption");
   }
@@ -110,9 +110,7 @@ public class FeatureHelperTest extends BaseHiltTest {
   @Test
   public void testGetSubtitle() {
     PointFeature feature =
-        TEST_POINT_FEATURE.toBuilder()
-            .setLayer(TEST_LAYER.toBuilder().setName("some layer").build())
-            .build();
+        POINT_FEATURE.toBuilder().setLayer(LAYER.toBuilder().setName("some layer").build()).build();
 
     assertThat(featureHelper.getSubtitle(Optional.of(feature))).isEqualTo("Layer: some layer");
   }

--- a/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/BaseMenuVisibilityTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/BaseMenuVisibilityTest.java
@@ -42,7 +42,7 @@ public abstract class BaseMenuVisibilityTest extends BaseHiltTest {
       FakeData.USER.toBuilder().setEmail("user4@gmail.com").build();
 
   private static final Project TEST_PROJECT =
-      FakeData.PROJECT_WITH_LAYER_AND_NO_FORM.toBuilder()
+      FakeData.PROJECT.toBuilder()
           .setAcl(
               ImmutableMap.<String, String>builder()
                   .put(TEST_USER_OWNER.getEmail(), "owner")

--- a/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/BaseMenuVisibilityTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/BaseMenuVisibilityTest.java
@@ -42,7 +42,7 @@ public abstract class BaseMenuVisibilityTest extends BaseHiltTest {
       FakeData.USER.toBuilder().setEmail("user4@gmail.com").build();
 
   private static final Project TEST_PROJECT =
-      FakeData.PROJECT.toBuilder()
+      FakeData.PROJECT_WITH_LAYER_AND_NO_FORM.toBuilder()
           .setAcl(
               ImmutableMap.<String, String>builder()
                   .put(TEST_USER_OWNER.getEmail(), "owner")

--- a/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/BaseMenuVisibilityTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/ui/home/featuredetails/BaseMenuVisibilityTest.java
@@ -30,20 +30,19 @@ import javax.inject.Inject;
 
 public abstract class BaseMenuVisibilityTest extends BaseHiltTest {
 
-  static final User TEST_USER_OWNER =
-      FakeData.TEST_USER.toBuilder().setEmail("user1@gmail.com").build();
+  static final User TEST_USER_OWNER = FakeData.USER.toBuilder().setEmail("user1@gmail.com").build();
 
   static final User TEST_USER_MANAGER =
-      FakeData.TEST_USER.toBuilder().setEmail("user2@gmail.com").build();
+      FakeData.USER.toBuilder().setEmail("user2@gmail.com").build();
 
   static final User TEST_USER_CONTRIBUTOR =
-      FakeData.TEST_USER.toBuilder().setEmail("user3@gmail.com").build();
+      FakeData.USER.toBuilder().setEmail("user3@gmail.com").build();
 
   static final User TEST_USER_UNKNOWN =
-      FakeData.TEST_USER.toBuilder().setEmail("user4@gmail.com").build();
+      FakeData.USER.toBuilder().setEmail("user4@gmail.com").build();
 
   private static final Project TEST_PROJECT =
-      FakeData.TEST_PROJECT.toBuilder()
+      FakeData.PROJECT.toBuilder()
           .setAcl(
               ImmutableMap.<String, String>builder()
                   .put(TEST_USER_OWNER.getEmail(), "owner")
@@ -66,14 +65,14 @@ public abstract class BaseMenuVisibilityTest extends BaseHiltTest {
   }
 
   static PointFeature createPointFeature(User user) {
-    return FakeData.TEST_POINT_FEATURE.toBuilder()
+    return FakeData.POINT_FEATURE.toBuilder()
         .setProject(TEST_PROJECT)
         .setCreated(AuditInfo.now(user))
         .build();
   }
 
   static PolygonFeature createPolygonFeature(User user) {
-    return FakeData.TEST_POLYGON_FEATURE.toBuilder()
+    return FakeData.POLYGON_FEATURE.toBuilder()
         .setProject(TEST_PROJECT)
         .setCreated(AuditInfo.now(user))
         .build();


### PR DESCRIPTION
Refactor, merge duplicates, and rename fake data constants.

Also simplifies setting of test project in `FakeRemoteDataStore`, removing conditional logic (https://testing.googleblog.com/2014/07/testing-on-toilet-dont-put-logic-in.html). 

Fixes #1041.

@shobhitagarwal1612 PTAL?