### PR TITLE
Improve CI build time

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,7 +44,7 @@ steps:
         # 1. List all files except hidden dirs.
         # 2. Filter by filename ending with .gradle
         # 3. Convert continuous spaces into a single space
-        # 4. Pick 5th column containing file size. This causes a collision if only a number is flipped (eg 2.4 -> 2.5). Look for a better alternative.
+        # 4. Pick 5th column containing file size. This causes a collision if only a number is flipped (eg "v2.4" -> "v2.5"). Look for a better alternative.
         # 5. Calculate md5sum (for mac, use md5)
         # 6. Strip ending " -" if present
         ls -lR | grep -e "\.gradle$" | tr -s " " | cut -d " " -f5 | md5sum | sed 's/  -//' > hashsum
@@ -230,7 +230,6 @@ steps:
         if [ -f $(< hashsum)-cache.tgz ]; then
           echo "Cache already exists, skipping save cache"
         else
-          # TODO(https://github.com/google/ground-android/issues/1098): Do not persist indefinitely. Add a retention policy to GCS bucket.
           gsutil cp cache.tgz gs://${_CACHE_BUCKET}/$(< hashsum)-cache.tgz
         fi
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,8 +36,21 @@ steps:
   - name: 'gcr.io/cloud-builders/gsutil'
     id: &copy_build_cache 'Copying build cache'
     waitFor: [ '-' ]
-    # we use rsync and not cp so that this step doesn't fail the first time it's run
-    args: [ 'rsync', 'gs://${_CACHE_BUCKET}/', './' ]
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        #### Calculate md5sum and save to a file.
+        # 1. List all files except hidden dirs.
+        # 2. Filter by filename ending with .gradle
+        # 3. Convert continuous spaces into a single space
+        # 4. Pick 5th column containing file size. This causes a collision if only a number is flipped (eg 2.4 -> 2.5). Look for a better alternative.
+        # 5. Calculate md5sum (for mac, use md5)
+        # 6. Strip ending " -" if present
+        ls -lR | grep -e "\.gradle$" | tr -s " " | cut -d " " -f5 | md5sum | sed 's/  -//' > hashsum
+
+        echo "Hashsum: " $(< hashsum)
+        gsutil cp "gs://${_CACHE_BUCKET}/$(< hashsum)-cache.tgz" ./ || echo "No cache found."
 
   - name: 'gcr.io/$PROJECT_ID/android:base'
     id: &extract_build_cache 'Extracting tar'
@@ -46,7 +59,7 @@ steps:
     args:
       - '-c'
       - |
-        tar zxf cache.tgz || echo "No cache found."
+        tar zxf $(< hashsum)-cache.tgz || echo "No cache found."
 
   - name: 'gcr.io/$PROJECT_ID/android:28'
     id: &config_google_services 'Load debug google-services.json'
@@ -200,13 +213,26 @@ steps:
     args:
       - '-c'
       - |
-        tar zcf cache.tgz .gradle/caches .gradle/wrapper
+        if [ -f $(< hashsum)-cache.tgz ]; then
+          echo "Cache already exists, skipping build cache"
+        else
+          tar zcf cache.tgz .gradle/caches .gradle/wrapper
+        fi
 
   - name: 'gcr.io/cloud-builders/gsutil'
     id: &save_cache 'Save gradle cache to GCS'
+    entrypoint: 'bash'
     waitFor:
       - *compress_cache
-    args: [ 'cp', 'cache.tgz', 'gs://${_CACHE_BUCKET}/cache.tgz' ]
+    args:
+      - '-c'
+      - |
+        if [ -f $(< hashsum)-cache.tgz ]; then
+          echo "Cache already exists, skipping save cache"
+        else
+          # TODO(https://github.com/google/ground-android/issues/1098): Do not persist indefinitely. Add a retention policy to GCS bucket.
+          gsutil cp cache.tgz gs://${_CACHE_BUCKET}/$(< hashsum)-cache.tgz
+        fi
 
 options:
   env:


### PR DESCRIPTION
Improve overall run time:
 * Pull & extract cache only if dependencies have not changed
 * Build & save cache only when dependencies have changed

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #270

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
Current run time: ~13.5 mins
New run time:
Run # | Cache Present in bucket | Cache pulled & extracted | Cache built & saved | Time taken
------|-------------------------|---------------------------|----------------------|------------
 1 a1c24b7 | No / Obsolete | No | Yes | 00:09:37
 2 4b98ce9  | Yes | Yes | No | 00:06:52

Notes:
 * Since the md5 depends on file size, it might result in a collision if only a number is changed in the gradle file. But the improvements are still huge and we can tackle that minor problem later if needed.
 * We should also consider adding `retention policy` to the cache bucket to avoid storing obsolete caches.

@gino-m  PTAL?
