### PR TITLE
[Polygon] Render a line between last added point and current target

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerFragment.java
@@ -104,7 +104,7 @@ public class MapContainerFragment extends AbstractMapViewerFragment {
         .subscribe(__ -> setDefaultMode());
     polygonDrawingViewModel
         .getPolygonFeature()
-        .observe(this, feature -> mapContainerViewModel.updateDrawnPolygonFeature(feature));
+        .observe(this, mapContainerViewModel::updateDrawnPolygonFeature);
     featureRepositionViewModel
         .getConfirmButtonClicks()
         .as(autoDisposable(this))


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1033
Fixes #1049

Displays a line between the last selected point and current camera target. Also includes code cleanup.

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

https://user-images.githubusercontent.com/8918023/142265832-d741015f-741e-4c19-8ec3-2d2396e2165c.mp4

@gino-m @atalekar  PTAL?

P.S. I'll try to add unit tests later in a separate PR.
