### PR TITLE
Fix survey not visible even when ACLs are present

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/Constants.kt
+++ b/ground/src/main/java/com/google/android/ground/model/Constants.kt
@@ -17,7 +17,7 @@ package com.google.android.ground.model
 
 object Constants {
   const val OWNER = "owner"
-  const val SURVEY_ORGANIZER = "survey-organizer"
-  const val DATA_COLLECTOR = "data-collector"
+  const val SURVEY_ORGANIZER = "survey_organizer"
+  const val DATA_COLLECTOR = "data_collector"
   const val VIEWER_ROLE = "viewer"
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Firebase uses "survey_organizer" whereas android app expects "survey-organizer". 

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

Verified by manually setting the ACL to "survey_organizer" in firebase and running the app locally.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@JSunde  PTAL?
