### PR TITLE
refactor: use coroutines for some UserRepository methods

### DIFF
--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -42,6 +42,7 @@ project.ext {
     rxBindingVersion = "2.2.0"
     workVersion = "2.5.0"
     geotoolsVersion = "27.0"
+    coroutinesVersion = "1.6.4"
 }
 
 // Load secrets.properties
@@ -152,10 +153,7 @@ android {
 
                 // Ignore generated classes from databinding, as well as Room and Firebase classes.
                 option("NullAway:UnannotatedSubPackages",
-                    "com.google.android.ground.databinding," +
-                        "com.google.android.ground.persistence.local.room," +
-                        "com.google.android.ground.persistence.remote.firestore," +
-                        "com.google.android.ground.persistence.remote.firestore.schema")
+                    "com.google.android.ground.databinding," + "com.google.android.ground.persistence.local.room," + "com.google.android.ground.persistence.remote.firestore," + "com.google.android.ground.persistence.remote.firestore.schema")
 
                 excludedPaths = ".*/build/generated/.*"
             }
@@ -178,8 +176,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$project.kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0-RC"
     implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
     // Android legacy support Libraries.
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
@@ -260,6 +258,7 @@ dependencies {
 
     // Room
     implementation "androidx.room:room-runtime:$roomVersion"
+    implementation "androidx.room:room-ktx:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
     implementation "androidx.room:room-rxjava2:$roomVersion"
     implementation "androidx.room:room-guava:$roomVersion"
@@ -285,6 +284,7 @@ dependencies {
     testImplementation 'android.arch.core:core-testing:1.1.1'
     testImplementation 'com.jraska.livedata:testing:1.2.0'
     testImplementation "androidx.arch.core:core-testing:1.3.0"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 
     // Mockito
     testImplementation 'org.mockito:mockito-inline:2.8.47'

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/CoroutineDao.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/CoroutineDao.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.persistence.local.room.dao
+
+import androidx.room.*
+
+/** Temporary shim to support coroutine migrations. */
+@Dao
+interface CoroutineDao<E> {
+  /** Inserts an entity into the database. */
+  @Insert suspend fun insert(entity: E)
+  /** Update an entity in the database. Returns the number of updated rows. */
+  @Update suspend fun update(entity: E): Int
+  /**
+   * Updates all database entities in the given list. Returns the number of successfully updated
+   * rows.
+   */
+  @Update suspend fun updateAll(entities: List<E>): Int
+  /** Deletes an entity from the database. */
+  @Delete suspend fun delete(entity: E)
+}
+
+/** Try to update the specified entity, and if it doesn't yet exist, create it. */
+@Transaction
+suspend fun <E> CoroutineDao<E>.insertOrUpdate(entity: E) {
+  if (update(entity) == 0) {
+    insert(entity)
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/UserDao.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/UserDao.kt
@@ -19,11 +19,14 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Transaction
 import com.google.android.ground.persistence.local.room.entity.UserEntity
-import io.reactivex.Maybe
 
 @Dao
-interface UserDao : BaseDao<UserEntity> {
+interface UserDao : CoroutineDao<UserEntity> {
+  /**
+   * Fetches the user with the given ID from local storage, or returns null if the user does not
+   * exist.
+   */
   @Transaction
   @Query("SELECT * FROM user WHERE id = :id")
-  fun findById(id: String): Maybe<UserEntity>
+  suspend fun findById(id: String): UserEntity?
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalUserStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalUserStore.kt
@@ -17,13 +17,12 @@ package com.google.android.ground.persistence.local.stores
 
 import com.google.android.ground.model.User
 import com.google.android.ground.rx.annotations.Cold
-import io.reactivex.Completable
 import io.reactivex.Single
 
 /** Provides access to [User] data in local storage. */
 interface LocalUserStore : LocalStore<User> {
   /** Add user to the database. */
-  fun insertOrUpdateUser(user: User): @Cold Completable
+  suspend fun insertOrUpdateUser(user: User)
   /**
    * Loads the user with the specified id from the local data store. The returned Single fails with
    * [java.util.NoSuchElementException] if not found.

--- a/ground/src/main/java/com/google/android/ground/repository/UserRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/UserRepository.kt
@@ -23,7 +23,6 @@ import com.google.android.ground.persistence.local.LocalValueStore
 import com.google.android.ground.rx.Schedulers
 import com.google.android.ground.rx.annotations.Cold
 import com.google.android.ground.system.auth.AuthenticationManager
-import io.reactivex.Completable
 import io.reactivex.Single
 import javax.inject.Inject
 
@@ -59,8 +58,8 @@ constructor(
       else -> Role.UNKNOWN
     }
 
-  fun saveUser(user: User): @Cold Completable =
-    userStore.insertOrUpdateUser(user).observeOn(schedulers.io())
+  /** Saves the given user's data to local storage. */
+  suspend fun saveUser(user: User) = userStore.insertOrUpdateUser(user)
 
   fun getUser(userId: String): @Cold Single<User> = userStore.getUser(userId)
 

--- a/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataLocalStoreTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataLocalStoreTest.kt
@@ -51,12 +51,15 @@ import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidTest
 import java.util.*
 import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
 class LocalDataLocalStoreTest : BaseHiltTest() {
@@ -112,14 +115,14 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testInsertAndGetUser() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).test().assertComplete()
+  fun testInsertAndGetUser() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.userStore.getUser("user id").test().assertValue(TEST_USER)
   }
 
   @Test
-  fun testApplyAndEnqueue_loiMutation() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testApplyAndEnqueue_loiMutation() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore
       .applyAndEnqueue(TEST_LOI_MUTATION)
@@ -138,8 +141,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testApplyAndEnqueue_polygonLoiMutation() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testApplyAndEnqueue_polygonLoiMutation() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore
       .applyAndEnqueue(TEST_POLYGON_LOI_MUTATION)
@@ -158,8 +161,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testGetLoisOnceAndStream() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testGetLoisOnceAndStream() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     val subscriber =
       localDataStore.localLocationOfInterestStore
@@ -175,8 +178,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testUpdateMutations() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testUpdateMutations() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore.applyAndEnqueue(TEST_LOI_MUTATION).blockingAwait()
     val mutation = createTestLocationOfInterestMutation(TEST_POINT_2)
@@ -188,8 +191,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testPolygonUpdateMutations() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testPolygonUpdateMutations() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore
       .applyAndEnqueue(TEST_POLYGON_LOI_MUTATION)
@@ -203,8 +206,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testFinalizePendingMutation() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testFinalizePendingMutation() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore.applyAndEnqueue(TEST_LOI_MUTATION).blockingAwait()
     localDataStore
@@ -215,8 +218,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testMergeLoi() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testMergeLoi() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore.applyAndEnqueue(TEST_LOI_MUTATION).blockingAwait()
     val loi =
@@ -232,8 +235,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testMergePolygonLoi() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testMergePolygonLoi() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore
       .applyAndEnqueue(TEST_POLYGON_LOI_MUTATION)
@@ -251,8 +254,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testApplyAndEnqueue_submissionMutation() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testApplyAndEnqueue_submissionMutation() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore.applyAndEnqueue(TEST_LOI_MUTATION).blockingAwait()
     localDataStore.submissionStore.applyAndEnqueue(TEST_SUBMISSION_MUTATION).test().assertComplete()
@@ -296,8 +299,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testMergeSubmission() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testMergeSubmission() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore.applyAndEnqueue(TEST_LOI_MUTATION).blockingAwait()
     localDataStore.submissionStore.applyAndEnqueue(TEST_SUBMISSION_MUTATION).blockingAwait()
@@ -320,9 +323,9 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testDeleteSubmission() {
+  fun testDeleteSubmission() = runTest {
     // Add test submission
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore.applyAndEnqueue(TEST_LOI_MUTATION).blockingAwait()
     localDataStore.submissionStore.applyAndEnqueue(TEST_SUBMISSION_MUTATION).blockingAwait()
@@ -355,8 +358,8 @@ class LocalDataLocalStoreTest : BaseHiltTest() {
   }
 
   @Test
-  fun testDeleteLoi() {
-    localDataStore.userStore.insertOrUpdateUser(TEST_USER).blockingAwait()
+  fun testDeleteLoi() = runTest {
+    localDataStore.userStore.insertOrUpdateUser(TEST_USER)
     localDataStore.surveyStore.insertOrUpdateSurvey(TEST_SURVEY).blockingAwait()
     localDataStore.localLocationOfInterestStore.applyAndEnqueue(TEST_LOI_MUTATION).blockingAwait()
     localDataStore.submissionStore.applyAndEnqueue(TEST_SUBMISSION_MUTATION).blockingAwait()

--- a/ground/src/test/java/com/google/android/ground/repository/UserRepositoryTest.kt
+++ b/ground/src/test/java/com/google/android/ground/repository/UserRepositoryTest.kt
@@ -25,10 +25,13 @@ import com.sharedtest.persistence.local.LocalDataStoreHelper
 import com.sharedtest.system.auth.FakeAuthenticationManager
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
 class UserRepositoryTest : BaseHiltTest() {
@@ -63,12 +66,12 @@ class UserRepositoryTest : BaseHiltTest() {
   }
 
   @Test
-  fun testSaveUser() {
+  fun testSaveUser() = runTest {
     localDataStore.userStore
       .getUser(FakeData.USER.id)
       .test()
       .assertFailure(NoSuchElementException::class.java)
-    userRepository.saveUser(FakeData.USER).test().assertComplete()
+    userRepository.saveUser(FakeData.USER)
     localDataStore.userStore.getUser(FakeData.USER.id).test().assertResult(FakeData.USER)
   }
 


### PR DESCRIPTION
A first experiment in a gradual migration to coroutines. We currently need to couple them with RX code, so we use runBlocking and RX methods to do so.

@gino-m @shobhitagarwal1612 @JSunde 
