### PR TITLE
Remove "defaultStyle" from Layer

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/Config.java
+++ b/gnd/src/main/java/com/google/android/gnd/Config.java
@@ -27,7 +27,7 @@ public final class Config {
 
   // Local db settings.
   // TODO(#128): Reset version to 1 before releasing.
-  public static final int DB_VERSION = 87;
+  public static final int DB_VERSION = 88;
   public static final String DB_NAME = "gnd.db";
 
   // Firebase Cloud Firestore settings.

--- a/gnd/src/main/java/com/google/android/gnd/model/TestModelBuilders.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/TestModelBuilders.java
@@ -23,7 +23,6 @@ import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.form.Field.Type;
 import com.google.android.gnd.model.form.Form;
 import com.google.android.gnd.model.layer.Layer;
-import com.google.android.gnd.model.layer.Style;
 import com.google.common.collect.ImmutableList;
 import com.google.firebase.firestore.GeoPoint;
 import java.util.Date;
@@ -94,11 +93,7 @@ public class TestModelBuilders {
   }
 
   public static Layer.Builder newLayer() {
-    return Layer.newBuilder().setId("").setName("").setDefaultStyle(newStyle().build());
-  }
-
-  public static Style.Builder newStyle() {
-    return Style.builder().setColor("");
+    return Layer.newBuilder().setId("").setName("");
   }
 
   public static Form.Builder newForm() {

--- a/gnd/src/main/java/com/google/android/gnd/model/layer/Layer.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/layer/Layer.java
@@ -28,8 +28,6 @@ public abstract class Layer {
 
   public abstract String getName();
 
-  public abstract Style getDefaultStyle();
-
   public abstract Optional<Form> getForm();
 
   public Optional<Form> getForm(String formId) {
@@ -60,8 +58,6 @@ public abstract class Layer {
     public abstract Builder setId(String newId);
 
     public abstract Builder setName(String newName);
-
-    public abstract Builder setDefaultStyle(Style newDefaultStyle);
 
     public abstract Builder setForm(Optional<Form> form);
 

--- a/gnd/src/main/java/com/google/android/gnd/model/layer/Style.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/layer/Style.java
@@ -20,6 +20,9 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class Style {
+
+  public static final Style DEFAULT_MAP_STYLE = Style.builder().setColor("#ff9131").build();
+
   public abstract String getColor();
 
   public static Builder builder() {

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/LayerEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/LayerEntity.java
@@ -25,7 +25,6 @@ import androidx.room.Index;
 import androidx.room.PrimaryKey;
 import com.google.android.gnd.model.feature.FeatureType;
 import com.google.android.gnd.model.layer.Layer;
-import com.google.android.gnd.model.layer.Style;
 import com.google.android.gnd.persistence.local.room.relations.FormEntityAndRelations;
 import com.google.android.gnd.persistence.local.room.relations.LayerEntityAndRelations;
 import com.google.auto.value.AutoValue;
@@ -57,10 +56,6 @@ public abstract class LayerEntity {
   public abstract String getName();
 
   @CopyAnnotations
-  @ColumnInfo(name = "default_style")
-  public abstract Style getDefaultStyle();
-
-  @CopyAnnotations
   @Nullable
   @ColumnInfo(name = "project_id")
   public abstract String getProjectId();
@@ -75,7 +70,6 @@ public abstract class LayerEntity {
         .setId(layer.getId())
         .setProjectId(projectId)
         .setName(layer.getName())
-        .setDefaultStyle(layer.getDefaultStyle())
         .setContributorsCanAdd(new JSONArray(layer.getContributorsCanAdd()))
         .build();
   }
@@ -85,7 +79,6 @@ public abstract class LayerEntity {
     Layer.Builder layerBuilder =
         Layer.newBuilder()
             .setId(layerEntity.getId())
-            .setDefaultStyle(layerEntity.getDefaultStyle())
             .setName(layerEntity.getName());
 
     for (FormEntityAndRelations formEntityAndRelations :
@@ -121,11 +114,10 @@ public abstract class LayerEntity {
   }
 
   public static LayerEntity create(
-      String id, String name, Style defaultStyle, String projectId, JSONArray contributorsCanAdd) {
+      String id, String name, String projectId, JSONArray contributorsCanAdd) {
     return builder()
         .setId(id)
         .setName(name)
-        .setDefaultStyle(defaultStyle)
         .setProjectId(projectId)
         .setContributorsCanAdd(contributorsCanAdd)
         .build();
@@ -141,8 +133,6 @@ public abstract class LayerEntity {
     public abstract Builder setId(String id);
 
     public abstract Builder setName(String name);
-
-    public abstract Builder setDefaultStyle(Style defaultStyle);
 
     public abstract Builder setProjectId(String projectId);
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
@@ -22,20 +22,15 @@ import static java8.util.stream.StreamSupport.stream;
 
 import com.google.android.gnd.model.feature.FeatureType;
 import com.google.android.gnd.model.layer.Layer;
-import com.google.android.gnd.model.layer.Style;
 import com.google.common.collect.ImmutableList;
-import java8.util.Objects;
-import java8.util.Optional;
 import timber.log.Timber;
 
 /** Converts between Firestore documents and {@link Layer} instances. */
 class LayerConverter {
-  /** Black marker used when default remote data is corrupt or missing. */
-  private static final String FALLBACK_COLOR = "#000000";
 
   static Layer toLayer(String id, LayerNestedObject obj) {
     Layer.Builder layer = Layer.newBuilder();
-    layer.setId(id).setName(getLocalizedMessage(obj.getName())).setDefaultStyle(toStyle(obj));
+    layer.setId(id).setName(getLocalizedMessage(obj.getName()));
     if (obj.getForms() != null && !obj.getForms().isEmpty()) {
       if (obj.getForms().size() > 1) {
         Timber.e("Multiple forms not supported");
@@ -62,20 +57,5 @@ class LayerConverter {
       default:
         return FeatureType.UNKNOWN;
     }
-  }
-
-  private static Style toStyle(LayerNestedObject obj) {
-    return Optional.ofNullable(obj.getDefaultStyle())
-        .map(StyleConverter::toStyle)
-        .orElseGet(() -> LayerConverter.toStyleFromLegacyColorField(obj));
-  }
-
-  private static Style toStyleFromLegacyColorField(LayerNestedObject obj) {
-    // Use "color" field until web UI is updated:
-    // TODO(https://github.com/google/ground-platform/issues/402): Remove fallback once updated in
-    // web client.
-    return Style.builder()
-        .setColor(Objects.requireNonNullElse(obj.getColor(), FALLBACK_COLOR))
-        .build();
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/MapContainerViewModel.java
@@ -38,6 +38,7 @@ import com.google.android.gnd.model.feature.GeoJsonFeature;
 import com.google.android.gnd.model.feature.Point;
 import com.google.android.gnd.model.feature.PointFeature;
 import com.google.android.gnd.model.feature.PolygonFeature;
+import com.google.android.gnd.model.layer.Style;
 import com.google.android.gnd.repository.FeatureRepository;
 import com.google.android.gnd.repository.OfflineAreaRepository;
 import com.google.android.gnd.repository.ProjectRepository;
@@ -212,7 +213,7 @@ public class MapContainerViewModel extends AbstractViewModel {
     return MapPin.newBuilder()
         .setId(feature.getId())
         .setPosition(feature.getPoint())
-        .setStyle(feature.getLayer().getDefaultStyle())
+        .setStyle(Style.DEFAULT_MAP_STYLE)
         .setFeature(feature)
         .build();
   }
@@ -221,7 +222,7 @@ public class MapContainerViewModel extends AbstractViewModel {
     return MapPolygon.newBuilder()
         .setId(feature.getId())
         .setVertices(feature.getVertices())
-        .setStyle(feature.getLayer().getDefaultStyle())
+        .setStyle(Style.DEFAULT_MAP_STYLE)
         .setFeature(feature)
         .build();
   }
@@ -304,7 +305,7 @@ public class MapContainerViewModel extends AbstractViewModel {
     return MapGeoJson.newBuilder()
         .setId(feature.getId())
         .setGeoJson(jsonObject)
-        .setStyle(feature.getLayer().getDefaultStyle())
+        .setStyle(Style.DEFAULT_MAP_STYLE)
         .setStrokeWidth(defaultPolygonStrokeWidth)
         .setFeature(feature)
         .build();

--- a/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/PolygonDrawingViewModel.kt
+++ b/gnd/src/main/java/com/google/android/gnd/ui/home/mapcontainer/PolygonDrawingViewModel.kt
@@ -16,38 +16,38 @@
 package com.google.android.gnd.ui.home.mapcontainer
 
 import androidx.lifecycle.LiveData
-import com.google.android.gnd.rx.BooleanOrError.Companion.falseValue
-import com.google.android.gnd.ui.common.SharedViewModel
-import javax.inject.Inject
-import com.google.android.gnd.system.auth.AuthenticationManager
-import com.google.android.gnd.persistence.uuid.OfflineUuidGenerator
-import com.google.android.gnd.ui.common.AbstractViewModel
-import com.google.android.gnd.rx.annotations.Hot
-import io.reactivex.subjects.PublishSubject
-import com.google.android.gnd.ui.map.MapPolygon
-import com.google.android.gnd.ui.map.MapFeature
-import com.google.android.gnd.rx.BooleanOrError
-import io.reactivex.processors.BehaviorProcessor
-import com.google.android.gnd.model.Project
-import io.reactivex.Flowable
-import io.reactivex.BackpressureStrategy
-import timber.log.Timber
-import com.google.android.gnd.model.AuditInfo
-import com.google.android.gnd.model.feature.PolygonFeature
-import com.google.android.gnd.ui.map.MapPin
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.lifecycle.MutableLiveData
 import com.google.android.gnd.R
+import com.google.android.gnd.model.AuditInfo
+import com.google.android.gnd.model.Project
 import com.google.android.gnd.model.feature.Point
+import com.google.android.gnd.model.feature.PolygonFeature
 import com.google.android.gnd.model.layer.Layer
+import com.google.android.gnd.model.layer.Style
+import com.google.android.gnd.persistence.uuid.OfflineUuidGenerator
+import com.google.android.gnd.rx.BooleanOrError
+import com.google.android.gnd.rx.BooleanOrError.Companion.falseValue
+import com.google.android.gnd.rx.annotations.Hot
 import com.google.android.gnd.system.LocationManager
+import com.google.android.gnd.system.auth.AuthenticationManager
+import com.google.android.gnd.ui.common.AbstractViewModel
+import com.google.android.gnd.ui.common.SharedViewModel
+import com.google.android.gnd.ui.map.MapFeature
+import com.google.android.gnd.ui.map.MapPin
+import com.google.android.gnd.ui.map.MapPolygon
 import com.google.auto.value.AutoValue
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSet
+import io.reactivex.BackpressureStrategy
+import io.reactivex.Flowable
 import io.reactivex.Observable
+import io.reactivex.processors.BehaviorProcessor
+import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import java8.util.Optional
-import java.util.ArrayList
+import timber.log.Timber
+import javax.inject.Inject
 
 @SharedViewModel
 class PolygonDrawingViewModel @Inject internal constructor(
@@ -207,7 +207,7 @@ class PolygonDrawingViewModel @Inject internal constructor(
             MapPolygon.newBuilder()
                 .setId(uuidGenerator.generateUuid())
                 .setVertices(ImmutableList.of())
-                .setStyle(selectedLayer.defaultStyle)
+                .setStyle(Style.DEFAULT_MAP_STYLE)
                 .build()
         )
     }

--- a/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
+++ b/gnd/src/sharedTest/java/com/google/android/gnd/FakeData.java
@@ -26,7 +26,6 @@ import com.google.android.gnd.model.feature.PointFeature;
 import com.google.android.gnd.model.feature.PolygonFeature;
 import com.google.android.gnd.model.layer.Layer;
 import com.google.android.gnd.model.layer.Layer.Builder;
-import com.google.android.gnd.model.layer.Style;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -45,10 +44,7 @@ public class FakeData {
   public static final Layer LAYER = newLayer().build();
 
   public static Builder newLayer() {
-    return Layer.newBuilder()
-        .setId("LAYER")
-        .setName("Layer")
-        .setDefaultStyle(Style.builder().setColor("#00ff00").build());
+    return Layer.newBuilder().setId("LAYER").setName("Layer");
   }
 
   public static final User USER =

--- a/gnd/src/test/java/com/google/android/gnd/persistence/local/LocalDataStoreTest.java
+++ b/gnd/src/test/java/com/google/android/gnd/persistence/local/LocalDataStoreTest.java
@@ -35,7 +35,6 @@ import com.google.android.gnd.model.form.Element;
 import com.google.android.gnd.model.form.Field;
 import com.google.android.gnd.model.form.Form;
 import com.google.android.gnd.model.layer.Layer;
-import com.google.android.gnd.model.layer.Style;
 import com.google.android.gnd.model.mutation.FeatureMutation;
 import com.google.android.gnd.model.mutation.Mutation;
 import com.google.android.gnd.model.mutation.Mutation.SyncStatus;
@@ -84,12 +83,7 @@ public class LocalDataStoreTest extends BaseHiltTest {
           .build();
 
   private static final Layer TEST_LAYER =
-      Layer.newBuilder()
-          .setId("layer id")
-          .setName("heading title")
-          .setDefaultStyle(Style.builder().setColor("000").build())
-          .setForm(TEST_FORM)
-          .build();
+      Layer.newBuilder().setId("layer id").setName("heading title").setForm(TEST_FORM).build();
 
   private static final Project TEST_PROJECT =
       Project.newBuilder()
@@ -254,18 +248,8 @@ public class LocalDataStoreTest extends BaseHiltTest {
 
   @Test
   public void testRemovedLayerFromProject() {
-    Layer layer1 =
-        Layer.newBuilder()
-            .setId("layer 1")
-            .setName("layer 1 name")
-            .setDefaultStyle(Style.builder().setColor("000").build())
-            .build();
-    Layer layer2 =
-        Layer.newBuilder()
-            .setId("layer 2")
-            .setName("layer 2 name")
-            .setDefaultStyle(Style.builder().setColor("000").build())
-            .build();
+    Layer layer1 = Layer.newBuilder().setId("layer 1").setName("layer 1 name").build();
+    Layer layer2 = Layer.newBuilder().setId("layer 2").setName("layer 2 name").build();
 
     Project project =
         Project.newBuilder()


### PR DESCRIPTION
Use orange accent color as default styling

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1129 

<!-- PR description. -->
Removes "default style" from Layer object and local entity. Defaults the style to map accent color.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor ObservationViewModel allow modification of sort order.
- [x] Sort results when returned from ObservationRepository.
-->

<!-- Add steps to verify bug/feature. -->

Tested by running unit tests and instrumentation tests locally.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@JSunde  PTAL?
