### PR TITLE
Replace deprecated API for launching intents

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/system/CameraManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/CameraManager.java
@@ -55,6 +55,13 @@ public class CameraManager {
     this.activityStreams = activityStreams;
   }
 
+  @Cold
+  public Completable obtainPermissionsIfNeeded() {
+    return permissionsManager
+        .obtainPermission(permission.WRITE_EXTERNAL_STORAGE)
+        .andThen(permissionsManager.obtainPermission(permission.CAMERA));
+  }
+
   /** Launches the system's photo capture flow, first obtaining permissions if necessary. */
   @Cold
   public Maybe<Nil> capturePhoto(File destFile) {

--- a/gnd/src/main/java/com/google/android/gnd/system/StorageManager.java
+++ b/gnd/src/main/java/com/google/android/gnd/system/StorageManager.java
@@ -35,7 +35,7 @@ import timber.log.Timber;
 @Singleton
 public class StorageManager {
 
-  static final int PICK_PHOTO_REQUEST_CODE = StorageManager.class.hashCode() & 0xffff;
+  public static final int PICK_PHOTO_REQUEST_CODE = StorageManager.class.hashCode() & 0xffff;
 
   private final PermissionsManager permissionsManager;
   private final ActivityStreams activityStreams;
@@ -49,6 +49,11 @@ public class StorageManager {
     this.permissionsManager = permissionsManager;
     this.activityStreams = activityStreams;
     this.bitmapUtil = bitmapUtil;
+  }
+
+  @Cold
+  public Completable obtainPermissionsIfNeeded() {
+    return permissionsManager.obtainPermission(permission.READ_EXTERNAL_STORAGE);
   }
 
   /**


### PR DESCRIPTION
TODO: Figure out a way to update the response in PhotoFieldViewModel from EditObservationViewModel.

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@... PTAL?
