### PR TITLE
fix: execute navigations on the main thread

### DIFF
--- a/gnd/src/main/java/com/google/android/gnd/MainViewModel.kt
+++ b/gnd/src/main/java/com/google/android/gnd/MainViewModel.kt
@@ -73,8 +73,8 @@ class MainViewModel @Inject constructor(
         disposeOnClear(
             authenticationManager
                 .signInState
-                .observeOn(schedulers.ui())
                 .compose(switchMapIfPresent(SignInState::user) { userRepository.saveUser(it) })
+                .observeOn(schedulers.ui())
                 .switchMap { signInState: SignInState -> onSignInStateChange(signInState) }
                 .subscribe { directions: NavDirections -> navigator.navigate(directions) })
     }


### PR DESCRIPTION
This fixes an issue on startup whereby navigations were executed on the
IO thread (which android doesn't allow). We compose the auth manager
stream with the userRepository. The userRepository returns an observable
that observes on the IO thread; post-composition, the resulting stream
takes the observation thread of the compose argument; so the final
stream was being observed on the IO thread.

The fix is straightforward: set the resulting stream to observe on the
UI thread after the composition is performed.

@gino-m @shobhitagarwal1612 
