### PR TITLE
Replace ValueOrError with Result in firestore

### DIFF
--- a/ground/src/main/java/com/google/android/ground/persistence/remote/RemoteDataStore.java
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/RemoteDataStore.java
@@ -23,7 +23,6 @@ import com.google.android.ground.model.User;
 import com.google.android.ground.model.locationofinterest.LocationOfInterest;
 import com.google.android.ground.model.mutation.Mutation;
 import com.google.android.ground.model.submission.Submission;
-import com.google.android.ground.rx.ValueOrError;
 import com.google.android.ground.rx.annotations.Cold;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
@@ -32,6 +31,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 import java.util.List;
+import kotlin.Result;
 
 /**
  * Defines API for accessing data in a remote data store. Implementations must ensure all
@@ -69,8 +69,7 @@ public interface RemoteDataStore {
    * are found.
    */
   @Cold
-  Single<ImmutableList<ValueOrError<Submission>>> loadSubmissions(
-      LocationOfInterest locationOfInterest);
+  Single<ImmutableList<Result<Submission>>> loadSubmissions(LocationOfInterest locationOfInterest);
 
   /**
    * Applies the provided mutations to the remote data store in a single batched transaction. If one

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firestore/FirestoreDataStore.java
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firestore/FirestoreDataStore.java
@@ -32,7 +32,6 @@ import com.google.android.ground.persistence.remote.RemoteDataStore;
 import com.google.android.ground.persistence.remote.firestore.schema.GroundFirestore;
 import com.google.android.ground.rx.RxTask;
 import com.google.android.ground.rx.Schedulers;
-import com.google.android.ground.rx.ValueOrError;
 import com.google.android.ground.rx.annotations.Cold;
 import com.google.android.ground.system.ApplicationErrorManager;
 import com.google.common.collect.ImmutableCollection;
@@ -47,6 +46,7 @@ import io.reactivex.Single;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import kotlin.Result;
 import timber.log.Timber;
 
 @Singleton
@@ -87,7 +87,7 @@ public class FirestoreDataStore implements RemoteDataStore {
 
   @Cold
   @Override
-  public Single<ImmutableList<ValueOrError<Submission>>> loadSubmissions(
+  public Single<ImmutableList<Result<Submission>>> loadSubmissions(
       LocationOfInterest locationOfInterest) {
     return db.surveys()
         .survey(locationOfInterest.getSurvey().getId())

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firestore/schema/SubmissionCollectionReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firestore/schema/SubmissionCollectionReference.kt
@@ -19,8 +19,6 @@ package com.google.android.ground.persistence.remote.firestore.schema
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.model.submission.Submission
 import com.google.android.ground.persistence.remote.firestore.base.FluentCollectionReference
-import com.google.android.ground.rx.ValueOrError
-import com.google.android.ground.rx.ValueOrError.Companion.create
 import com.google.android.ground.rx.annotations.Cold
 import com.google.android.ground.util.toImmutableList
 import com.google.common.collect.ImmutableList
@@ -35,7 +33,7 @@ class SubmissionCollectionReference internal constructor(ref: CollectionReferenc
 
     fun submissionsByLocationOfInterestId(
         locationOfInterest: LocationOfInterest
-    ): @Cold Single<ImmutableList<ValueOrError<Submission?>>> {
+    ): @Cold Single<ImmutableList<Result<Submission>>> {
         return RxFirestore.getCollection(byLoiId(locationOfInterest.id))
             .map { querySnapshot: QuerySnapshot -> convert(querySnapshot, locationOfInterest) }
             .toSingle(ImmutableList.of())
@@ -43,10 +41,10 @@ class SubmissionCollectionReference internal constructor(ref: CollectionReferenc
 
     private fun convert(
         querySnapshot: QuerySnapshot, locationOfInterest: LocationOfInterest
-    ): ImmutableList<ValueOrError<Submission?>> {
+    ): ImmutableList<Result<Submission>> {
         return querySnapshot.documents
             .map { doc: DocumentSnapshot ->
-                create {
+                runCatching {
                     SubmissionConverter.toSubmission(locationOfInterest, doc)
                 }
             }

--- a/ground/src/main/java/com/google/android/ground/repository/SubmissionRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SubmissionRepository.kt
@@ -26,12 +26,10 @@ import com.google.android.ground.model.submission.ResponseDelta
 import com.google.android.ground.model.submission.Submission
 import com.google.android.ground.persistence.local.LocalDataStore
 import com.google.android.ground.persistence.local.room.models.MutationEntitySyncStatus
-import com.google.android.ground.persistence.remote.DataStoreException
 import com.google.android.ground.persistence.remote.NotFoundException
 import com.google.android.ground.persistence.remote.RemoteDataStore
 import com.google.android.ground.persistence.sync.DataSyncWorkManager
 import com.google.android.ground.persistence.uuid.OfflineUuidGenerator
-import com.google.android.ground.rx.ValueOrError
 import com.google.android.ground.rx.annotations.Cold
 import com.google.android.ground.system.auth.AuthenticationManager
 import com.google.common.collect.ImmutableList
@@ -92,22 +90,23 @@ class SubmissionRepository @Inject constructor(
             .loadSubmissions(locationOfInterest)
             .timeout(LOAD_REMOTE_SUBMISSIONS_TIMEOUT_SECS, TimeUnit.SECONDS)
             .doOnError { Timber.e(it, "Submission sync timed out") }
-            .flatMapCompletable { submissions: ImmutableList<ValueOrError<Submission>> ->
+            .flatMapCompletable { submissions: ImmutableList<Result<Submission>> ->
                 mergeRemoteSubmissions(submissions)
             }
             .onErrorComplete()
         return remoteSync.andThen(localDataStore.getSubmissions(locationOfInterest, taskId))
     }
 
-    private fun mergeRemoteSubmissions(submissions: ImmutableList<ValueOrError<Submission>>): @Cold Completable {
+    private fun mergeRemoteSubmissions(submissions: ImmutableList<Result<Submission>>): @Cold Completable {
         return Observable.fromIterable(submissions)
-            .doOnNext { voe: ValueOrError<Submission> ->
-                voe.error().ifPresent { Timber.e(it, "Skipping bad submission") }
+            .doOnNext { result: Result<Submission> ->
+                if (result.isFailure) {
+                    Timber.e(result.exceptionOrNull(), "Skipping bad submission")
+                }
             }
-            .compose { ValueOrError.ignoreErrors(it) }
-            .flatMapCompletable { submission: Submission ->
-                localDataStore.mergeSubmission(submission)
-            }
+            .filter { it.isSuccess }
+            .map { it.getOrThrow() }
+            .flatMapCompletable { localDataStore.mergeSubmission(it) }
     }
 
     fun getSubmission(

--- a/ground/src/main/java/com/google/android/ground/rx/ValueOrError.kt
+++ b/ground/src/main/java/com/google/android/ground/rx/ValueOrError.kt
@@ -15,9 +15,7 @@
  */
 package com.google.android.ground.rx
 
