### PR TITLE
Pull out the Data Collection Task header into subcomponent

### DIFF
--- a/ground/src/main/res/layout/data_collection_header.xml
+++ b/ground/src/main/res/layout/data_collection_header.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2022 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+    <import type="android.view.View" />
+    <variable
+      name="viewModel"
+      type="com.google.android.ground.ui.editsubmission.TextTaskViewModel" />
+  </data>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <TextView
+      android:id="@+id/data_collection_step_number"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@{@string/task_number(viewModel.task.index + 1)}"
+      android:textSize="16sp"
+      app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+    <ImageView
+      android:id="@+id/data_collection_task_icon"
+      android:layout_width="24dp"
+      android:layout_height="24dp"
+      android:layout_marginStart="8dp"
+      android:layout_marginLeft="8dp"
+      app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
+      app:layout_constraintStart_toEndOf="@+id/data_collection_step_number"
+      app:layout_constraintTop_toTopOf="parent"
+      app:srcCompat="@drawable/ic_question_answer" />
+    <TextView
+      android:id="@+id/data_collection_task_name"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:paddingStart="8dp"
+      android:paddingLeft="8dp"
+      android:text="@string/question_data_collection_title"
+      android:textSize="16sp"
+      app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
+      app:layout_constraintStart_toEndOf="@+id/data_collection_task_icon"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+      android:id="@+id/data_collection_question"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:paddingTop="24dp"
+      android:text="@{viewModel.task.label}"
+      android:textSize="16sp"
+      app:layout_constraintBottom_toTopOf="@+id/text_input_layout"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="parent" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/ground/src/main/res/layout/data_collection_header.xml
+++ b/ground/src/main/res/layout/data_collection_header.xml
@@ -35,18 +35,18 @@
       android:layout_height="wrap_content"
       android:text="@{@string/task_number(viewModel.task.index + 1)}"
       android:textSize="16sp"
+      app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
+      app:layout_constraintStart_toStartOf="parent" />
     <ImageView
       android:id="@+id/data_collection_task_icon"
       android:layout_width="24dp"
       android:layout_height="24dp"
       android:layout_marginStart="8dp"
       android:layout_marginLeft="8dp"
+      app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
       app:layout_constraintStart_toEndOf="@+id/data_collection_step_number"
-      app:layout_constraintTop_toTopOf="parent"
       app:srcCompat="@drawable/ic_question_answer" />
     <TextView
       android:id="@+id/data_collection_task_name"
@@ -56,9 +56,9 @@
       android:paddingLeft="8dp"
       android:text="@string/question_data_collection_title"
       android:textSize="16sp"
+      app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
-      app:layout_constraintStart_toEndOf="@+id/data_collection_task_icon"
-      app:layout_constraintTop_toTopOf="parent" />
+      app:layout_constraintStart_toEndOf="@+id/data_collection_task_icon" />
 
     <TextView
       android:id="@+id/data_collection_question"
@@ -67,8 +67,8 @@
       android:paddingTop="24dp"
       android:text="@{viewModel.task.label}"
       android:textSize="16sp"
-      app:layout_constraintBottom_toTopOf="@+id/text_input_layout"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="parent" />
+      app:layout_constraintTop_toBottomOf="@+id/data_collection_step_number"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/ground/src/main/res/layout/question_data_collection_frag.xml
+++ b/ground/src/main/res/layout/question_data_collection_frag.xml
@@ -34,47 +34,12 @@
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="wrap_content"
       android:layout_height="wrap_content">
-      <TextView
-        android:id="@+id/data_collection_step_number"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@{@string/task_number(viewModel.task.index + 1)}"
-        android:textSize="16sp"
-        app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-      <ImageView
-        android:id="@+id/data_collection_task_icon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
-        app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
-        app:layout_constraintStart_toEndOf="@+id/data_collection_step_number"
+      <include
+        android:id="@+id/data_collection_header"
+        app:viewModel="@{viewModel}"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_question_answer" />
-      <TextView
-        android:id="@+id/data_collection_task_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingStart="8dp"
-        android:paddingLeft="8dp"
-        android:text="@string/question_data_collection_title"
-        android:textSize="16sp"
-        app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
-        app:layout_constraintStart_toEndOf="@+id/data_collection_task_icon"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <TextView
-        android:id="@+id/data_collection_question"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="24dp"
-        android:text="@{viewModel.task.label}"
-        android:textSize="16sp"
         app:layout_constraintBottom_toTopOf="@+id/text_input_layout"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/data_collection_task_name" />
+        layout="@layout/data_collection_header"/>
 
       <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
@@ -84,7 +49,7 @@
         android:paddingTop="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/data_collection_question">
+        app:layout_constraintTop_toBottomOf="@+id/data_collection_header">
         <com.google.android.material.textfield.TextInputEditText
           android:id="@+id/user_response_text"
           android:layout_width="200dp"


### PR DESCRIPTION
Added a new subcomponent view for the Data Collection Task header so it can be reused between different task fragments

Towards #1146 

@shobhitagarwal1612 PTAL