### PR TITLE
Remove contributorsCanAdd

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/Config.kt
+++ b/gnd/src/main/java/com/google/android/gnd/Config.kt
@@ -25,7 +25,7 @@ object Config {
 
     // Local db settings.
     // TODO(#128): Reset version to 1 before releasing.
-    const val DB_VERSION = 88
+    const val DB_VERSION = 89
     const val DB_NAME = "gnd.db"
 
     // Firebase Cloud Firestore settings.

--- a/gnd/src/main/java/com/google/android/gnd/model/layer/Layer.java
+++ b/gnd/src/main/java/com/google/android/gnd/model/layer/Layer.java
@@ -34,14 +34,7 @@ public abstract class Layer {
     return getForm().filter(form -> form.getId().equals(formId));
   }
 
-  /** Returns the list of feature types contributors may to add to this layer. */
-  public abstract ImmutableList<FeatureType> getContributorsCanAdd();
-
-  /**
-   * Returns the list of feature types the current user may add to this layer. If the user has
-   * contributor role, this will be equivalent to `getContributorsCanAdd()`. For managers and
-   * owners, all possible `FeatureType`s will be return.
-   */
+  /** Returns the list of feature types the current user may add to this layer. */
   public abstract ImmutableList<FeatureType> getUserCanAdd();
 
   public abstract Builder toBuilder();
@@ -49,7 +42,6 @@ public abstract class Layer {
   public static Builder newBuilder() {
     return new AutoValue_Layer.Builder()
         .setForm(Optional.empty())
-        .setContributorsCanAdd(ImmutableList.of())
         .setUserCanAdd(ImmutableList.of());
   }
 
@@ -60,8 +52,6 @@ public abstract class Layer {
     public abstract Builder setName(String newName);
 
     public abstract Builder setForm(Optional<Form> form);
-
-    public abstract Builder setContributorsCanAdd(ImmutableList<FeatureType> contributorsCanAdd);
 
     public abstract Builder setUserCanAdd(ImmutableList<FeatureType> userCanAdd);
 

--- a/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/LayerEntity.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/local/room/entity/LayerEntity.java
@@ -23,14 +23,11 @@ import androidx.room.Entity;
 import androidx.room.ForeignKey;
 import androidx.room.Index;
 import androidx.room.PrimaryKey;
-import com.google.android.gnd.model.feature.FeatureType;
 import com.google.android.gnd.model.layer.Layer;
 import com.google.android.gnd.persistence.local.room.relations.FormEntityAndRelations;
 import com.google.android.gnd.persistence.local.room.relations.LayerEntityAndRelations;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.AutoValue.CopyAnnotations;
-import com.google.common.collect.ImmutableList;
-import org.json.JSONArray;
 
 @AutoValue
 @Entity(
@@ -60,17 +57,11 @@ public abstract class LayerEntity {
   @ColumnInfo(name = "project_id")
   public abstract String getProjectId();
 
-  @CopyAnnotations
-  @Nullable
-  @ColumnInfo(name = "contributors_can_add")
-  public abstract JSONArray getContributorsCanAdd();
-
   public static LayerEntity fromLayer(String projectId, Layer layer) {
     return LayerEntity.builder()
         .setId(layer.getId())
         .setProjectId(projectId)
         .setName(layer.getName())
-        .setContributorsCanAdd(new JSONArray(layer.getContributorsCanAdd()))
         .build();
   }
 
@@ -86,40 +77,14 @@ public abstract class LayerEntity {
       layerBuilder.setForm(FormEntity.toForm(formEntityAndRelations));
     }
 
-    layerBuilder.setContributorsCanAdd(toFeatureTypes(layerEntity.getContributorsCanAdd()));
-
     return layerBuilder.build();
   }
 
-  private static ImmutableList<FeatureType> toFeatureTypes(JSONArray jsonArray) {
-    ImmutableList.Builder<FeatureType> builder = ImmutableList.builder();
-    for (int i = 0; i < jsonArray.length(); i++) {
-      String value = jsonArray.optString(i, null);
-      if (value != null) {
-        builder.add(toFeatureType(value));
-      }
-    }
-    return builder.build();
-  }
-
-  private static FeatureType toFeatureType(String stringValue) {
-    switch (stringValue) {
-      case "points":
-        return FeatureType.POINT;
-      case "polygons":
-        return FeatureType.POLYGON;
-      default:
-        return FeatureType.UNKNOWN;
-    }
-  }
-
-  public static LayerEntity create(
-      String id, String name, String projectId, JSONArray contributorsCanAdd) {
+  public static LayerEntity create(String id, String name, String projectId) {
     return builder()
         .setId(id)
         .setName(name)
         .setProjectId(projectId)
-        .setContributorsCanAdd(contributorsCanAdd)
         .build();
   }
 
@@ -135,8 +100,6 @@ public abstract class LayerEntity {
     public abstract Builder setName(String name);
 
     public abstract Builder setProjectId(String projectId);
-
-    public abstract Builder setContributorsCanAdd(JSONArray contributorsCanAdd);
 
     public abstract LayerEntity build();
   }

--- a/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
+++ b/gnd/src/main/java/com/google/android/gnd/persistence/remote/firestore/schema/LayerConverter.java
@@ -16,13 +16,9 @@
 
 package com.google.android.gnd.persistence.remote.firestore.schema;
 
-import static com.google.android.gnd.util.ImmutableListCollector.toImmutableList;
 import static com.google.android.gnd.util.Localization.getLocalizedMessage;
-import static java8.util.stream.StreamSupport.stream;
 
-import com.google.android.gnd.model.feature.FeatureType;
 import com.google.android.gnd.model.layer.Layer;
-import com.google.common.collect.ImmutableList;
 import timber.log.Timber;
 
 /** Converts between Firestore documents and {@link Layer} instances. */
@@ -38,24 +34,6 @@ class LayerConverter {
       String formId = obj.getForms().keySet().iterator().next();
       layer.setForm(FormConverter.toForm(formId, obj.getForms().get(formId)));
     }
-    if (obj.getContributorsCanAdd() != null) {
-      ImmutableList<FeatureType> featureTypes =
-          stream(obj.getContributorsCanAdd())
-              .map(LayerConverter::toFeatureType)
-              .collect(toImmutableList());
-      layer.setContributorsCanAdd(featureTypes);
-    }
     return layer.build();
-  }
-
-  private static FeatureType toFeatureType(String stringValue) {
-    switch (stringValue) {
-      case "points":
-        return FeatureType.POINT;
-      case "polygons":
-        return FeatureType.POLYGON;
-      default:
-        return FeatureType.UNKNOWN;
-    }
   }
 }

--- a/gnd/src/main/java/com/google/android/gnd/repository/ProjectRepository.kt
+++ b/gnd/src/main/java/com/google/android/gnd/repository/ProjectRepository.kt
@@ -107,17 +107,16 @@ class ProjectRepository @Inject constructor(
         for (layer in project.layers) {
             layers.put(
                 layer.id,
-                layer.toBuilder().setUserCanAdd(getAddableFeatureTypes(userRole, layer)).build()
+                layer.toBuilder().setUserCanAdd(getAddableFeatureTypes(userRole)).build()
             )
         }
         return project.toBuilder().setLayerMap(layers.build()).build()
     }
 
-    private fun getAddableFeatureTypes(userRole: Role, layer: Layer): ImmutableList<FeatureType> =
+    private fun getAddableFeatureTypes(userRole: Role): ImmutableList<FeatureType> =
         when (userRole) {
             Role.OWNER, Role.MANAGER -> FeatureType.ALL
-            Role.CONTRIBUTOR -> layer.contributorsCanAdd
-            Role.UNKNOWN -> ImmutableList.of()
+            else -> ImmutableList.of()
         }
 
     /** This only works if the project is already cached to local db.  */

--- a/gnd/src/test/java/com/google/android/gnd/ui/home/AddFeatureDialogFragmentTest.kt
+++ b/gnd/src/test/java/com/google/android/gnd/ui/home/AddFeatureDialogFragmentTest.kt
@@ -15,21 +15,21 @@
  */
 package com.google.android.gnd.ui.home
 
-import dagger.hilt.android.testing.HiltAndroidTest
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import com.google.android.gnd.BaseHiltTest
-import org.junit.Before
-import com.google.android.gnd.MainActivity
-import org.robolectric.Robolectric
-import org.robolectric.Shadows
 import android.os.Looper
 import android.view.View
+import com.google.android.gnd.BaseHiltTest
 import com.google.android.gnd.FakeData
-import com.google.common.truth.Truth.assertThat
+import com.google.android.gnd.MainActivity
 import com.google.android.gnd.model.feature.FeatureType
 import com.google.common.collect.ImmutableList
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
@@ -54,11 +54,11 @@ class AddFeatureDialogFragmentTest : BaseHiltTest() {
 
         val layer1 = FakeData.newLayer()
             .setId("Layer 1")
-            .setContributorsCanAdd(ImmutableList.of(FeatureType.POINT))
+            .setUserCanAdd(ImmutableList.of(FeatureType.POINT))
             .build()
         val layer2 = FakeData.newLayer()
             .setId("Layer 2")
-            .setContributorsCanAdd(ImmutableList.of(FeatureType.POLYGON))
+            .setUserCanAdd(ImmutableList.of(FeatureType.POLYGON))
             .build()
         addFeatureDialogFragment.show(listOf(layer1, layer2), activity.supportFragmentManager
         ) { }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1130

<!-- PR description. -->

- [x] Removes `contributorsCanAdd` from layer

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->


