### PR TITLE
Use navGraph scoped ViewModel to share DataCollectionViewModel

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,7 @@
         <option name="TAB_SIZE" value="2" />
       </value>
     </option>
+    <option name="ENABLE_SECOND_REFORMAT" value="true" />
     <AndroidXmlCodeStyleSettings>
       <option name="LAYOUT_SETTINGS">
         <value>

--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -269,6 +269,8 @@ dependencies {
     androidTestImplementation 'com.squareup.rx.idler:rx2-idler:0.11.0'
     testImplementation 'com.squareup.rx.idler:rx2-idler:0.11.0'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$project.kotlinVersion"
+    testImplementation "androidx.navigation:navigation-testing:$project.navigationVersion"
+    androidTestImplementation "androidx.navigation:navigation-testing:$project.navigationVersion"
 
     // Mockito
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"

--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -191,6 +191,7 @@ dependencies {
     // Hilt
     implementation "com.google.dagger:hilt-android:$project.hiltVersion"
     kapt "com.google.dagger:hilt-compiler:$project.hiltVersion"
+    implementation "androidx.hilt:hilt-navigation-fragment:$project.hiltJetpackVersion"
     // For Robolectric tests.
     testImplementation "com.google.dagger:hilt-android-testing:$project.hiltVersion"
     // ...with Kotlin.

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -19,7 +19,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.navArgs
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.ground.R
@@ -40,7 +40,7 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
   @Inject lateinit var viewPagerAdapterFactory: DataCollectionViewPagerAdapterFactory
 
   private val args: DataCollectionFragmentArgs by navArgs()
-  private val viewModel: DataCollectionViewModel by activityViewModels()
+  private val viewModel: DataCollectionViewModel by hiltNavGraphViewModels(R.id.data_collection)
 
   private lateinit var viewPager: ViewPager2
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/date/DateTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/date/DateTaskFragment.kt
@@ -35,6 +35,7 @@ class DateTaskFragment : AbstractFragment(), TaskFragment<DateTaskViewModel> {
   private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
   override lateinit var viewModel: DateTaskViewModel
   override var position by Delegates.notNull<Int>()
+  private lateinit var binding: DateTaskFragBinding
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -54,14 +55,18 @@ class DateTaskFragment : AbstractFragment(), TaskFragment<DateTaskViewModel> {
     savedInstanceState: Bundle?
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
-    val binding = DateTaskFragBinding.inflate(inflater, container, false)
+    binding = DateTaskFragBinding.inflate(inflater, container, false)
+
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
 
     viewModel = dataCollectionViewModel.getTaskViewModel(position) as DateTaskViewModel
     binding.lifecycleOwner = this
     binding.setVariable(BR.viewModel, viewModel)
     binding.setVariable(BR.fragment, this)
-
-    return binding.root
   }
 
   fun showDateDialog() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/date/DateTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/date/DateTaskFragment.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnAttach
 import androidx.fragment.app.activityViewModels
 import com.google.android.ground.BR
 import com.google.android.ground.databinding.DateTaskFragBinding
@@ -63,10 +64,12 @@ class DateTaskFragment : AbstractFragment(), TaskFragment<DateTaskViewModel> {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as DateTaskViewModel
-    binding.lifecycleOwner = this
-    binding.setVariable(BR.viewModel, viewModel)
-    binding.setVariable(BR.fragment, this)
+    view.doOnAttach {
+      viewModel = dataCollectionViewModel.getTaskViewModel(position) as DateTaskViewModel
+      binding.lifecycleOwner = this
+      binding.setVariable(BR.viewModel, viewModel)
+      binding.setVariable(BR.fragment, this)
+    }
   }
 
   fun showDateDialog() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
@@ -19,7 +19,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.recyclerview.selection.ItemDetailsLookup
 import androidx.recyclerview.selection.ItemKeyProvider
 import androidx.recyclerview.selection.SelectionTracker
@@ -43,7 +43,8 @@ import kotlin.properties.Delegates
  */
 @AndroidEntryPoint
 class MultipleChoiceTaskFragment : AbstractFragment(), TaskFragment<MultipleChoiceTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
+  private val dataCollectionViewModel: DataCollectionViewModel by
+    hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: MultipleChoiceTaskViewModel
   override var position by Delegates.notNull<Int>()
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
@@ -31,7 +31,7 @@ import com.google.android.ground.R
 import com.google.android.ground.databinding.MultipleChoiceTaskFragBinding
 import com.google.android.ground.model.task.MultipleChoice
 import com.google.android.ground.ui.common.AbstractFragment
-import com.google.android.ground.ui.datacollection.*
+import com.google.android.ground.ui.datacollection.DataCollectionViewModel
 import com.google.android.ground.ui.datacollection.tasks.TaskFragment
 import com.google.android.ground.ui.datacollection.tasks.TaskFragment.Companion.POSITION
 import dagger.hilt.android.AndroidEntryPoint

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
@@ -19,6 +19,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnAttach
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.recyclerview.selection.ItemDetailsLookup
 import androidx.recyclerview.selection.ItemKeyProvider
@@ -75,20 +76,22 @@ class MultipleChoiceTaskFragment : AbstractFragment(), TaskFragment<MultipleChoi
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as MultipleChoiceTaskViewModel
-    binding.lifecycleOwner = this
-    binding.setVariable(BR.viewModel, viewModel)
+    view.doOnAttach {
+      viewModel = dataCollectionViewModel.getTaskViewModel(position) as MultipleChoiceTaskViewModel
+      binding.lifecycleOwner = this
+      binding.setVariable(BR.viewModel, viewModel)
 
-    val multipleChoice = viewModel.task.multipleChoice!!
-    val optionListView = binding.root.findViewById<RecyclerView>(R.id.select_option_list)
-    optionListView.setHasFixedSize(true)
-    if (multipleChoice.cardinality == MultipleChoice.Cardinality.SELECT_MULTIPLE) {
-      val adapter = SelectMultipleOptionAdapter(multipleChoice.options, viewModel)
-      adapter.setHasStableIds(true)
-      optionListView.adapter = adapter
-      setupMultipleSelectionTracker(optionListView, adapter)
-    } else {
-      optionListView.adapter = SelectOneOptionAdapter(multipleChoice.options, viewModel)
+      val multipleChoice = viewModel.task.multipleChoice!!
+      val optionListView = binding.root.findViewById<RecyclerView>(R.id.select_option_list)
+      optionListView.setHasFixedSize(true)
+      if (multipleChoice.cardinality == MultipleChoice.Cardinality.SELECT_MULTIPLE) {
+        val adapter = SelectMultipleOptionAdapter(multipleChoice.options, viewModel)
+        adapter.setHasStableIds(true)
+        optionListView.adapter = adapter
+        setupMultipleSelectionTracker(optionListView, adapter)
+      } else {
+        optionListView.adapter = SelectOneOptionAdapter(multipleChoice.options, viewModel)
+      }
     }
   }
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
@@ -47,6 +47,7 @@ class MultipleChoiceTaskFragment : AbstractFragment(), TaskFragment<MultipleChoi
     hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: MultipleChoiceTaskViewModel
   override var position by Delegates.notNull<Int>()
+  private lateinit var binding: MultipleChoiceTaskFragBinding
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -66,7 +67,13 @@ class MultipleChoiceTaskFragment : AbstractFragment(), TaskFragment<MultipleChoi
     savedInstanceState: Bundle?
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
-    val binding = MultipleChoiceTaskFragBinding.inflate(inflater, container, false)
+    binding = MultipleChoiceTaskFragBinding.inflate(inflater, container, false)
+
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
 
     viewModel = dataCollectionViewModel.getTaskViewModel(position) as MultipleChoiceTaskViewModel
     binding.lifecycleOwner = this
@@ -83,8 +90,6 @@ class MultipleChoiceTaskFragment : AbstractFragment(), TaskFragment<MultipleChoi
     } else {
       optionListView.adapter = SelectOneOptionAdapter(multipleChoice.options, viewModel)
     }
-
-    return binding.root
   }
 
   private fun setupMultipleSelectionTracker(view: RecyclerView, adapter: SelectionAdapter<*>) {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
@@ -37,6 +37,7 @@ class NumberTaskFragment : AbstractFragment(), TaskFragment<NumberTaskViewModel>
     hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: NumberTaskViewModel
   override var position by Delegates.notNull<Int>()
+  private lateinit var binding: NumberTaskFragBinding
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -58,10 +59,14 @@ class NumberTaskFragment : AbstractFragment(), TaskFragment<NumberTaskViewModel>
     super.onCreateView(inflater, container, savedInstanceState)
     val binding = NumberTaskFragBinding.inflate(inflater, container, false)
 
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
     viewModel = dataCollectionViewModel.getTaskViewModel(position) as NumberTaskViewModel
     binding.lifecycleOwner = this
     binding.setVariable(BR.viewModel, viewModel)
-
-    return binding.root
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
@@ -19,6 +19,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnAttach
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.google.android.ground.BR
 import com.google.android.ground.R
@@ -57,7 +58,7 @@ class NumberTaskFragment : AbstractFragment(), TaskFragment<NumberTaskViewModel>
     savedInstanceState: Bundle?
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
-    val binding = NumberTaskFragBinding.inflate(inflater, container, false)
+    binding = NumberTaskFragBinding.inflate(inflater, container, false)
 
     return binding.root
   }
@@ -65,8 +66,10 @@ class NumberTaskFragment : AbstractFragment(), TaskFragment<NumberTaskViewModel>
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as NumberTaskViewModel
-    binding.lifecycleOwner = this
-    binding.setVariable(BR.viewModel, viewModel)
+    view.doOnAttach {
+      viewModel = dataCollectionViewModel.getTaskViewModel(position) as NumberTaskViewModel
+      binding.lifecycleOwner = this
+      binding.setVariable(BR.viewModel, viewModel)
+    }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
@@ -19,7 +19,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.activityViewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.google.android.ground.BR
 import com.google.android.ground.R
@@ -34,7 +33,8 @@ import kotlin.properties.Delegates
 /** Fragment allowing the user to answer questions to complete a task. */
 @AndroidEntryPoint
 class NumberTaskFragment : AbstractFragment(), TaskFragment<NumberTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by hiltNavGraphViewModels(R.id.data_collection)
+  private val dataCollectionViewModel: DataCollectionViewModel by
+    hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: NumberTaskViewModel
   override var position by Delegates.notNull<Int>()
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
@@ -20,7 +20,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.google.android.ground.BR
+import com.google.android.ground.R
 import com.google.android.ground.databinding.NumberTaskFragBinding
 import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.datacollection.DataCollectionViewModel
@@ -32,7 +34,7 @@ import kotlin.properties.Delegates
 /** Fragment allowing the user to answer questions to complete a task. */
 @AndroidEntryPoint
 class NumberTaskFragment : AbstractFragment(), TaskFragment<NumberTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
+  private val dataCollectionViewModel: DataCollectionViewModel by hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: NumberTaskViewModel
   override var position by Delegates.notNull<Int>()
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
@@ -58,6 +58,7 @@ class PhotoTaskFragment : AbstractFragment(), TaskFragment<PhotoTaskViewModel> {
   override var position by Delegates.notNull<Int>()
   private lateinit var selectPhotoLauncher: ActivityResultLauncher<String>
   private lateinit var capturePhotoLauncher: ActivityResultLauncher<Uri>
+  private lateinit var binding: PhotoTaskFragBinding
   private var hasRequestedPermissionsOnResume = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -73,7 +74,13 @@ class PhotoTaskFragment : AbstractFragment(), TaskFragment<PhotoTaskViewModel> {
     savedInstanceState: Bundle?
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
+    binding = PhotoTaskFragBinding.inflate(inflater, container, false)
 
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
     viewModel = dataCollectionViewModel.getTaskViewModel(position) as PhotoTaskViewModel
     selectPhotoLauncher =
       registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
@@ -83,8 +90,6 @@ class PhotoTaskFragment : AbstractFragment(), TaskFragment<PhotoTaskViewModel> {
       registerForActivityResult(ActivityResultContracts.TakePicture()) { result: Boolean ->
         viewModel.onCapturePhotoResult(result)
       }
-
-    val binding = PhotoTaskFragBinding.inflate(inflater, container, false)
 
     binding.lifecycleOwner = this
     binding.setVariable(BR.viewModel, viewModel)
@@ -96,11 +101,6 @@ class PhotoTaskFragment : AbstractFragment(), TaskFragment<PhotoTaskViewModel> {
     observeSelectPhotoClicks()
     observePhotoResults()
 
-    return binding.root
-  }
-
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
     viewModel.setTaskWaitingForPhoto(savedInstanceState?.getString(TASK_WAITING_FOR_PHOTO))
     viewModel.setCapturedPhotoPath(savedInstanceState?.getString(CAPTURED_PHOTO_PATH))
   }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
+import androidx.core.view.doOnAttach
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.google.android.ground.BR
 import com.google.android.ground.BuildConfig
@@ -81,28 +82,31 @@ class PhotoTaskFragment : AbstractFragment(), TaskFragment<PhotoTaskViewModel> {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as PhotoTaskViewModel
-    selectPhotoLauncher =
-      registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-        viewModel.onSelectPhotoResult(uri)
-      }
-    capturePhotoLauncher =
-      registerForActivityResult(ActivityResultContracts.TakePicture()) { result: Boolean ->
-        viewModel.onCapturePhotoResult(result)
-      }
 
-    binding.lifecycleOwner = this
-    binding.setVariable(BR.viewModel, viewModel)
-    binding.setVariable(BR.dataCollectionViewModel, dataCollectionViewModel)
+    view.doOnAttach {
+      viewModel = dataCollectionViewModel.getTaskViewModel(position) as PhotoTaskViewModel
+      selectPhotoLauncher =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+          viewModel.onSelectPhotoResult(uri)
+        }
+      capturePhotoLauncher =
+        registerForActivityResult(ActivityResultContracts.TakePicture()) { result: Boolean ->
+          viewModel.onCapturePhotoResult(result)
+        }
 
-    viewModel.setEditable(true)
-    viewModel.setSurveyId(dataCollectionViewModel.surveyId)
-    viewModel.setSubmissionId(dataCollectionViewModel.submissionId)
-    observeSelectPhotoClicks()
-    observePhotoResults()
+      binding.lifecycleOwner = this
+      binding.setVariable(BR.viewModel, viewModel)
+      binding.setVariable(BR.dataCollectionViewModel, dataCollectionViewModel)
 
-    viewModel.setTaskWaitingForPhoto(savedInstanceState?.getString(TASK_WAITING_FOR_PHOTO))
-    viewModel.setCapturedPhotoPath(savedInstanceState?.getString(CAPTURED_PHOTO_PATH))
+      viewModel.setEditable(true)
+      viewModel.setSurveyId(dataCollectionViewModel.surveyId)
+      viewModel.setSubmissionId(dataCollectionViewModel.submissionId)
+      observeSelectPhotoClicks()
+      observePhotoResults()
+
+      viewModel.setTaskWaitingForPhoto(savedInstanceState?.getString(TASK_WAITING_FOR_PHOTO))
+      viewModel.setCapturedPhotoPath(savedInstanceState?.getString(CAPTURED_PHOTO_PATH))
+    }
   }
 
   override fun onResume() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
@@ -24,9 +24,10 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
-import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.google.android.ground.BR
 import com.google.android.ground.BuildConfig
+import com.google.android.ground.R
 import com.google.android.ground.coroutines.ApplicationScope
 import com.google.android.ground.databinding.PhotoTaskFragBinding
 import com.google.android.ground.repository.UserMediaRepository
@@ -51,7 +52,8 @@ class PhotoTaskFragment : AbstractFragment(), TaskFragment<PhotoTaskViewModel> {
   @Inject @ApplicationScope lateinit var externalScope: CoroutineScope
   @Inject lateinit var permissionsManager: PermissionsManager
 
-  private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
+  private val dataCollectionViewModel: DataCollectionViewModel by
+    hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: PhotoTaskViewModel
   override var position by Delegates.notNull<Int>()
   private lateinit var selectPhotoLauncher: ActivityResultLauncher<String>

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinTaskFragment.kt
@@ -19,6 +19,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnAttach
 import androidx.fragment.app.activityViewModels
 import com.google.android.ground.databinding.BasemapLayoutBinding
 import com.google.android.ground.ui.MarkerIconFactory
@@ -68,11 +69,14 @@ class DropAPinTaskFragment : AbstractMapContainerFragment(), TaskFragment<DropAP
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as DropAPinTaskViewModel
 
     binding.fragment = this
-    binding.viewModel = mapViewModel
     binding.lifecycleOwner = this
+
+    view.doOnAttach {
+      viewModel = dataCollectionViewModel.getTaskViewModel(position) as DropAPinTaskViewModel
+      binding.viewModel = mapViewModel
+    }
   }
 
   override fun onMapReady(mapFragment: MapFragment) {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinTaskFragment.kt
@@ -61,13 +61,18 @@ class DropAPinTaskFragment : AbstractMapContainerFragment(), TaskFragment<DropAP
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    binding = BasemapLayoutBinding.inflate(inflater, container, false)
+
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
     viewModel = dataCollectionViewModel.getTaskViewModel(position) as DropAPinTaskViewModel
 
-    binding = BasemapLayoutBinding.inflate(inflater, container, false)
     binding.fragment = this
     binding.viewModel = mapViewModel
     binding.lifecycleOwner = this
-    return binding.root
   }
 
   override fun onMapReady(mapFragment: MapFragment) {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingTaskFragment.kt
@@ -19,6 +19,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnAttach
 import androidx.fragment.app.activityViewModels
 import com.google.android.ground.databinding.BasemapLayoutBinding
 import com.google.android.ground.databinding.PolygonDrawingTaskFragBinding
@@ -70,16 +71,21 @@ class PolygonDrawingTaskFragment :
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as PolygonDrawingViewModel
+
     binding.fragment = this
-    binding.viewModel = mapViewModel
     binding.lifecycleOwner = this
 
-    val container = binding.bottomContainer
-    val taskControlsBinding = PolygonDrawingTaskFragBinding.inflate(layoutInflater, container, true)
-    taskControlsBinding.viewModel = viewModel
-    taskControlsBinding.lifecycleOwner = this
-    viewModel.startDrawingFlow()
+    view.doOnAttach {
+      viewModel = dataCollectionViewModel.getTaskViewModel(position) as PolygonDrawingViewModel
+      binding.viewModel = mapViewModel
+
+      val container = binding.bottomContainer
+      val taskControlsBinding =
+        PolygonDrawingTaskFragBinding.inflate(layoutInflater, container, true)
+      taskControlsBinding.viewModel = viewModel
+      taskControlsBinding.lifecycleOwner = this
+      viewModel.startDrawingFlow()
+    }
   }
 
   override fun onMapReady(mapFragment: MapFragment) {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingTaskFragment.kt
@@ -64,17 +64,17 @@ class PolygonDrawingTaskFragment :
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as PolygonDrawingViewModel
-
     binding = BasemapLayoutBinding.inflate(inflater, container, false)
-    binding.fragment = this
-    binding.viewModel = mapViewModel
-    binding.lifecycleOwner = this
     return binding.root
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+    viewModel = dataCollectionViewModel.getTaskViewModel(position) as PolygonDrawingViewModel
+    binding.fragment = this
+    binding.viewModel = mapViewModel
+    binding.lifecycleOwner = this
+
     val container = binding.bottomContainer
     val taskControlsBinding = PolygonDrawingTaskFragBinding.inflate(layoutInflater, container, true)
     taskControlsBinding.viewModel = viewModel

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/QuestionTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/QuestionTaskFragment.kt
@@ -19,6 +19,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnAttach
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.google.android.ground.BR
 import com.google.android.ground.R
@@ -57,7 +58,7 @@ class QuestionTaskFragment : AbstractFragment(), TaskFragment<TextTaskViewModel>
     savedInstanceState: Bundle?
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
-    val binding = QuestionTaskFragBinding.inflate(inflater, container, false)
+    binding = QuestionTaskFragBinding.inflate(inflater, container, false)
 
     return binding.root
   }
@@ -65,8 +66,10 @@ class QuestionTaskFragment : AbstractFragment(), TaskFragment<TextTaskViewModel>
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as TextTaskViewModel
-    binding.lifecycleOwner = this
-    binding.setVariable(BR.viewModel, viewModel)
+    view.doOnAttach {
+      viewModel = dataCollectionViewModel.getTaskViewModel(position) as TextTaskViewModel
+      binding.lifecycleOwner = this
+      binding.setVariable(BR.viewModel, viewModel)
+    }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/QuestionTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/QuestionTaskFragment.kt
@@ -37,6 +37,7 @@ class QuestionTaskFragment : AbstractFragment(), TaskFragment<TextTaskViewModel>
     hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: TextTaskViewModel
   override var position by Delegates.notNull<Int>()
+  private lateinit var binding: QuestionTaskFragBinding
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -58,10 +59,14 @@ class QuestionTaskFragment : AbstractFragment(), TaskFragment<TextTaskViewModel>
     super.onCreateView(inflater, container, savedInstanceState)
     val binding = QuestionTaskFragBinding.inflate(inflater, container, false)
 
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
     viewModel = dataCollectionViewModel.getTaskViewModel(position) as TextTaskViewModel
     binding.lifecycleOwner = this
     binding.setVariable(BR.viewModel, viewModel)
-
-    return binding.root
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/QuestionTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/QuestionTaskFragment.kt
@@ -19,8 +19,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.google.android.ground.BR
+import com.google.android.ground.R
 import com.google.android.ground.databinding.QuestionTaskFragBinding
 import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.datacollection.DataCollectionViewModel
@@ -32,7 +33,8 @@ import kotlin.properties.Delegates
 /** Fragment allowing the user to answer questions to complete a task. */
 @AndroidEntryPoint
 class QuestionTaskFragment : AbstractFragment(), TaskFragment<TextTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
+  private val dataCollectionViewModel: DataCollectionViewModel by
+    hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: TextTaskViewModel
   override var position by Delegates.notNull<Int>()
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/time/TimeTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/time/TimeTaskFragment.kt
@@ -36,6 +36,7 @@ class TimeTaskFragment : AbstractFragment(), TaskFragment<TimeTaskViewModel> {
   private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
   override lateinit var viewModel: TimeTaskViewModel
   override var position by Delegates.notNull<Int>()
+  private lateinit var binding: TimeTaskFragBinding
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -55,14 +56,18 @@ class TimeTaskFragment : AbstractFragment(), TaskFragment<TimeTaskViewModel> {
     savedInstanceState: Bundle?
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
-    val binding = TimeTaskFragBinding.inflate(inflater, container, false)
+    binding = TimeTaskFragBinding.inflate(inflater, container, false)
+
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
 
     viewModel = dataCollectionViewModel.getTaskViewModel(position) as TimeTaskViewModel
     binding.lifecycleOwner = this
     binding.setVariable(BR.viewModel, viewModel)
     binding.setVariable(BR.fragment, this)
-
-    return binding.root
   }
 
   fun showTimeDialog() {

--- a/ground/src/main/res/navigation/nav_graph.xml
+++ b/ground/src/main/res/navigation/nav_graph.xml
@@ -76,7 +76,7 @@
       app:destination="@id/surveySelectorFragment" />
     <action
       android:id="@+id/action_home_screen_fragment_to_dataCollectionFragment"
-      app:destination="@id/data_collection_fragment" />
+      app:destination="@id/data_collection" />
     <action
       android:id="@+id/action_home_screen_fragment_to_locationOfInterestSelectorFragment"
       app:destination="@id/locationOfInterestSelectorFragment" />
@@ -86,23 +86,65 @@
     android:name="com.google.android.ground.ui.syncstatus.SyncStatusFragment"
     android:label="@string/sync_status"
     tools:layout="@layout/sync_status_frag" />
-  <fragment
-    android:id="@+id/data_collection_fragment"
-    android:name="com.google.android.ground.ui.datacollection.DataCollectionFragment"
-    android:label="@string/collect_data"
-    tools:layout="@layout/data_collection_frag">
+  <navigation
+    android:id="@+id/data_collection"
+    app:startDestination="@id/data_collection_fragment">
     <argument
       android:name="surveyId"
       type="string" />
     <argument
       android:name="locationOfInterestId"
       type="string" />
-  </fragment>
-  <fragment
-    android:id="@+id/question_data_collection_fragment"
-    android:name="com.google.android.ground.ui.datacollection.tasks.text.QuestionTaskFragment"
-    android:label="@string/collect_data"
-    tools:layout="@layout/question_task_frag" />
+
+    <fragment
+      android:id="@+id/data_collection_fragment"
+      android:name="com.google.android.ground.ui.datacollection.DataCollectionFragment"
+      android:label="@string/collect_data"
+      tools:layout="@layout/data_collection_frag">
+      <argument
+        android:name="surveyId"
+        type="string" />
+      <argument
+        android:name="locationOfInterestId"
+        type="string" />
+    </fragment>
+
+    <fragment
+      android:id="@+id/drop_a_pin_task_fragment"
+      android:name="com.google.android.ground.ui.datacollection.DropAPinTaskFragment"
+      android:label="@string/collect_data"
+      tools:layout="@layout/question_task_frag" />
+
+    <fragment
+      android:id="@+id/multiple_choice_task_fragment"
+      android:name="com.google.android.ground.ui.datacollection.MultipleChoiceTaskFragment"
+      android:label="@string/collect_data"
+      tools:layout="@layout/question_task_frag" />
+
+    <fragment
+      android:id="@+id/number_task_fragment"
+      android:name="com.google.android.ground.ui.datacollection.NumberTaskFragment"
+      android:label="@string/collect_data"
+      tools:layout="@layout/question_task_frag" />
+
+    <fragment
+      android:id="@+id/photo_task_fragment"
+      android:name="com.google.android.ground.ui.datacollection.PhotoTaskFragment"
+      android:label="@string/collect_data"
+      tools:layout="@layout/question_task_frag" />
+
+    <fragment
+      android:id="@+id/polygon_task_fragment"
+      android:name="com.google.android.ground.ui.datacollection.PolygonDrawingTaskFragment"
+      android:label="@string/collect_data"
+      tools:layout="@layout/question_task_frag" />
+
+    <fragment
+      android:id="@+id/question_task_fragment"
+      android:name="com.google.android.ground.ui.datacollection.tasks.text.QuestionTaskFragment"
+      android:label="@string/collect_data"
+      tools:layout="@layout/question_task_frag" />
+  </navigation>
   <fragment
     android:id="@+id/offline_areas_fragment"
     android:name="com.google.android.ground.ui.offlinebasemap.OfflineAreasFragment"

--- a/ground/src/test/java/com/google/android/ground/HiltExt.kt
+++ b/ground/src/test/java/com/google/android/ground/HiltExt.kt
@@ -35,9 +35,8 @@ inline fun <reified T : Fragment> launchFragmentInHiltContainer(
   fragmentArgs: Bundle? = null,
   @StyleRes themeResId: Int = R.style.FragmentScenarioEmptyFragmentActivityTheme,
   crossinline action: Fragment.() -> Unit = {},
-): ActivityScenario<HiltTestActivity> {
-  return hiltActivityScenario(themeResId).launchFragment<T>(fragmentArgs, {}) { this.action() }
-}
+): ActivityScenario<HiltTestActivity> =
+  hiltActivityScenario(themeResId).launchFragment<T>(fragmentArgs, {}) { this.action() }
 
 /** Instantiates a new activity scenario with Hilt support. */
 fun hiltActivityScenario(
@@ -63,8 +62,8 @@ inline fun <reified T : Fragment> ActivityScenario<HiltTestActivity>.launchFragm
   fragmentArgs: Bundle? = null,
   crossinline preTransactionAction: Fragment.() -> Unit = {},
   crossinline postTransactionAction: Fragment.() -> Unit = {}
-): ActivityScenario<HiltTestActivity> {
-  return this.onActivity { activity ->
+): ActivityScenario<HiltTestActivity> =
+  this.onActivity { activity ->
     val fragment: Fragment =
       activity.supportFragmentManager.fragmentFactory.instantiate(
         Preconditions.checkNotNull(T::class.java.classLoader),
@@ -81,4 +80,3 @@ inline fun <reified T : Fragment> ActivityScenario<HiltTestActivity>.launchFragm
 
     fragment.postTransactionAction()
   }
-}

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -17,6 +17,9 @@
 package com.google.android.ground.ui.datacollection
 
 import android.widget.RadioButton
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
@@ -321,8 +324,13 @@ class DataCollectionFragmentTest : BaseHiltTest() {
     val argsBundle =
       DataCollectionFragmentArgs.Builder(SURVEY.id, LOCATION_OF_INTEREST.id).build().toBundle()
 
+    val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
     launchFragmentInHiltContainer<DataCollectionFragment>(argsBundle) {
       fragment = this as DataCollectionFragment
+
+      navController.setGraph(R.id.data_collection)
+
+      Navigation.setViewNavController(fragment.requireView(), navController)
     }
   }
 }


### PR DESCRIPTION
Fixes #1608

Previously we used an ActivityScoped view model to share the DataCollectionViewModel between the DataCollectionFragment and the Task fragments, but this caused issues when the user completed one job and opened another because the DataCollectionViewModel would not be cleared. Now the DataCollectionViewModel is scoped to a new nav graph which includes only the Data Collection fragments so we properly create a new DataCollectionViewModel instance for each new job.