### PR TITLE
fix: show deletion mutations in sync status UI

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/RoomLocalDataStore.java
@@ -412,9 +412,11 @@ public class RoomLocalDataStore implements LocalDataStore {
         .flatMapCompletable(
             mutation -> {
               if (mutation instanceof ObservationMutation) {
-                return deleteObservation(((ObservationMutation) mutation).getObservationId());
+                // Deletions are finalized once the remote receives the delete and propagated locally
+                // via Project.syncFeatures
+                return Completable.complete();
               } else if (mutation instanceof FeatureMutation) {
-                return deleteFeature(mutation.getFeatureId());
+                return Completable.complete();
               } else {
                 return Completable.error(new RuntimeException("Unknown type : " + mutation));
               }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/FeatureMutationEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/FeatureMutationEntity.java
@@ -17,6 +17,7 @@
 package com.google.android.gnd.persistence.local.room.entity;
 
 import static androidx.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.SET_DEFAULT;
 import static com.google.android.gnd.persistence.local.room.entity.FeatureEntity.formatVertices;
 import static com.google.android.gnd.persistence.local.room.entity.FeatureEntity.parseVertices;
 
@@ -49,7 +50,7 @@ import java8.util.Optional;
             entity = FeatureEntity.class,
             parentColumns = "id",
             childColumns = "feature_id",
-            onDelete = CASCADE),
+            onDelete = SET_DEFAULT),
     indices = {@Index("feature_id")})
 public abstract class FeatureMutationEntity extends MutationEntity {
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/ObservationMutationEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/ObservationMutationEntity.java
@@ -17,6 +17,7 @@
 package com.google.android.gnd.persistence.local.room.entity;
 
 import static androidx.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.SET_DEFAULT;
 
 import androidx.annotation.Nullable;
 import androidx.room.ColumnInfo;
@@ -45,12 +46,12 @@ import org.json.JSONObject;
           entity = FeatureEntity.class,
           parentColumns = "id",
           childColumns = "feature_id",
-          onDelete = CASCADE),
+          onDelete = SET_DEFAULT),
       @ForeignKey(
           entity = ObservationEntity.class,
           parentColumns = "id",
           childColumns = "observation_id",
-          onDelete = CASCADE)
+          onDelete = SET_DEFAULT)
     },
     indices = {@Index("feature_id"), @Index("observation_id")})
 public abstract class ObservationMutationEntity extends MutationEntity {


### PR DESCRIPTION
Before, we cascaded deletions on the foreign keys for
feature/observation mutations, meaning all mutations for a
feature/observation were wiped from the DB, eradicating the user's
edit/sync history.

This change alters that behavior so that we keep mutations around even
after a feature is deleted. Additionally, it removes a redundant call
to deleteFeature when handling mutations (these are handled server side
and should not be finalized until deleted on the server--the local
project receives this update via syncFeatures).

fixes #1059
<img width="415" alt="Screen Shot 2021-11-18 at 2 27 23 PM" src="https://user-images.githubusercontent.com/11237600/142484196-14afe0a0-f392-4226-aa29-436042716947.png">