-import io.reactivex.Observable
 import java8.util.Optional
-import java8.util.function.Supplier
 
 /**
  * Represents the outcome of an operation that either succeeds with a value, or fails with an
@@ -34,27 +32,4 @@ open class ValueOrError<T> protected constructor(
     fun value(): Optional<T> = Optional.ofNullable(value)
 
     fun error(): Optional<Throwable?> = Optional.ofNullable(error)
-
-    companion object {
-        /** Returns the value returned by the specified supplier, or an error if the supplier fails.  */
-        @JvmStatic
-        fun <T> create(supplier: Supplier<T>): ValueOrError<T?> =
-            try {
-                newValue(supplier.get())
-            } catch (e: Throwable) {
-                newError(e)
-            }
-
-        /** Returns a new instance with the specified value.  */
-        private fun <T> newValue(value: T): ValueOrError<T?> = ValueOrError(value, null)
-
-        /** Returns a new instance with the specified error.  */
-        private fun <T> newError(t: Throwable?): ValueOrError<T?> = ValueOrError(null, t)
-
-        /** Modifies the specified stream to ignore errors, returning wrapped values.  */
-        @JvmStatic
-        fun <T> ignoreErrors(observable: Observable<ValueOrError<T>>): Observable<T> =
-            observable.filter { it.isPresent }.map { it.value().get() }
-
-    }
 }

--- a/sharedTest/src/main/java/com/google/android/ground/test/persistence/remote/FakeRemoteDataStore.java
+++ b/sharedTest/src/main/java/com/google/android/ground/test/persistence/remote/FakeRemoteDataStore.java
@@ -24,7 +24,6 @@ import com.google.android.ground.model.mutation.Mutation;
 import com.google.android.ground.model.submission.Submission;
 import com.google.android.ground.persistence.remote.RemoteDataEvent;
 import com.google.android.ground.persistence.remote.RemoteDataStore;
-import com.google.android.ground.rx.ValueOrError;
 import com.google.android.ground.rx.annotations.Cold;
 import com.google.android.ground.test.FakeData;
 import com.google.common.collect.ImmutableCollection;
@@ -38,6 +37,7 @@ import java.util.List;
 import java8.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import kotlin.Result;
 
 @Singleton
 public class FakeRemoteDataStore implements RemoteDataStore {
@@ -97,7 +97,7 @@ public class FakeRemoteDataStore implements RemoteDataStore {
   }
 
   @Override
-  public Single<ImmutableList<ValueOrError<Submission>>> loadSubmissions(
+  public Single<ImmutableList<Result<Submission>>> loadSubmissions(
       LocationOfInterest locationOfInterest) {
     return null;
   }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Things done:

1. Remove dependency on `ValueOrError` and use kotlin `Result`
2. Cleanup unused static helper methods

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@JSunde  PTAL?
