### PR TITLE
Run instrumentation tests only for push to master

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,7 @@
 #                                \                   /                                                                     \
 #                                 > Build debug apks                                                                       Save reports to GCS --> Update CI status --> Compress gradle cache --> Save gradle cache to GCS
 #                                /                   \                                                                     /
-#  Fetch google-services.json -->                      --> Authorize Gcloud --> Build test apks --> Instrumented tests -->
+#  Fetch google-services.json -->                      (master only)-----> Authorize Gcloud --> Instrumented tests ------>
 #
 # Notes:
 # ------
@@ -78,7 +78,11 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex assembleStaging assembleStagingUnitTest assembleStagingAndroidTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex assembleStaging assembleStagingUnitTest -PtestBuildType=staging
+
+        if [[ "${_PUSH_TO_MASTER}" ]]; then
+          ./gradlew -PdisablePreDex assembleStagingAndroidTest -PtestBuildType=staging
+        fi
 
   # Run code quality checks
   - name: 'gcr.io/$PROJECT_ID/android:28'
@@ -128,16 +132,20 @@ steps:
     args:
       - '-c'
       - |
-        gcloud --quiet beta firebase test android run \
-        --type instrumentation --num-uniform-shards=1 \
-        --app ground/build/outputs/apk/staging/*.apk \
-        --test ground/build/outputs/apk/androidTest/staging/*.apk \
-        --device model=Pixel2,version=28,locale=en,orientation=portrait \
-        --results-bucket ${_ARTIFACT_BUCKET} \
-        --results-dir "$BRANCH_NAME-$BUILD_ID/reports" \
-        --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
-        --directories-to-pull /sdcard \
-        --timeout 20m
+        if [[ "${_PUSH_TO_MASTER}" ]]; then
+          gcloud --quiet beta firebase test android run \
+          --type instrumentation --num-uniform-shards=1 \
+          --app ground/build/outputs/apk/staging/*.apk \
+          --test ground/build/outputs/apk/androidTest/staging/*.apk \
+          --device model=Pixel2,version=28,locale=en,orientation=portrait \
+          --results-bucket ${_ARTIFACT_BUCKET} \
+          --results-dir "$BRANCH_NAME-$BUILD_ID/reports" \
+          --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
+          --directories-to-pull /sdcard \
+          --timeout 20m
+        else
+          echo "Skipping"
+        fi
 
   - name: 'gcr.io/cloud-builders/gsutil'
     id: &save_reports 'Save reports to GCS'


### PR DESCRIPTION
Changes made:
 1. Building instrumentation apk in "assemble_debug" step
 2. Running instrumentation tests in firebase test lab

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->



<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
