### PR TITLE
Remove builder() from LocationOfInterestMutation

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/locationofinterest/LocationOfInterest.kt
+++ b/ground/src/main/java/com/google/android/ground/model/locationofinterest/LocationOfInterest.kt
@@ -19,7 +19,6 @@ import com.google.android.ground.model.AuditInfo
 import com.google.android.ground.model.geometry.*
 import com.google.android.ground.model.job.Job
 import com.google.android.ground.model.mutation.LocationOfInterestMutation
-import com.google.android.ground.model.mutation.LocationOfInterestMutation.Companion.builder
 import com.google.android.ground.model.mutation.Mutation
 import com.google.android.ground.model.mutation.Mutation.SyncStatus
 import java.util.*
@@ -59,15 +58,14 @@ data class LocationOfInterest(
    * Converts this LOI to a mutation that can be used to update this LOI in the remote and local
    * database.
    */
-  fun toMutation(type: Mutation.Type, userId: String): LocationOfInterestMutation {
-    return builder()
-      .setJobId(job.id)
-      .setType(type)
-      .setSyncStatus(SyncStatus.PENDING)
-      .setSurveyId(surveyId)
-      .setLocationOfInterestId(id)
-      .setUserId(userId)
-      .setClientTimestamp(Date())
-      .build()
-  }
+  fun toMutation(type: Mutation.Type, userId: String): LocationOfInterestMutation =
+    LocationOfInterestMutation(
+      jobId = job.id,
+      type = type,
+      syncStatus = SyncStatus.PENDING,
+      surveyId = surveyId,
+      locationOfInterestId = id,
+      userId = userId,
+      clientTimestamp = Date()
+    )
 }

