### PR TITLE
refactor: clean up mbtiles parser; use RX

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
+++ b/gnd/src/main/java/com/google/android/gnd/repository/OfflineAreaRepository.java
@@ -270,12 +270,18 @@ public class OfflineAreaRepository {
         .map(ImmutableList::asList)
         .flatMap(Flowable::fromIterable)
         .firstOrError()
-        .flatMap(this::identifyAndHandleSource)
+        .flatMap(this::getTileSets)
         .doOnError(t -> Timber.e(t, "Couldn't retrieve basemap sources for the active project"));
   }
 
-  private Single<ImmutableList<TileSet>> identifyAndHandleSource(BaseMap baseMap)
-      throws IOException {
+  /**
+   * Returns a list of {@link TileSet}s corresponding to a given {@link BaseMap} based on the
+   * BaseMap's type.
+   *
+   * <p>This function may perform network IO when the provided BaseMap requires downloading TileSets
+   * locally.
+   */
+  private Single<ImmutableList<TileSet>> getTileSets(BaseMap baseMap) throws IOException {
     switch (baseMap.getType()) {
       case MBTILES_FOOTPRINTS:
         File tileFile = downloadOfflineBaseMapSource(baseMap);

--- a/gnd/src/main/java/com/google/android/gnd/util/ImmutableListCollector.java
+++ b/gnd/src/main/java/com/google/android/gnd/util/ImmutableListCollector.java
@@ -50,8 +50,8 @@ public abstract class ImmutableListCollector {
   }
 
   /**
-   * Returns a function for use in rx streams that maps a function over the contents of an immutable
-   * list and recollects the results back into an immutable list.
+   * Returns a function for use with RxJava Observables that maps a function over the contents of an
+   * immutable list and recollects the results back into an immutable list.
    *
    * <p>This eliminates list handling boilerplate when lists are used as rx stream values.
    */
@@ -61,8 +61,8 @@ public abstract class ImmutableListCollector {
     return x -> StreamSupport.stream(x).map(func).collect(toImmutableList());
   }
   /**
-   * Returns a function for use in rx streams that filters a list using a provided function and
-   * recollects the results back into an immutable list.
+   * Returns a function for use with RxJava Observables that filters a list using a provided
+   * function and recollects the results back into an immutable list.
    *
    * <p>This eliminates list handling boilerplate when lists are used as rx stream values.
    */

--- a/gnd/src/main/java/com/google/android/gnd/util/ImmutableListCollector.java
+++ b/gnd/src/main/java/com/google/android/gnd/util/ImmutableListCollector.java
@@ -60,6 +60,7 @@ public abstract class ImmutableListCollector {
           Function<T, E> func) {
     return x -> StreamSupport.stream(x).map(func).collect(toImmutableList());
   }
+
   /**
    * Returns a function for use with RxJava Observables that filters a list using a provided
    * function and recollects the results back into an immutable list.


### PR DESCRIPTION
This commit cleans up the mbtiles footprint parser by:

- deleting unused methods.
- wrapping return values in RX constructs
- making use of collection helpers to reduce stream boilerplate.

It also adds two helper functions to ImmutableList collector to simplify
working with collections in the context of RX streams.
