### PR TITLE
fix: render custom icons for cluster items

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
@@ -173,6 +173,7 @@ class GoogleMapsFragment : SupportMapFragment(), MapFragment {
     this.map = map
     this.clusterManager = LocationOfInterestClusterManager(context, map)
     clusterManager.setOnClusterItemClickListener(this::onClusterItemClick)
+    clusterManager.renderer = LocationOfInterestClusterRenderer(context, map, clusterManager)
 
     map.setOnCameraIdleListener(this::onCameraIdle)
     map.setOnCameraMoveStartedListener(this::onCameraMoveStarted)

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/LocationOfInterestClusterManager.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/LocationOfInterestClusterManager.kt
@@ -26,12 +26,7 @@ import timber.log.Timber
 
 class LocationOfInterestClusterManager(context: Context?, map: GoogleMap) :
   ClusterManager<LocationOfInterestClusterItem>(context, map) {
-
-  private val renderer: LocationOfInterestClusterRenderer =
-    LocationOfInterestClusterRenderer(context, map, this)
   var activeLocationOfInterest: String? = null
-
-  override fun getRenderer(): LocationOfInterestClusterRenderer = renderer
 
   fun addOrUpdateLocationOfInterest(locationOfInterest: LocationOfInterest) {
     if (locationOfInterest.geometry !is Point) {
@@ -69,4 +64,8 @@ class LocationOfInterestClusterManager(context: Context?, map: GoogleMap) :
 
   fun getMapLocationsOfInterest() =
     algorithm.items.map { MapLocationOfInterest(it.locationOfInterest) }.toImmutableSet()
+
+  init {
+    this.renderer = LocationOfInterestClusterRenderer(context, map, this)
+  }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/LocationOfInterestClusterManager.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/LocationOfInterestClusterManager.kt
@@ -64,8 +64,4 @@ class LocationOfInterestClusterManager(context: Context?, map: GoogleMap) :
 
   fun getMapLocationsOfInterest() =
     algorithm.items.map { MapLocationOfInterest(it.locationOfInterest) }.toImmutableSet()
-
-  init {
-    this.renderer = LocationOfInterestClusterRenderer(context, map, this)
-  }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/LocationOfInterestClusterRenderer.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/LocationOfInterestClusterRenderer.kt
@@ -19,12 +19,11 @@ import android.content.Context
 import android.graphics.Color
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptor
-import com.google.android.gms.maps.model.Marker
+import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.ground.R
 import com.google.android.ground.model.job.Style
 import com.google.android.ground.ui.MarkerIconFactory
 import com.google.maps.android.clustering.view.DefaultClusterRenderer
-import javax.inject.Inject
 import timber.log.Timber
 
 class LocationOfInterestClusterRenderer(
@@ -33,7 +32,7 @@ class LocationOfInterestClusterRenderer(
   private val clusterManager: LocationOfInterestClusterManager,
 ) : DefaultClusterRenderer<LocationOfInterestClusterItem>(context, map, clusterManager) {
 
-  @Inject lateinit var markerIconFactory: MarkerIconFactory
+  val markerIconFactory: MarkerIconFactory? = context?.let { MarkerIconFactory(it) }
 
   private fun parseColor(colorHexCode: String?): Int =
     try {
@@ -43,16 +42,17 @@ class LocationOfInterestClusterRenderer(
       context?.resources?.getColor(R.color.colorMapAccent) ?: 0
     }
 
-  private fun getMarkerIcon(isSelected: Boolean = false): BitmapDescriptor =
-    markerIconFactory.getMarkerIcon(parseColor(Style().color), map.cameraPosition.zoom, isSelected)
+  private fun getMarkerIcon(isSelected: Boolean = false): BitmapDescriptor? =
+    markerIconFactory?.getMarkerIcon(parseColor(Style().color), map.cameraPosition.zoom, isSelected)
 
-  override fun onClusterItemRendered(clusterItem: LocationOfInterestClusterItem, marker: Marker) {
-    super.onClusterItemRendered(clusterItem, marker)
-
-    if (clusterItem.locationOfInterest.id == clusterManager.activeLocationOfInterest) {
-      marker.setIcon(getMarkerIcon(true))
+  override fun onBeforeClusterItemRendered(
+    item: LocationOfInterestClusterItem,
+    markerOptions: MarkerOptions
+  ) {
+    if (item.locationOfInterest.id == clusterManager.activeLocationOfInterest) {
+      markerOptions.icon(getMarkerIcon(true))
     } else {
-      marker.setIcon(getMarkerIcon(false))
+      markerOptions.icon(getMarkerIcon(false))
     }
   }
 }


### PR DESCRIPTION
Fixes an issue whereby cluster items were not rendered using custom icons. Turns out I had implemented the wrong method *and* did not set the renderer properly. We now implement the correct method and ensure the marker icon factory is initialized, if it isn't, default marker icons will be rendered as a fallback.

Fixes #1387

@gino-m 