--- a/ground/src/main/java/com/google/android/ground/model/mutation/LocationOfInterestMutation.kt
+++ b/ground/src/main/java/com/google/android/ground/model/mutation/LocationOfInterestMutation.kt
@@ -50,9 +50,6 @@ data class LocationOfInterestMutation(
     var geometry: Geometry? = null
       @JvmSynthetic set
 
-    fun setJobId(jobId: String): Builder = apply { this.jobId = jobId }
-    fun setGeometry(geometry: Geometry?): Builder = apply { this.geometry = geometry }
-
     override fun build() =
       LocationOfInterestMutation(
         id,
@@ -70,9 +67,6 @@ data class LocationOfInterestMutation(
   }
 
   companion object {
-    @JvmStatic fun builder(): Builder = LocationOfInterestMutation().toBuilder()
-
-    @JvmStatic
     fun filter(mutations: ImmutableList<out Mutation>): ImmutableList<LocationOfInterestMutation> {
       return mutations
         .toTypedArray()

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/RoomLocalDataStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/RoomLocalDataStore.kt
@@ -376,11 +376,11 @@ class RoomLocalDataStore @Inject internal constructor() : LocalDataStore {
   private fun markComplete(mutations: ImmutableList<Mutation>): Completable {
     val locationOfInterestMutations =
       LocationOfInterestMutation.filter(mutations)
-        .map { it.toBuilder().setSyncStatus(SyncStatus.COMPLETED).build() }
+        .map { it.copy(syncStatus = SyncStatus.COMPLETED) }
         .map(LocationOfInterestMutationModelToLocalDbConverter::convertTo)
     val submissionMutations =
       SubmissionMutation.filter(mutations)
-        .map { it.toBuilder().setSyncStatus(SyncStatus.COMPLETED).build() }
+        .map { it.copy(syncStatus = SyncStatus.COMPLETED) }
         .map { SubmissionMutationEntity.fromMutation(it) }
         .toImmutableList()
     return locationOfInterestMutationDao

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -21,7 +21,6 @@ import com.google.android.ground.model.geometry.Point
 import com.google.android.ground.model.geometry.Polygon
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.model.mutation.LocationOfInterestMutation
-import com.google.android.ground.model.mutation.LocationOfInterestMutation.Companion.builder
 import com.google.android.ground.model.mutation.Mutation
 import com.google.android.ground.model.mutation.Mutation.SyncStatus
 import com.google.android.ground.persistence.local.LocalDataStore
@@ -126,16 +125,16 @@ constructor(
     point: Point,
     date: Date
   ): LocationOfInterestMutation =
-    builder()
-      .setJobId(jobId)
-      .setGeometry(point)
-      .setType(Mutation.Type.CREATE)
-      .setSyncStatus(SyncStatus.PENDING)
-      .setLocationOfInterestId(uuidGenerator.generateUuid())
-      .setSurveyId(surveyId)
-      .setUserId(authManager.currentUser.id)
-      .setClientTimestamp(date)
-      .build()
+    LocationOfInterestMutation(
+      jobId = jobId,
+      geometry = point,
+      type = Mutation.Type.CREATE,
+      syncStatus = SyncStatus.PENDING,
+      locationOfInterestId = uuidGenerator.generateUuid(),
+      surveyId = surveyId,
+      userId = authManager.currentUser.id,
+      clientTimestamp = date
+    )
 
   fun newPolygonOfInterestMutation(
     surveyId: String,
@@ -143,16 +142,16 @@ constructor(
     vertices: ImmutableList<Point>,
     date: Date
   ): LocationOfInterestMutation =
-    builder()
-      .setJobId(jobId)
-      .setGeometry(Polygon(LinearRing(vertices.map { it.coordinate })))
-      .setType(Mutation.Type.CREATE)
-      .setSyncStatus(SyncStatus.PENDING)
-      .setLocationOfInterestId(uuidGenerator.generateUuid())
-      .setSurveyId(surveyId)
-      .setUserId(authManager.currentUser.id)
-      .setClientTimestamp(date)
-      .build()
+    LocationOfInterestMutation(
+      jobId = jobId,
+      geometry = Polygon(LinearRing(vertices.map { it.coordinate })),
+      type = Mutation.Type.CREATE,
+      syncStatus = SyncStatus.PENDING,
+      locationOfInterestId = uuidGenerator.generateUuid(),
+      surveyId = surveyId,
+      userId = authManager.currentUser.id,
+      clientTimestamp = date
+    )
 
   /**
    * Creates a mutation entry for the given parameters, applies it to the local db and schedules a

--- a/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTest.kt
@@ -250,11 +250,7 @@ class LocalDataStoreTest : BaseHiltTest() {
         )
       )
     val mutation =
-      TEST_SUBMISSION_MUTATION.toBuilder()
-        .setResponseDeltas(deltas)
-        .setId(2L)
-        .setType(Mutation.Type.UPDATE)
-        .build()
+      TEST_SUBMISSION_MUTATION.copy(responseDeltas = deltas, id = 2L, type = Mutation.Type.UPDATE)
     localDataStore.applyAndEnqueue(mutation).test().assertComplete()
     localDataStore
       .getPendingMutations("loi id")
@@ -295,8 +291,7 @@ class LocalDataStoreTest : BaseHiltTest() {
     localDataStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.applyAndEnqueue(TEST_LOI_MUTATION).blockingAwait()
     localDataStore.applyAndEnqueue(TEST_SUBMISSION_MUTATION).blockingAwait()
-    val mutation =
-      TEST_SUBMISSION_MUTATION.toBuilder().setId(null).setType(Mutation.Type.DELETE).build()
+    val mutation = TEST_SUBMISSION_MUTATION.copy(id = null, type = Mutation.Type.DELETE)
 
     // Calling applyAndEnqueue marks the local submission as deleted.
     localDataStore.applyAndEnqueue(mutation).blockingAwait()
@@ -329,7 +324,7 @@ class LocalDataStoreTest : BaseHiltTest() {
     // Assert that one LOI is streamed.
     val loi = localDataStore.getLocationOfInterest(TEST_SURVEY, "loi id").blockingGet()
     subscriber.assertValueAt(0, ImmutableSet.of(loi))
-    val mutation = TEST_LOI_MUTATION.toBuilder().setId(null).setType(Mutation.Type.DELETE).build()
+    val mutation = TEST_LOI_MUTATION.copy(id = null, type = Mutation.Type.DELETE)
 
     // Calling applyAndEnqueue marks the local LOI as deleted.
     localDataStore.applyAndEnqueue(mutation).blockingAwait()
@@ -492,35 +487,33 @@ class LocalDataStoreTest : BaseHiltTest() {
         "Test Area"
       )
 
-    private fun createTestLocationOfInterestMutation(point: Point): LocationOfInterestMutation {
-      return LocationOfInterestMutation.builder()
-        .setJobId("job id")
-        .setGeometry(point)
-        .setId(1L)
-        .setLocationOfInterestId("loi id")
-        .setType(Mutation.Type.CREATE)
-        .setSyncStatus(SyncStatus.PENDING)
-        .setUserId("user id")
-        .setSurveyId("survey id")
-        .setClientTimestamp(Date())
-        .build()
-    }
+    private fun createTestLocationOfInterestMutation(point: Point): LocationOfInterestMutation =
+      LocationOfInterestMutation(
+        jobId = "job id",
+        geometry = point,
+        id = 1L,
+        locationOfInterestId = "loi id",
+        type = Mutation.Type.CREATE,
+        syncStatus = SyncStatus.PENDING,
+        userId = "user id",
+        surveyId = "survey id",
+        clientTimestamp = Date()
+      )
 
     private fun createTestAreaOfInterestMutation(
       polygonVertices: ImmutableList<Point>
-    ): LocationOfInterestMutation {
-      return LocationOfInterestMutation.builder()
-        .setJobId("job id")
-        .setGeometry(Polygon(LinearRing(polygonVertices.map { it.coordinate })))
-        .setId(1L)
-        .setLocationOfInterestId("loi id")
-        .setType(Mutation.Type.CREATE)
-        .setSyncStatus(SyncStatus.PENDING)
-        .setUserId("user id")
-        .setSurveyId("survey id")
-        .setClientTimestamp(Date())
-        .build()
-    }
+    ): LocationOfInterestMutation =
+      LocationOfInterestMutation(
+        jobId = "job id",
+        geometry = Polygon(LinearRing(polygonVertices.map { it.coordinate })),
+        id = 1L,
+        locationOfInterestId = "loi id",
+        type = Mutation.Type.CREATE,
+        syncStatus = SyncStatus.PENDING,
+        userId = "user id",
+        surveyId = "survey id",
+        clientTimestamp = Date()
+      )
 
     private fun assertEquivalent(mutation: SubmissionMutation, submission: Submission) {
       assertThat(mutation.submissionId).isEqualTo(submission.id)


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #1288 

<!-- PR description. -->
Replaces references of `builder()` with kotlin object instantiation and `copy()`

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@scolsen  PTAL?
