### PR TITLE
Update roboelectric for M1 chipset support

### DIFF
--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -263,13 +263,18 @@ dependencies {
 
     // Testing
     testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     testImplementation 'com.google.truth:truth:1.1.3'
     androidTestImplementation 'com.google.truth:truth:1.1.3'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.robolectric:robolectric:4.9.2'
     testImplementation 'android.arch.core:core-testing:1.1.1'
+    androidTestImplementation 'android.arch.core:core-testing:1.1.1'
     testImplementation 'com.jraska.livedata:testing:1.2.0'
     testImplementation "androidx.arch.core:core-testing:1.3.0"
+    androidTestImplementation 'com.squareup.rx.idler:rx2-idler:0.11.0'
+    testImplementation 'com.squareup.rx.idler:rx2-idler:0.11.0'
 
     // Mockito
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"
@@ -285,14 +290,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     androidTestImplementation('androidx.test.espresso:espresso-core:3.5.1', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-    androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'android.arch.core:core-testing:1.1.1'
-    androidTestImplementation 'com.squareup.rx.idler:rx2-idler:0.11.0'
-    testImplementation 'com.squareup.rx.idler:rx2-idler:0.11.0'
-    testImplementation('androidx.test.espresso:espresso-core:3.3.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 

--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -279,8 +279,12 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
-    testImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.3.0', {
+    // Espresso
+    testImplementation 'androidx.test.espresso:espresso-contrib:3.5.1'
+    testImplementation('androidx.test.espresso:espresso-core:3.5.1', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.5.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     androidTestImplementation 'junit:junit:4.13.2'

--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -266,7 +266,7 @@ dependencies {
     testImplementation 'com.google.truth:truth:1.1.3'
     androidTestImplementation 'com.google.truth:truth:1.1.3'
     testImplementation 'androidx.test:core:1.3.0'
-    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'org.robolectric:robolectric:4.9.2'
     testImplementation 'android.arch.core:core-testing:1.1.1'
     testImplementation 'com.jraska.livedata:testing:1.2.0'
     testImplementation "androidx.arch.core:core-testing:1.3.0"


### PR DESCRIPTION
Required to use in-memory SQLite on Apple M1 chipsets.

Towards #1471.

@shobhitagarwal1612 PTAL?