### PR TITLE
Fix crash when attempting to logout

### DIFF
--- a/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
@@ -87,7 +87,7 @@ constructor(
 
   private fun selectSurvey(surveyId: String): @Cold Flowable<Loadable<Survey>> {
     // Empty id indicates intent to deactivate the current survey or first login.
-    return if (surveyId.isEmpty()) Flowable.just(Loadable.notFound())
+    return if (surveyId.isEmpty()) Flowable.never()
     else
       syncSurveyWithRemote(surveyId)
         .onErrorResumeNext { getSurvey(surveyId) }

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
@@ -392,7 +392,6 @@ class HomeScreenFragment :
 
   private fun onActiveSurveyChange(loadable: Loadable<Survey>) {
     when (loadable.state) {
-      LoadState.NOT_FOUND -> showSurveySelector()
       LoadState.LOADED -> {
         dismissSurveyLoadingDialog()
         updateNavDrawer(loadable.value().get())

--- a/ground/src/main/java/com/google/android/ground/ui/submissiondetails/SubmissionDetailsFragment.java
+++ b/ground/src/main/java/com/google/android/ground/ui/submissiondetails/SubmissionDetailsFragment.java
@@ -98,7 +98,6 @@ public class SubmissionDetailsFragment extends AbstractFragment {
       case LOADED:
         submission.value().ifPresent(this::showSubmission);
         break;
-      case NOT_FOUND:
       case ERROR:
         // TODO: Replace w/error view?
         Timber.e("Failed to load submission");

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorDialogFragment.java
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorDialogFragment.java
@@ -83,7 +83,6 @@ public class SurveySelectorDialogFragment extends AbstractDialogFragment {
       case LOADED:
         surveySummaries.value().ifPresent(this::showSurveyList);
         break;
-      case NOT_FOUND:
       case ERROR:
         onSurveyListLoadError(surveySummaries.error().orElse(new UnknownError()));
         break;


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1303

<!-- PR description. -->
This PR changes the behavior of displaying the survey selector is no survey is active.

Things done:
 * Removed `NOT_FOUND` state from Loadable.
 * Manually dispose survey sync subscription after logout to prevent firebase from attempting to sync without any user.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@JSunde @scolsen  PTAL?
