### PR TITLE
Prevent reseting last saved position

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/MapContainerViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/MapContainerViewModel.kt
@@ -24,7 +24,6 @@ import com.cocoahero.android.gmaps.addons.mapbox.MapBoxOfflineTileProvider
 import com.google.android.ground.R
 import com.google.android.ground.model.Survey
 import com.google.android.ground.model.basemap.tile.TileSet
-import com.google.android.ground.model.geometry.Coordinate
 import com.google.android.ground.model.geometry.Point
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.model.locationofinterest.LocationOfInterestType
@@ -274,9 +273,6 @@ internal constructor(
     // Higher zoom levels means the map is more zoomed in. 0.0f is fully zoomed out.
     const val ZOOM_LEVEL_THRESHOLD = 16f
     const val DEFAULT_LOI_ZOOM_LEVEL = 18.0f
-    private const val DEFAULT_MAP_ZOOM_LEVEL = 0.0f
-    private val DEFAULT_MAP_POINT = Point(Coordinate(0.0, 0.0))
-    val DEFAULT_CAMERA_POSITION = CameraPosition(DEFAULT_MAP_POINT, DEFAULT_MAP_ZOOM_LEVEL)
 
     private fun concatLocationsOfInterestSets(
       objects: Array<Any>

--- a/ground/src/main/java/com/google/android/ground/ui/map/MapController.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/MapController.kt
@@ -56,16 +56,14 @@ constructor(
 
   /** Emits a stream of camera update requests due to active survey changes. */
   private fun getCameraUpdatedFromSurveyChanges(): Flowable<CameraPosition> =
-    surveyRepository.activeSurvey.flatMap { surveyOptional ->
-      val position: CameraPosition? =
-        surveyOptional.map { surveyRepository.getLastCameraPosition(it.id) }.orElse(null)
-
-      if (position == null) {
-        Flowable.empty()
-      } else {
-        Flowable.just(position.copy(isAllowZoomOut = true))
+    surveyRepository.activeSurvey
+      .filter { it.isPresent }
+      .map { it.get().id }
+      .flatMap { surveyId ->
+        surveyRepository.getLastCameraPosition(surveyId)?.let {
+          Flowable.just(it.copy(isAllowZoomOut = true))
+        }
       }
-    }
 
   /** Requests moving the map camera to [position] with zoom level [DEFAULT_LOI_ZOOM_LEVEL]. */
   fun panAndZoomCamera(position: Point) {

--- a/ground/src/test/java/com/google/android/ground/ui/map/MapControllerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/map/MapControllerTest.kt
@@ -83,15 +83,12 @@ class MapControllerTest : BaseHiltTest() {
   }
 
   @Test
-  fun testGetCameraUpdates_whenSurveyChanges_whenLastLocationNotAvailable_returnsDefaultPosition() {
+  fun testGetCameraUpdates_whenSurveyChanges_whenLastLocationNotAvailable_returnsNothing() {
     Mockito.`when`(locationController.getLocationUpdates()).thenReturn(Flowable.empty())
     Mockito.`when`(surveyRepository.activeSurvey).thenReturn(Flowable.just(TEST_SURVEY))
     Mockito.`when`(surveyRepository.getLastCameraPosition(any())).thenReturn(null)
 
-    mapController
-      .getCameraUpdates()
-      .test()
-      .assertValues(CameraPosition(Point(Coordinate(0.0, 0.0)), 0.0f))
+    mapController.getCameraUpdates().test().assertNoValues()
   }
 
   @Test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1321 

<!-- PR description. -->
When the app is killed forcefully, the active survey id momentarily changes to empty string. The current logic translates that to default position (0, 0). After that, the actual survey id kicks in but the position is already changed by that time.

This PR fixes that behavior by not returning anything if last saved position doesn't exist in shared prefs.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@scolsen @JSunde  PTAL?
