### PR TITLE
Refactor: store polygon holes in db; add converters

### DIFF
--- a/ground/src/main/java/com/google/android/ground/converter/Converter.kt
+++ b/ground/src/main/java/com/google/android/ground/converter/Converter.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.converter
+
+/** Defines methods for converting classes to/from other representations. */
+sealed interface Converter<T, R> {
+  /** Converts a T object to its R representation. */
+  fun convertTo(model: T): R?
+  /** Converts an R object to its T representation. */
+  fun convertFrom(entity: R): T?
+}

--- a/ground/src/main/java/com/google/android/ground/converter/GeometryModelToLocalDbConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/converter/GeometryModelToLocalDbConverter.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.converter
+
+import com.google.android.ground.model.geometry.*
+import com.google.android.ground.persistence.local.room.entity.GeometryEntity
+import com.google.android.ground.persistence.local.room.models.Coordinates
+import com.google.android.ground.persistence.local.room.models.GeometryType
+import com.google.android.ground.util.toImmutableList
+import com.google.common.collect.ImmutableList
+import com.google.common.reflect.TypeToken
+import com.google.gson.Gson
+
+/** Converts [Geometry] model objects to/from a persisted database representation. */
+object GeometryModelToLocalDbConverter : Converter<Geometry, GeometryEntity> {
+  override fun convertTo(model: Geometry): GeometryEntity? =
+    when (model) {
+      is Point -> fromPointModel(model)
+      is Polygon -> fromPolygonModel(model)
+      else -> null
+    }
+
+  override fun convertFrom(entity: GeometryEntity): Geometry? =
+    when (entity.geometryType) {
+      GeometryType.POINT.name -> toPointModel(entity)
+      GeometryType.POLYGON.name -> toPolygonModel(entity)
+      else -> null
+    }
+
+  private fun toPointModel(record: GeometryEntity): Geometry? = record.location?.toPoint()
+
+  private fun toPolygonModel(record: GeometryEntity): Geometry {
+    val shell = LinearRing(parseVertices(record.vertices).map { it.coordinate })
+    val holes = parseHoles(record.holes).map { LinearRing(it.map(Point::coordinate)) }
+
+    return Polygon(shell, holes)
+  }
+
+  private fun fromPointModel(point: Point): GeometryEntity =
+    GeometryEntity(GeometryType.POINT.name, Coordinates.fromPoint(point))
+
+  private fun fromPolygonModel(polygon: Polygon): GeometryEntity {
+    val shell = formatVertices(polygon.vertices)
+    val holes = formatHoles(polygon.holes.map { it.vertices })
+
+    return GeometryEntity(GeometryType.POLYGON.name, null, shell, holes)
+  }
+
+  private fun formatHoles(holes: List<ImmutableList<Point>>): String? {
+    if (holes.isEmpty()) {
+      return null
+    }
+
+    val gson = Gson()
+    val holeArray =
+      holes.map { hole -> hole.map { ImmutableList.of(it.coordinate.x, it.coordinate.y) } }
+
+    return gson.toJson(holeArray)
+  }
+
+  fun formatVertices(vertices: ImmutableList<Point>): String? {
+    if (vertices.isEmpty()) {
+      return null
+    }
+    val gson = Gson()
+    val verticesArray =
+      vertices.map { (coordinate): Point -> ImmutableList.of(coordinate.x, coordinate.y) }.toList()
+    return gson.toJson(verticesArray)
+  }
+
+  private fun parseHoles(holes: String?): List<ImmutableList<Point>> {
+    if (holes == null || holes.isEmpty()) {
+      return ImmutableList.of()
+    }
+
+    val gson = Gson()
+    val holesArray =
+      gson.fromJson<List<List<List<Double>>>>(
+        holes,
+        object : TypeToken<List<List<List<Double?>?>?>?>() {}.type
+      )
+
+    return holesArray.map {
+      it.map { vertex -> Point(Coordinate(vertex[0], vertex[1])) }.toImmutableList()
+    }
+  }
+
+  fun parseVertices(vertices: String?): ImmutableList<Point> {
+    if (vertices == null || vertices.isEmpty()) {
+      return ImmutableList.of()
+    }
+    val gson = Gson()
+    val verticesArray =
+      gson.fromJson<List<List<Double>>>(
+        vertices,
+        object : TypeToken<List<List<Double?>?>?>() {}.type
+      )
+    return verticesArray
+      .map { vertex: List<Double> -> Point(Coordinate(vertex[0], vertex[1])) }
+      .toImmutableList()
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/converter/LocationOfInterestModelToLocalDbConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/converter/LocationOfInterestModelToLocalDbConverter.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.converter
+
+import com.google.android.ground.model.AuditInfo
+import com.google.android.ground.model.Survey
+import com.google.android.ground.model.locationofinterest.LocationOfInterest
+import com.google.android.ground.model.mutation.LocationOfInterestMutation
+import com.google.android.ground.persistence.local.LocalDataConsistencyException
+import com.google.android.ground.persistence.local.room.entity.AuditInfoEntity
+import com.google.android.ground.persistence.local.room.entity.LocationOfInterestEntity
+import com.google.android.ground.persistence.local.room.models.EntityState
+
+/**
+ * Converts [LocationOfInterest] model objects associated with a given [Survey] to/from a persisted
+ * database representation.
+ */
+class LocationOfInterestModelToLocalDbConverter(val survey: Survey) :
+  Converter<LocationOfInterest, LocationOfInterestEntity> {
+
+  companion object : Converter<LocationOfInterest, LocationOfInterestEntity> {
+    fun fromMutation(
+      mutation: LocationOfInterestMutation,
+      created: AuditInfo
+    ): LocationOfInterestEntity {
+      val authInfo = AuditInfoEntity.fromObject(created)
+      return LocationOfInterestEntity(
+        id = mutation.locationOfInterestId,
+        surveyId = mutation.surveyId,
+        jobId = mutation.jobId,
+        state = EntityState.DEFAULT,
+        created = authInfo,
+        lastModified = authInfo,
+        geometry = mutation.geometry?.let { GeometryModelToLocalDbConverter.convertTo(it) }
+      )
+    }
+
+    // Permits serialization w/o having to pass a `survey`.
+    override fun convertTo(model: LocationOfInterest): LocationOfInterestEntity =
+      LocationOfInterestEntity(
+        id = model.id,
+        surveyId = model.surveyId,
+        jobId = model.job.id,
+        state = EntityState.DEFAULT,
+        created = AuditInfoEntity.fromObject(model.created),
+        lastModified = AuditInfoEntity.fromObject(model.lastModified),
+        geometry = GeometryModelToLocalDbConverter.convertTo(model.geometry)
+      )
+
+    override fun convertFrom(entity: LocationOfInterestEntity): LocationOfInterest? = null
+  }
+
+  // We can serialize perfectly fine without passing a `survey`; delegate to the companion.
+  override fun convertTo(model: LocationOfInterest): LocationOfInterestEntity =
+    Companion.convertTo(model)
+
+  override fun convertFrom(entity: LocationOfInterestEntity): LocationOfInterest {
+    val geometry = entity.geometry?.let { GeometryModelToLocalDbConverter.convertFrom(it) }
+    if (geometry == null) {
+      throw LocalDataConsistencyException("No geometry in location of interest $entity.id")
+    } else {
+      return LocationOfInterest(
+        id = entity.id,
+        surveyId = entity.surveyId,
+        created = AuditInfoEntity.toObject(entity.created),
+        lastModified = AuditInfoEntity.toObject(entity.lastModified),
+        geometry = geometry,
+        job =
+          this.survey.getJob(jobId = entity.jobId).orElseThrow {
+            LocalDataConsistencyException(
+              "Unknown jobId $entity.jobId in location of interest $entity.id"
+            )
+          }
+      )
+    }
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/converter/LocationOfInterestMutationModelToLocalDbConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/converter/LocationOfInterestMutationModelToLocalDbConverter.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.converter
+
+import com.google.android.ground.model.mutation.LocationOfInterestMutation
+import com.google.android.ground.persistence.local.room.entity.LocationOfInterestMutationEntity
+import com.google.android.ground.persistence.local.room.models.MutationEntitySyncStatus
+import com.google.android.ground.persistence.local.room.models.MutationEntityType
+import java.util.*
+
+/**
+ * Converts [LocationOfInterestMutation] model objects to/from a persisted database representation.
+ */
+object LocationOfInterestMutationModelToLocalDbConverter :
+  Converter<LocationOfInterestMutation, LocationOfInterestMutationEntity> {
+  override fun convertTo(model: LocationOfInterestMutation): LocationOfInterestMutationEntity =
+    LocationOfInterestMutationEntity(
+      id = model.id,
+      surveyId = model.surveyId,
+      jobId = model.jobId,
+      type = MutationEntityType.fromMutationType(model.type),
+      newGeometry = model.geometry?.let { GeometryModelToLocalDbConverter.convertTo(it) },
+      userId = model.userId,
+      locationOfInterestId = model.locationOfInterestId,
+      syncStatus = MutationEntitySyncStatus.fromMutationSyncStatus(model.syncStatus),
+      clientTimestamp = model.clientTimestamp.time,
+      lastError = model.lastError,
+      retryCount = model.retryCount
+    )
+
+  override fun convertFrom(entity: LocationOfInterestMutationEntity): LocationOfInterestMutation =
+    LocationOfInterestMutation(
+      id = entity.id,
+      surveyId = entity.surveyId,
+      jobId = entity.jobId,
+      type = entity.type.toMutationType(),
+      geometry = entity.newGeometry?.let { GeometryModelToLocalDbConverter.convertFrom(it) },
+      userId = entity.userId,
+      locationOfInterestId = entity.locationOfInterestId,
+      syncStatus = entity.syncStatus.toMutationSyncStatus(),
+      clientTimestamp = Date(entity.clientTimestamp),
+      lastError = entity.lastError,
+      retryCount = entity.retryCount,
+    )
+}

--- a/ground/src/main/java/com/google/android/ground/model/mutation/LocationOfInterestMutation.kt
+++ b/ground/src/main/java/com/google/android/ground/model/mutation/LocationOfInterestMutation.kt
@@ -15,11 +15,10 @@
  */
 package com.google.android.ground.model.mutation
 
-import com.google.android.ground.model.geometry.Point
+import com.google.android.ground.model.geometry.Geometry
 import com.google.android.ground.util.toImmutableList
 import com.google.common.collect.ImmutableList
 import java.util.*
-import java8.util.Optional
 
 data class LocationOfInterestMutation(
   override val id: Long? = null,
@@ -32,16 +31,14 @@ data class LocationOfInterestMutation(
   override val retryCount: Long = 0,
   override val lastError: String = "",
   val jobId: String = "",
-  val location: Optional<Point> = Optional.empty(),
-  val polygonVertices: ImmutableList<Point> = ImmutableList.of(),
+  val geometry: Geometry? = null,
 ) : Mutation() {
 
   override fun toBuilder(): Builder {
     return Builder()
       .also {
         it.jobId = this.jobId
-        it.location = this.location
-        it.polygonVertices = this.polygonVertices
+        it.geometry = this.geometry
       }
       .fromMutation(this) as Builder
   }
@@ -50,18 +47,11 @@ data class LocationOfInterestMutation(
   inner class Builder : Mutation.Builder<LocationOfInterestMutation>() {
     var jobId: String = ""
       @JvmSynthetic set
-    var location: Optional<Point> = Optional.empty()
-      @JvmSynthetic set
-    var polygonVertices: ImmutableList<Point> = ImmutableList.of()
+    var geometry: Geometry? = null
       @JvmSynthetic set
 
     fun setJobId(jobId: String): Builder = apply { this.jobId = jobId }
-
-    fun setLocation(newLocation: Optional<Point>): Builder = apply { this.location = newLocation }
-
-    fun setPolygonVertices(newVertices: ImmutableList<Point>): Builder = apply {
-      this.polygonVertices = newVertices
-    }
+    fun setGeometry(geometry: Geometry?): Builder = apply { this.geometry = geometry }
 
     override fun build() =
       LocationOfInterestMutation(
@@ -75,8 +65,7 @@ data class LocationOfInterestMutation(
         retryCount,
         lastError,
         jobId,
-        location,
-        polygonVertices
+        geometry,
       )
   }
 

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/GeometryEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/GeometryEntity.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.persistence.local.room.entity
+
+import androidx.room.Embedded
+import com.google.android.ground.persistence.local.room.models.Coordinates
+
+data class GeometryEntity(
+  /** The type of this geometry. */
+  val geometryType: String,
+  /** Non-null iff this geometry is a point. */
+  @Embedded val location: Coordinates? = null,
+  /** Non-null iff this geometry is a polygon */
+  val vertices: String? = null,
+  /** Non-null iff this geometry is a polygon */
+  val holes: String? = null,
+)

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestEntity.kt
@@ -16,21 +16,7 @@
 package com.google.android.ground.persistence.local.room.entity
 
 import androidx.room.*
-import com.google.android.ground.model.AuditInfo
-import com.google.android.ground.model.Survey
-import com.google.android.ground.model.geometry.*
-import com.google.android.ground.model.locationofinterest.LocationOfInterest
-import com.google.android.ground.model.locationofinterest.LocationOfInterestType
-import com.google.android.ground.model.mutation.LocationOfInterestMutation
-import com.google.android.ground.persistence.local.LocalDataConsistencyException
-import com.google.android.ground.persistence.local.room.entity.AuditInfoEntity.Companion.fromObject
-import com.google.android.ground.persistence.local.room.entity.AuditInfoEntity.Companion.toObject
-import com.google.android.ground.persistence.local.room.models.Coordinates
 import com.google.android.ground.persistence.local.room.models.EntityState
-import com.google.android.ground.util.toImmutableList
-import com.google.common.collect.ImmutableList
-import com.google.common.reflect.TypeToken
-import com.google.gson.Gson
 
 /**
  * Defines how Room persists LOIs in the local db. By default, Room uses the name of object fields
@@ -41,131 +27,8 @@ data class LocationOfInterestEntity(
   @ColumnInfo(name = "id") @PrimaryKey val id: String,
   @ColumnInfo(name = "survey_id") val surveyId: String,
   @ColumnInfo(name = "job_id") val jobId: String,
-  @ColumnInfo(name = "geo_json") val geoJson: String?,
-  @ColumnInfo(name = "polygon_vertices") val polygonVertices: String?,
-  @Embedded val location: Coordinates?,
   @ColumnInfo(name = "state") var state: EntityState, // TODO: Rename to DeletionState.
   @Embedded(prefix = "created_") val created: AuditInfoEntity,
   @Embedded(prefix = "modified_") val lastModified: AuditInfoEntity,
-) {
-
-  companion object {
-    fun fromMutation(
-      mutation: LocationOfInterestMutation,
-      created: AuditInfo
-    ): LocationOfInterestEntity {
-      val authInfo = fromObject(created)
-      return LocationOfInterestEntity(
-        id = mutation.locationOfInterestId,
-        surveyId = mutation.surveyId,
-        jobId = mutation.jobId,
-        state = EntityState.DEFAULT,
-        created = authInfo,
-        lastModified = authInfo,
-        location = mutation.location.map { Coordinates.fromPoint(it) }.orElse(null),
-        polygonVertices = formatVertices(mutation.polygonVertices),
-        geoJson = null
-      )
-    }
-
-    fun fromLocationOfInterest(locationOfInterest: LocationOfInterest): LocationOfInterestEntity {
-      var location: Coordinates? = null
-      var polygonVertices: String? = null
-
-      when (locationOfInterest.type) {
-        LocationOfInterestType.POINT ->
-          location = Coordinates.fromPoint(locationOfInterest.geometry.vertices[0])
-        // TODO(#1247): Add support for storing holes in the DB.
-        else -> polygonVertices = formatVertices(locationOfInterest.geometry.vertices)
-      }
-
-      return LocationOfInterestEntity(
-        id = locationOfInterest.id,
-        surveyId = locationOfInterest.surveyId,
-        jobId = locationOfInterest.job.id,
-        state = EntityState.DEFAULT,
-        created = fromObject(locationOfInterest.created),
-        lastModified = fromObject(locationOfInterest.lastModified),
-        location = location,
-        polygonVertices = polygonVertices,
-        geoJson = null
-      )
-    }
-
-    fun toLocationOfInterest(
-      locationOfInterestEntity: LocationOfInterestEntity,
-      survey: Survey
-    ): LocationOfInterest {
-      if (locationOfInterestEntity.location != null) {
-        return fillLocationOfInterest(
-          locationOfInterestEntity,
-          survey,
-          locationOfInterestEntity.location.toPoint()
-        )
-      }
-      if (locationOfInterestEntity.polygonVertices != null) {
-        val points = parseVertices(locationOfInterestEntity.polygonVertices)
-        val coordinates = points.map(Point::coordinate)
-        val linearRing = LinearRing(coordinates)
-        return fillLocationOfInterest(
-          locationOfInterestEntity,
-          survey,
-          Polygon(linearRing, ImmutableList.of())
-        )
-      }
-      throw LocalDataConsistencyException(
-        "No geometry data found in location of interest " + locationOfInterestEntity.id
-      )
-    }
-
-    @JvmStatic
-    fun formatVertices(vertices: ImmutableList<Point>): String? {
-      if (vertices.isEmpty()) {
-        return null
-      }
-      val gson = Gson()
-      val verticesArray =
-        vertices
-          .map { (coordinate): Point -> ImmutableList.of(coordinate.x, coordinate.y) }
-          .toList()
-      return gson.toJson(verticesArray)
-    }
-
-    @JvmStatic
-    fun parseVertices(vertices: String?): ImmutableList<Point> {
-      if (vertices == null || vertices.isEmpty()) {
-        return ImmutableList.of()
-      }
-      val gson = Gson()
-      val verticesArray =
-        gson.fromJson<List<List<Double>>>(
-          vertices,
-          object : TypeToken<List<List<Double?>?>?>() {}.type
-        )
-      return verticesArray
-        .map { vertex: List<Double> -> Point(Coordinate(vertex[0], vertex[1])) }
-        .toImmutableList()
-    }
-
-    private fun fillLocationOfInterest(
-      locationOfInterestEntity: LocationOfInterestEntity,
-      survey: Survey,
-      geometry: Geometry?
-    ): LocationOfInterest {
-      val id = locationOfInterestEntity.id
-      val jobId = locationOfInterestEntity.jobId
-      val job =
-        survey.getJob(jobId).orElseThrow {
-          LocalDataConsistencyException("Unknown jobId $jobId in location of interest $id")
-        }
-      return LocationOfInterest(
-        id = id,
-        surveyId = survey.id,
-        job = job,
-        created = toObject(locationOfInterestEntity.created),
-        lastModified = toObject(locationOfInterestEntity.lastModified),
-        geometry = geometry!!
-      )
-    }
-  }
-}
+  @Embedded val geometry: GeometryEntity?
+)

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestMutationEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestMutationEntity.kt
@@ -16,15 +16,8 @@
 package com.google.android.ground.persistence.local.room.entity
 
 import androidx.room.*
-import com.google.android.ground.model.geometry.Point
-import com.google.android.ground.model.mutation.LocationOfInterestMutation
-import com.google.android.ground.persistence.local.room.entity.LocationOfInterestEntity.Companion.formatVertices
-import com.google.android.ground.persistence.local.room.entity.LocationOfInterestEntity.Companion.parseVertices
-import com.google.android.ground.persistence.local.room.models.Coordinates
 import com.google.android.ground.persistence.local.room.models.MutationEntitySyncStatus
 import com.google.android.ground.persistence.local.room.models.MutationEntityType
-import java.util.*
-import java8.util.Optional
 
 /**
  * Defines how Room persists LOI mutations for remote sync in the local db. By default, Room uses
@@ -55,44 +48,6 @@ data class LocationOfInterestMutationEntity(
   @ColumnInfo(name = "client_timestamp") val clientTimestamp: Long,
   @ColumnInfo(name = "location_of_interest_id") val locationOfInterestId: String,
   @ColumnInfo(name = "job_id") val jobId: String,
-  /** Non-null if the LOI's location was updated, null if unchanged. */
-  @Embedded val newLocation: Coordinates?,
-  /** Non-empty if a polygon's vertices were updated, null if unchanged. */
-  @ColumnInfo(name = "polygon_vertices") val newPolygonVertices: String?
-) {
-
-  fun toMutation(): LocationOfInterestMutation {
-    return LocationOfInterestMutation.builder()
-      .setJobId(jobId)
-      .setLocation(Optional.ofNullable(newLocation).map { obj: Coordinates? -> obj!!.toPoint() })
-      .setPolygonVertices(parseVertices(newPolygonVertices))
-      .setId(id)
-      .setSurveyId(surveyId)
-      .setLocationOfInterestId(locationOfInterestId)
-      .setType(type.toMutationType())
-      .setSyncStatus(syncStatus.toMutationSyncStatus())
-      .setRetryCount(retryCount)
-      .setLastError(lastError)
-      .setUserId(userId)
-      .setClientTimestamp(Date(clientTimestamp))
-      .build()
-  }
-
-  companion object {
-    fun fromMutation(m: LocationOfInterestMutation): LocationOfInterestMutationEntity =
-      LocationOfInterestMutationEntity(
-        id = m.id,
-        surveyId = m.surveyId,
-        locationOfInterestId = m.locationOfInterestId,
-        jobId = m.jobId,
-        newLocation = m.location.map { point: Point? -> Coordinates.fromPoint(point) }.orElse(null),
-        newPolygonVertices = formatVertices(m.polygonVertices),
-        type = MutationEntityType.fromMutationType(m.type),
-        syncStatus = MutationEntitySyncStatus.fromMutationSyncStatus(m.syncStatus),
-        retryCount = m.retryCount,
-        lastError = m.lastError,
-        userId = m.userId,
-        clientTimestamp = m.clientTimestamp.time
-      )
-  }
-}
+  /** Non-null if the LOI's geometry was updated, null if unchanged. */
+  @Embedded val newGeometry: GeometryEntity?,
+)

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/models/GeometryType.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/models/GeometryType.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.persistence.local.room.models
+
+enum class GeometryType {
+  POLYGON,
+  POINT,
+}

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -16,7 +16,9 @@
 package com.google.android.ground.repository
 
 import com.google.android.ground.model.Survey
+import com.google.android.ground.model.geometry.LinearRing
 import com.google.android.ground.model.geometry.Point
+import com.google.android.ground.model.geometry.Polygon
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.model.mutation.LocationOfInterestMutation
 import com.google.android.ground.model.mutation.LocationOfInterestMutation.Companion.builder
@@ -37,7 +39,6 @@ import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSet
 import io.reactivex.*
 import java.util.*
-import java8.util.Optional
 import javax.inject.Inject
 import javax.inject.Singleton
 import timber.log.Timber
@@ -127,7 +128,7 @@ constructor(
   ): LocationOfInterestMutation =
     builder()
       .setJobId(jobId)
-      .setLocation(Optional.of(point))
+      .setGeometry(point)
       .setType(Mutation.Type.CREATE)
       .setSyncStatus(SyncStatus.PENDING)
       .setLocationOfInterestId(uuidGenerator.generateUuid())
@@ -144,7 +145,7 @@ constructor(
   ): LocationOfInterestMutation =
     builder()
       .setJobId(jobId)
-      .setPolygonVertices(vertices)
+      .setGeometry(Polygon(LinearRing(vertices.map { it.coordinate })))
       .setType(Mutation.Type.CREATE)
       .setSyncStatus(SyncStatus.PENDING)
       .setLocationOfInterestId(uuidGenerator.generateUuid())

--- a/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTest.kt
@@ -18,6 +18,7 @@ package com.google.android.ground.persistence.local
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.ground.BaseHiltTest
+import com.google.android.ground.converter.GeometryModelToLocalDbConverter
 import com.google.android.ground.model.Survey
 import com.google.android.ground.model.User
 import com.google.android.ground.model.basemap.OfflineArea
@@ -48,7 +49,6 @@ import com.google.common.collect.ImmutableSet
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidTest
 import java.util.*
-import java8.util.Optional
 import javax.inject.Inject
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
@@ -404,12 +404,12 @@ class LocalDataStoreTest : BaseHiltTest() {
 
   @Test
   fun testParseVertices_emptyString() {
-    assertThat(LocationOfInterestEntity.parseVertices("")).isEqualTo(ImmutableList.of<Any>())
+    assertThat(GeometryModelToLocalDbConverter.parseVertices("")).isEqualTo(ImmutableList.of<Any>())
   }
 
   @Test
   fun testFormatVertices_emptyList() {
-    assertThat(LocationOfInterestEntity.formatVertices(ImmutableList.of())).isNull()
+    assertThat(GeometryModelToLocalDbConverter.formatVertices(ImmutableList.of())).isNull()
   }
 
   @Test
@@ -495,8 +495,7 @@ class LocalDataStoreTest : BaseHiltTest() {
     private fun createTestLocationOfInterestMutation(point: Point): LocationOfInterestMutation {
       return LocationOfInterestMutation.builder()
         .setJobId("job id")
-        .setLocation(Optional.ofNullable(point))
-        .setPolygonVertices(ImmutableList.of())
+        .setGeometry(point)
         .setId(1L)
         .setLocationOfInterestId("loi id")
         .setType(Mutation.Type.CREATE)
@@ -512,8 +511,7 @@ class LocalDataStoreTest : BaseHiltTest() {
     ): LocationOfInterestMutation {
       return LocationOfInterestMutation.builder()
         .setJobId("job id")
-        .setLocation(Optional.empty())
-        .setPolygonVertices(polygonVertices)
+        .setGeometry(Polygon(LinearRing(polygonVertices.map { it.coordinate })))
         .setId(1L)
         .setLocationOfInterestId("loi id")
         .setType(Mutation.Type.CREATE)

--- a/ground/src/test/java/com/google/android/ground/persistence/remote/firestore/GeometryModelToLocalDbConverterTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/remote/firestore/GeometryModelToLocalDbConverterTest.kt
@@ -24,7 +24,7 @@ import org.junit.Test
 
 typealias Path = Array<Pair<Double, Double>>
 
-class GeometryConverterTest {
+class GeometryModelToLocalDbConverterTest {
   private val x = -42.121
   private val y = 28.482
   private val path1 =

--- a/ground/src/test/java/com/google/android/ground/repository/LocationOfInterestRepositoryTest.kt
+++ b/ground/src/test/java/com/google/android/ground/repository/LocationOfInterestRepositoryTest.kt
@@ -255,7 +255,7 @@ class LocationOfInterestRepositoryTest : BaseHiltTest() {
     assertThat(locationOfInterestId).isEqualTo("TEST UUID")
     assertThat(surveyId).isEqualTo("foo_survey_id")
     assertThat(jobId).isEqualTo("foo_job_id")
-    assertThat(location.get()).isEqualTo(FakeData.POINT)
+    assertThat(location).isEqualTo(FakeData.POINT)
     assertThat(userId).isEqualTo(FakeData.USER.id)
     assertThat(clientTimestamp).isEqualTo(testDate)
   }
@@ -264,20 +264,7 @@ class LocationOfInterestRepositoryTest : BaseHiltTest() {
   fun testNewPolygonOfInterest() {
     fakeAuthenticationManager.setUser(FakeData.USER)
     val testDate = Date()
-    val (
-      id,
-      _,
-      _,
-      surveyId,
-      locationOfInterestId,
-      userId,
-      clientTimestamp,
-      _,
-      _,
-      jobId,
-      _,
-      polygonVertices
-    ) =
+    val (id, _, _, surveyId, locationOfInterestId, userId, clientTimestamp, _, _, jobId, polygon) =
       locationOfInterestRepository.newPolygonOfInterestMutation(
         "foo_survey_id",
         "foo_job_id",
@@ -288,7 +275,7 @@ class LocationOfInterestRepositoryTest : BaseHiltTest() {
     assertThat(locationOfInterestId).isEqualTo("TEST UUID")
     assertThat(surveyId).isEqualTo("foo_survey_id")
     assertThat(jobId).isEqualTo("foo_job_id")
-    assertThat(polygonVertices).isEqualTo(FakeData.VERTICES)
+    assertThat(polygon?.vertices).isEqualTo(FakeData.VERTICES)
     assertThat(userId).isEqualTo(FakeData.USER.id)
     assertThat(clientTimestamp).isEqualTo(testDate)
   }


### PR DESCRIPTION
We now decouple model->DB entity conversions from the models and entities themselves and handle them in dedicated Converter classes.

Additionally, we now write polygon holes to the database as a list of lists of coordinates. This also required updating the handling of geometries in mutations.
