### PR TITLE
Cleanup out of range Data Collection fragments

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -55,7 +55,7 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
         val binding = DataCollectionFragBinding.inflate(inflater, container, false)
         viewPager = binding.root.findViewById(R.id.pager)
         viewPager.isUserInputEnabled = false
-        viewPager.offscreenPageLimit = 3
+        viewPager.offscreenPageLimit = 1
 
         viewModel.loadSubmissionDetails(args)
         viewModel.submission.observe(viewLifecycleOwner) { submission: Loadable<Submission> ->

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -55,6 +55,7 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
         val binding = DataCollectionFragBinding.inflate(inflater, container, false)
         viewPager = binding.root.findViewById(R.id.pager)
         viewPager.isUserInputEnabled = false
+        viewPager.offscreenPageLimit = 3
 
         viewModel.loadSubmissionDetails(args)
         viewModel.submission.observe(viewLifecycleOwner) { submission: Loadable<Submission> ->


### PR DESCRIPTION
Set the offScreenPageLimit of the Data Collection ViewPager2 to 1 to clean up fragments older than the last one and newer than the next one.

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m PTAL?
