### PR TITLE
Save config for google chat notifications

### DIFF
--- a/cloud-builder/chat-notifier.yaml
+++ b/cloud-builder/chat-notifier.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sends a notification to Google Chat Space.
+# Deployment steps: https://cloud.google.com/build/docs/configuring-notifications/configure-googlechat#configuring_google_chat_notifications
+# Config API documentation: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds
+
+apiVersion: cloud-build-notifiers/v1
+kind: GoogleChatNotifier
+metadata:
+  name: googlechat-notifier
+spec:
+  notification:
+    filter: build.status in [Build.Status.SUCCESS, Build.Status.FAILURE, Build.Status.TIMEOUT] && build.substitutions["BRANCH_NAME"] == "master" && build.substitutions["REPO_NAME"] == "ground-android"
+    delivery:
+      webhookUrl:
+        secretRef: webhook-url
+  secrets:
+    - name: webhook-url
+      value: projects/264658303667/secrets/google_chat_android_webhook/versions/latest


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #1177 

<!-- PR description. -->
Configures a google chat notifier when a build is passes / fails / timeouts on the master branch.
https://cloud.google.com/build/docs/configuring-notifications/notifiers

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

How does it work?

![image](https://user-images.githubusercontent.com/8918023/183302687-8dec4a07-ac32-4680-b48a-21a25690e47f.png)

Cloud run free tier:
![image](https://user-images.githubusercontent.com/8918023/183302725-03ce53f6-211a-4446-ae27-f840b61b8934.png)


<!-- Add steps to verify bug/feature. -->
Tested by removing the "master" filter and triggering a cloud build. A notification was sent to the google chat space after the build was complete. 
![image](https://user-images.githubusercontent.com/8918023/183302587-62e06ab9-cde9-4186-8883-cf9d59a6350c.png)


<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?

P.S. The same config can be extended to be used for web repo