### PR TITLE
Simplify SurveyRepository tests using in memory local db instead of mocks

### DIFF
--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -275,6 +275,7 @@ dependencies {
     testImplementation "androidx.arch.core:core-testing:1.3.0"
     androidTestImplementation 'com.squareup.rx.idler:rx2-idler:0.11.0'
     testImplementation 'com.squareup.rx.idler:rx2-idler:0.11.0'
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$project.kotlinVersion"
 
     // Mockito
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"

--- a/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.rx2.awaitSingleOrNull
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 private const val LOAD_REMOTE_SURVEY_TIMEOUT_SECS: Long = 15
@@ -109,14 +108,12 @@ constructor(
       return
     }
 
-    externalScope.launch {
-      withContext(ioDispatcher) {
-        try {
-          surveyStore.getSurveyById(surveyId).awaitSingleOrNull() ?: syncSurveyFromRemote(surveyId)
-          localValueStore.activeSurveyId = surveyId
-        } catch (e: Error) {
-          Timber.e("Error activating survey", e)
-        }
+    externalScope.launch(ioDispatcher) {
+      try {
+        surveyStore.getSurveyById(surveyId).awaitSingleOrNull() ?: syncSurveyFromRemote(surveyId)
+        localValueStore.activeSurveyId = surveyId
+      } catch (e: Error) {
+        Timber.e("Error activating survey", e)
       }
     }
   }

--- a/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
@@ -53,7 +53,6 @@ constructor(
   private val localDataStore: LocalDataStore,
   private val remoteDataStore: RemoteDataStore,
   private val localValueStore: LocalValueStore,
-  @ApplicationScope private val externalScope: CoroutineScope,
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
   private val surveyStore = localDataStore.surveyStore

--- a/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
@@ -15,7 +15,6 @@
  */
 package com.google.android.ground.repository
 
-import com.google.android.ground.coroutines.ApplicationScope
 import com.google.android.ground.coroutines.IoDispatcher
 import com.google.android.ground.model.Survey
 import com.google.android.ground.model.User
@@ -32,7 +31,6 @@ import java8.util.Optional
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.rx2.awaitSingleOrNull
 import kotlinx.coroutines.withContext

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenViewModel.kt
@@ -16,6 +16,7 @@
 package com.google.android.ground.ui.home
 
 import androidx.lifecycle.MutableLiveData
+import com.google.android.ground.coroutines.ApplicationScope
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.repository.LocationOfInterestRepository
 import com.google.android.ground.repository.SurveyRepository
@@ -33,6 +34,8 @@ import io.reactivex.processors.PublishProcessor
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @SharedViewModel
@@ -41,7 +44,8 @@ class HomeScreenViewModel
 internal constructor(
   private val surveyRepository: SurveyRepository,
   private val locationOfInterestRepository: LocationOfInterestRepository,
-  private val navigator: Navigator
+  private val navigator: Navigator,
+  @ApplicationScope private val externalScope: CoroutineScope
 ) : AbstractViewModel() {
 
   @JvmField
@@ -79,9 +83,7 @@ internal constructor(
     isSubmissionButtonVisible.value = false
   }
 
-  fun init() {
-    surveyRepository.loadLastActiveSurvey()
-  }
+  fun init() = externalScope.launch { surveyRepository.loadLastActiveSurvey() }
 
   fun showOfflineAreas() {
     navigator.navigate(HomeScreenFragmentDirections.showOfflineAreas())

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
@@ -17,6 +17,7 @@ package com.google.android.ground.ui.surveyselector
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.LiveDataReactiveStreams
+import androidx.lifecycle.viewModelScope
 import com.google.android.ground.model.Survey
 import com.google.android.ground.repository.SurveyRepository
 import com.google.android.ground.system.auth.AuthenticationManager
@@ -25,6 +26,7 @@ import com.google.android.ground.ui.common.Navigator
 import com.google.android.ground.ui.home.HomeScreenFragmentDirections
 import io.reactivex.Single
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 /** Represents view state and behaviors of the survey selector dialog. */
 class SurveySelectorViewModel
@@ -65,10 +67,12 @@ internal constructor(
     get() = surveyRepository.getSurveySummaries(authManager.currentUser)
 
   /** Triggers the specified survey to be loaded and activated. */
-  fun activateSurvey(surveyId: String) {
-    surveyRepository.activateSurvey(surveyId)
-    navigateToHomeScreen()
-  }
+  fun activateSurvey(surveyId: String) =
+    viewModelScope.launch {
+      // TODO(#1497): Handle exceptions thrown by activateSurvey().
+      surveyRepository.activateSurvey(surveyId)
+      navigateToHomeScreen()
+    }
 
   private fun navigateToHomeScreen() {
     navigator.navigate(HomeScreenFragmentDirections.showHomeScreen())

--- a/ground/src/test/java/com/google/android/ground/repository/SurveyRepositoryTest.kt
+++ b/ground/src/test/java/com/google/android/ground/repository/SurveyRepositoryTest.kt
@@ -18,7 +18,6 @@ package com.google.android.ground.repository
 import com.google.android.ground.BaseHiltTest
 import com.google.android.ground.coroutines.DefaultDispatcher
 import com.google.android.ground.persistence.local.LocalValueStore
-import com.google.android.ground.persistence.local.room.LocalDatabase
 import com.google.android.ground.persistence.local.stores.LocalSurveyStore
 import com.google.common.truth.Truth.assertThat
 import com.sharedtest.FakeData.SURVEY
@@ -32,7 +31,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.*
@@ -42,19 +40,11 @@ import org.robolectric.RobolectricTestRunner
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
 class SurveyRepositoryTest : BaseHiltTest() {
-  @Inject lateinit var localDatabase: LocalDatabase
   @Inject lateinit var surveyStore: LocalSurveyStore
   @Inject lateinit var fakeRemoteDataStore: FakeRemoteDataStore
   @Inject lateinit var surveyRepository: SurveyRepository
   @Inject lateinit var localValueStore: LocalValueStore
   @DefaultDispatcher @Inject lateinit var testDispatcher: CoroutineDispatcher
-
-  @Before
-  override fun setUp() {
-    super.setUp()
-    // Reset local test db between tests.
-    localDatabase.clearAllTables()
-  }
 
   @Test
   fun activateSurvey_firstTime() =

--- a/ground/src/test/java/com/google/android/ground/repository/SurveyRepositoryTest.kt
+++ b/ground/src/test/java/com/google/android/ground/repository/SurveyRepositoryTest.kt
@@ -17,106 +17,88 @@ package com.google.android.ground.repository
 
 import com.google.android.ground.BaseHiltTest
 import com.google.android.ground.coroutines.DefaultDispatcher
-import com.google.android.ground.model.Survey
-import com.google.android.ground.persistence.local.LocalDataStore
-import com.google.android.ground.persistence.local.LocalDataStoreModule
 import com.google.android.ground.persistence.local.LocalValueStore
-import com.google.android.ground.persistence.local.room.RoomLocalDataStore
+import com.google.android.ground.persistence.local.room.LocalDatabase
 import com.google.android.ground.persistence.local.stores.LocalSurveyStore
 import com.google.common.truth.Truth.assertThat
 import com.sharedtest.FakeData.SURVEY
 import com.sharedtest.persistence.remote.FakeRemoteDataStore
-import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.UninstallModules
-import io.reactivex.Completable
-import io.reactivex.Maybe
 import java8.util.Optional
 import javax.inject.Inject
+import kotlin.test.assertFails
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyString
-import org.mockito.InjectMocks
-import org.mockito.Mock
 import org.mockito.Mockito.*
-import org.mockito.kotlin.any
 import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@UninstallModules(LocalDataStoreModule::class)
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
 class SurveyRepositoryTest : BaseHiltTest() {
-  @BindValue @InjectMocks var mockLocalDataStore: LocalDataStore = RoomLocalDataStore()
-
-  @BindValue @Mock lateinit var mockLocalSurveyStore: LocalSurveyStore
-
+  @Inject lateinit var localDatabase: LocalDatabase
+  @Inject lateinit var surveyStore: LocalSurveyStore
   @Inject lateinit var fakeRemoteDataStore: FakeRemoteDataStore
-
   @Inject lateinit var surveyRepository: SurveyRepository
-
   @Inject lateinit var localValueStore: LocalValueStore
-
   @DefaultDispatcher @Inject lateinit var testDispatcher: CoroutineDispatcher
 
   @Before
   override fun setUp() {
     super.setUp()
-    `when`(mockLocalSurveyStore.insertOrUpdateSurvey(any())).thenReturn(Completable.complete())
+    // Reset local test db between tests.
+    localDatabase.clearAllTables()
   }
 
   @Test
   fun activateSurvey_firstTime() =
     runTest(testDispatcher) {
-      // TODO(#1470): Remove this once we no longer rely on mocking `getSurvey`.
-      `when`(mockLocalSurveyStore.getSurveyById(anyString()))
-        .thenReturn(Maybe.empty(), Maybe.just(SURVEY))
       fakeRemoteDataStore.setTestSurvey(SURVEY)
 
       surveyRepository.activateSurvey(SURVEY.id)
       advanceUntilIdle()
 
+      // Verify survey is available offline.
+      surveyRepository.getOfflineSurvey(SURVEY.id).test().assertValue(SURVEY)
+      // Verify survey is active.
       surveyRepository.activeSurvey.test().assertValues(Optional.of(SURVEY))
-      verify(mockLocalSurveyStore).insertOrUpdateSurvey(SURVEY)
+      // Verify app is subscribed to push updates.
       assertThat(fakeRemoteDataStore.isSubscribedToSurveyUpdates(SURVEY.id)).isTrue()
     }
 
   @Test
   fun activateSurvey_firstTime_handleRemoteFailure() =
     runTest(testDispatcher) {
-      clearLocalTestSurvey()
       fakeRemoteDataStore.failOnLoadSurvey = true
 
-      surveyRepository.activateSurvey(SURVEY.id)
+      assertFails { surveyRepository.activateSurvey(SURVEY.id) }
       advanceUntilIdle()
-
-      verify(mockLocalSurveyStore, never()).insertOrUpdateSurvey(SURVEY)
       assertThat(fakeRemoteDataStore.isSubscribedToSurveyUpdates(SURVEY.id)).isFalse()
     }
 
   @Test
   fun activateSurvey_alreadyAvailableOffline() =
     runTest(testDispatcher) {
-      setLocalTestSurvey(SURVEY)
+      surveyStore.insertOrUpdateSurvey(SURVEY).await()
 
       surveyRepository.activateSurvey(SURVEY.id)
       advanceUntilIdle()
 
       surveyRepository.activeSurvey.test().assertValue(Optional.of(SURVEY))
-      verify(mockLocalSurveyStore, never()).insertOrUpdateSurvey(any())
       assertThat(fakeRemoteDataStore.isSubscribedToSurveyUpdates(SURVEY.id)).isFalse()
     }
 
   @Test
   fun loadLastActiveSurvey() =
     runTest(testDispatcher) {
+      surveyStore.insertOrUpdateSurvey(SURVEY).await()
       localValueStore.activeSurveyId = SURVEY.id
-      setLocalTestSurvey(SURVEY)
 
       surveyRepository.loadLastActiveSurvey()
       advanceUntilIdle()
@@ -127,20 +109,12 @@ class SurveyRepositoryTest : BaseHiltTest() {
   @Test
   fun loadLastActiveSurvey_noneSet() =
     runTest(testDispatcher) {
+      surveyStore.insertOrUpdateSurvey(SURVEY).await()
       localValueStore.activeSurveyId = ""
-      setLocalTestSurvey(SURVEY)
 
       surveyRepository.loadLastActiveSurvey()
       advanceUntilIdle()
 
       surveyRepository.activeSurvey.test().assertValue(Optional.empty())
     }
-
-  private fun clearLocalTestSurvey() {
-    `when`(mockLocalSurveyStore.getSurveyById(anyString())).thenReturn(Maybe.empty())
-  }
-
-  private fun setLocalTestSurvey(survey: Survey) {
-    `when`(mockLocalSurveyStore.getSurveyById(anyString())).thenReturn(Maybe.just(survey))
-  }
 }


### PR DESCRIPTION
Also pushes launch of `activateSurvey()` up to view models so that exceptions can be propagated and handled there.

Towards #1471.

@shobhitagarwal1612 Could you PTAL?