### PR TITLE
Remove builder() from SubmissionMutationEntity

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/mutation/SubmissionMutation.kt
+++ b/ground/src/main/java/com/google/android/ground/model/mutation/SubmissionMutation.kt
@@ -56,14 +56,6 @@ data class SubmissionMutation(
     var responseDeltas: ImmutableList<ResponseDelta> = ImmutableList.of()
       @JvmSynthetic set
 
-    fun setJob(job: Job): Builder = apply { this.job = job }
-
-    fun setSubmissionId(id: String): Builder = apply { this.submissionId = id }
-
-    fun setResponseDeltas(deltas: ImmutableList<ResponseDelta>): Builder = apply {
-      this.responseDeltas = deltas
-    }
-
     override fun build(): SubmissionMutation =
       SubmissionMutation(
         id,
@@ -82,11 +74,8 @@ data class SubmissionMutation(
   }
 
   companion object {
-    @JvmStatic fun builder(): Builder = SubmissionMutation().toBuilder()
-
-    @JvmStatic
-    fun filter(mutations: ImmutableList<out Mutation>): ImmutableList<SubmissionMutation> {
-      return mutations
+    fun filter(mutations: ImmutableList<out Mutation>): ImmutableList<SubmissionMutation> =
+      mutations
         .toTypedArray()
         .filter {
           when (it) {
@@ -97,6 +86,5 @@ data class SubmissionMutation(
         }
         .map { it as SubmissionMutation }
         .toImmutableList()
-    }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/SubmissionMutationEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/SubmissionMutationEntity.kt
@@ -73,20 +73,20 @@ data class SubmissionMutationEntity(
       survey.getJob(jobId).orElseThrow {
         LocalDataConsistencyException("Unknown jobId in submission mutation $id")
       }
-    return SubmissionMutation.builder()
-      .setJob(job)
-      .setSubmissionId(submissionId)
-      .setResponseDeltas(fromString(job, responseDeltas))
-      .setId(id)
-      .setSurveyId(surveyId)
-      .setLocationOfInterestId(locationOfInterestId)
-      .setType(type.toMutationType())
-      .setSyncStatus(syncStatus.toMutationSyncStatus())
-      .setRetryCount(retryCount)
-      .setLastError(lastError)
-      .setUserId(userId)
-      .setClientTimestamp(Date(clientTimestamp))
-      .build()
+    return SubmissionMutation(
+      job = job,
+      submissionId = submissionId,
+      responseDeltas = fromString(job, responseDeltas),
+      id = id,
+      surveyId = surveyId,
+      locationOfInterestId = locationOfInterestId,
+      type = type.toMutationType(),
+      syncStatus = syncStatus.toMutationSyncStatus(),
+      retryCount = retryCount,
+      lastError = lastError,
+      userId = userId,
+      clientTimestamp = Date(clientTimestamp)
+    )
   }
 
   companion object {

--- a/ground/src/main/java/com/google/android/ground/repository/SubmissionRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SubmissionRepository.kt
@@ -20,7 +20,6 @@ import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.model.mutation.Mutation
 import com.google.android.ground.model.mutation.Mutation.SyncStatus
 import com.google.android.ground.model.mutation.SubmissionMutation
-import com.google.android.ground.model.mutation.SubmissionMutation.Companion.builder
 import com.google.android.ground.model.submission.ResponseDelta
 import com.google.android.ground.model.submission.Submission
 import com.google.android.ground.persistence.local.LocalDataStore
@@ -36,7 +35,6 @@ import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.Single
-import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import timber.log.Timber
@@ -142,41 +140,36 @@ constructor(
     }
   }
 
-  fun deleteSubmission(submission: Submission): @Cold Completable {
-    return applyAndEnqueue(
-      builder()
-        .setJob(submission.job)
-        .setSubmissionId(submission.id)
-        .setResponseDeltas(ImmutableList.of())
-        .setType(Mutation.Type.DELETE)
-        .setSyncStatus(SyncStatus.PENDING)
-        .setSurveyId(submission.surveyId)
-        .setLocationOfInterestId(submission.locationOfInterest.id)
-        .setClientTimestamp(Date())
-        .setUserId(authManager.currentUser.id)
-        .build()
+  fun deleteSubmission(submission: Submission): @Cold Completable =
+    applyAndEnqueue(
+      SubmissionMutation(
+        job = submission.job,
+        submissionId = submission.id,
+        type = Mutation.Type.DELETE,
+        syncStatus = SyncStatus.PENDING,
+        surveyId = submission.surveyId,
+        locationOfInterestId = submission.locationOfInterest.id,
+        userId = authManager.currentUser.id
+      )
     )
-  }
 
   fun createOrUpdateSubmission(
     submission: Submission,
     responseDeltas: ImmutableList<ResponseDelta>,
     isNew: Boolean
-  ): @Cold Completable {
-    return applyAndEnqueue(
-      builder()
-        .setJob(submission.job)
-        .setSubmissionId(submission.id)
-        .setResponseDeltas(responseDeltas)
-        .setType(if (isNew) Mutation.Type.CREATE else Mutation.Type.UPDATE)
-        .setSyncStatus(SyncStatus.PENDING)
-        .setSurveyId(submission.surveyId)
-        .setLocationOfInterestId(submission.locationOfInterest.id)
-        .setClientTimestamp(Date())
-        .setUserId(authManager.currentUser.id)
-        .build()
+  ): @Cold Completable =
+    applyAndEnqueue(
+      SubmissionMutation(
+        job = submission.job,
+        submissionId = submission.id,
+        responseDeltas = responseDeltas,
+        type = if (isNew) Mutation.Type.CREATE else Mutation.Type.UPDATE,
+        syncStatus = SyncStatus.PENDING,
+        surveyId = submission.surveyId,
+        locationOfInterestId = submission.locationOfInterest.id,
+        userId = authManager.currentUser.id
+      )
     )
-  }
 
   private fun applyAndEnqueue(mutation: SubmissionMutation): @Cold Completable =
     localDataStore

--- a/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTest.kt
@@ -457,22 +457,20 @@ class LocalDataStoreTest : BaseHiltTest() {
     private val TEST_LOI_MUTATION = createTestLocationOfInterestMutation(TEST_POINT)
     private val TEST_POLYGON_LOI_MUTATION = createTestAreaOfInterestMutation(TEST_POLYGON_1)
     private val TEST_SUBMISSION_MUTATION =
-      SubmissionMutation.builder()
-        .setJob(TEST_JOB)
-        .setSubmissionId("submission id")
-        .setResponseDeltas(
+      SubmissionMutation(
+        job = TEST_JOB,
+        submissionId = "submission id",
+        responseDeltas =
           ImmutableList.of(
             ResponseDelta("task id", Task.Type.TEXT, TextResponse.fromString("updated response"))
-          )
-        )
-        .setId(1L)
-        .setType(Mutation.Type.CREATE)
-        .setSyncStatus(SyncStatus.PENDING)
-        .setSurveyId("survey id")
-        .setLocationOfInterestId("loi id")
-        .setUserId("user id")
-        .setClientTimestamp(Date())
-        .build()
+          ),
+        id = 1L,
+        type = Mutation.Type.CREATE,
+        syncStatus = SyncStatus.PENDING,
+        surveyId = "survey id",
+        locationOfInterestId = "loi id",
+        userId = "user id"
+      )
     private val TEST_PENDING_TILE_SOURCE =
       TileSet("some_url 1", "id_1", "some_path 1", TileSet.State.PENDING, 1)
     private val TEST_DOWNLOADED_TILE_SOURCE =


### PR DESCRIPTION
Towards https://github.com/google/ground-android/issues/1288

Replaces references of `builder()` with kotlin object instantiation and `copy()`

@scolsen PTAL?