### PR TITLE
[Revamped Data Collection UI] Apply shared task view and buttons to task fragments

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/components/ButtonAction.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/components/ButtonAction.kt
@@ -15,12 +15,22 @@
  */
 package com.google.android.ground.ui.datacollection.components
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.google.android.ground.R
+
 /** Defines a unique action that can be bound to a [TaskButton], along with the UI styling. */
-enum class ButtonAction(val type: Type, val theme: Theme) {
+enum class ButtonAction(
+  val type: Type,
+  val theme: Theme,
+  @StringRes val textId: Int? = null,
+  @DrawableRes val drawableId: Int? = null
+) {
+
   // All tasks
-  CONTINUE(Type.TEXT, Theme.DARK_GREEN),
-  SKIP(Type.TEXT, Theme.LIGHT_GREEN),
-  UNDO(Type.ICON, Theme.LIGHT_GREEN),
+  CONTINUE(Type.TEXT, Theme.DARK_GREEN, textId = R.string.continue_text),
+  SKIP(Type.TEXT, Theme.LIGHT_GREEN, textId = R.string.skip),
+  UNDO(Type.ICON, Theme.LIGHT_GREEN, drawableId = R.drawable.ic_undo_black),
 
   // Drop a pin task
   DROP_PIN(Type.TEXT, Theme.OUTLINED),

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/components/TaskButton.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/components/TaskButton.kt
@@ -24,12 +24,38 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.content.res.ResourcesCompat
 import com.google.android.ground.databinding.*
+import com.google.android.ground.model.submission.TaskData
 import com.google.android.ground.ui.datacollection.components.ButtonAction.Theme
 import com.google.android.ground.ui.datacollection.components.ButtonAction.Type
 import com.google.android.material.button.MaterialButton
 
 /** Wrapper class for holding a button. */
-data class TaskButton(val view: View) {
+data class TaskButton(private val view: View) {
+
+  private var taskUpdatedCallback: ((button: TaskButton, taskData: TaskData?) -> Unit)? = null
+
+  /** Updates the state of the button. */
+  fun updateState(block: View.() -> Unit): TaskButton {
+    block(view)
+    return this
+  }
+
+  /** Register a callback to be invoked when this view is clicked. */
+  fun setOnClickListener(block: () -> Unit): TaskButton {
+    view.setOnClickListener { block() }
+    return this
+  }
+
+  /** Register a callback to be invoked when [TaskData] is updated. */
+  fun setOnTaskUpdated(block: (button: TaskButton, taskData: TaskData?) -> Unit): TaskButton {
+    this.taskUpdatedCallback = block
+    return this
+  }
+
+  /** Must be called when a new [TaskData] is available. */
+  fun onTaskDataUpdated(taskData: TaskData?) {
+    taskUpdatedCallback?.let { it(this, taskData) }
+  }
 
   companion object {
     /** Inflates the button layout and attaches to the given container view. */
@@ -58,11 +84,7 @@ data class TaskButton(val view: View) {
               icon = ResourcesCompat.getDrawable(resources, requireNotNull(drawableId), null)
             }
           }
-        }.apply {
-          id = View.generateViewId()
-          // Default state
-          isEnabled = false
-        }
+        }.apply { id = View.generateViewId() }
       )
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.datacollection.tasks
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import com.google.android.ground.R
+import com.google.android.ground.model.submission.TaskData
+import com.google.android.ground.ui.common.AbstractFragment
+import com.google.android.ground.ui.datacollection.DataCollectionViewModel
+import com.google.android.ground.ui.datacollection.components.ButtonAction
+import com.google.android.ground.ui.datacollection.components.TaskButton
+import com.google.android.ground.ui.datacollection.components.TaskView
+import java.util.*
+import kotlin.properties.Delegates
+
+abstract class AbstractTaskFragment<T : AbstractTaskViewModel> :
+  AbstractFragment(), TaskFragment<T> {
+
+  protected val dataCollectionViewModel: DataCollectionViewModel by
+    hiltNavGraphViewModels(R.id.data_collection)
+
+  private val buttons: EnumMap<ButtonAction, TaskButton> = EnumMap(ButtonAction::class.java)
+  private lateinit var taskView: TaskView
+  override lateinit var viewModel: T
+
+  /** Position of the task in the Job's sorted task list. Used for instantiating the [viewModel]. */
+  override var position by Delegates.notNull<Int>()
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    if (savedInstanceState != null) {
+      position = savedInstanceState.getInt(TaskFragment.POSITION)
+    }
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    outState.putInt(TaskFragment.POSITION, position)
+  }
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    super.onCreateView(inflater, container, savedInstanceState)
+
+    @Suppress("UNCHECKED_CAST")
+    viewModel = dataCollectionViewModel.getTaskViewModel(position) as T
+
+    taskView = onCreateTaskView(inflater, container)
+    taskView.bind(this, viewModel)
+    taskView.addTaskView(onCreateTaskBody(inflater))
+
+    onCreateActionButtons()
+    onActionButtonsCreated()
+
+    return taskView.root
+  }
+
+  /** Creates the view for common task template with/without header. */
+  abstract fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView
+
+  /** Creates the view for body of the task. */
+  abstract fun onCreateTaskBody(inflater: LayoutInflater): View
+
+  /** Invoked when the fragment is ready to add buttons to the current [TaskView]. */
+  open fun onCreateActionButtons() {
+    addContinueButton()
+    addSkipButton()
+  }
+
+  /** Invoked when the all [ButtonAction]s are added to the current [TaskView]. */
+  open fun onActionButtonsCreated() {
+    viewModel.taskData.observe(viewLifecycleOwner) { onTaskDataUpdated(it.orElse(null)) }
+  }
+
+  /** Invoked when the data associated with the current task gets modified. */
+  protected open fun onTaskDataUpdated(taskData: TaskData?) {
+    for ((_, button) in buttons) {
+      button.onTaskDataUpdated(taskData)
+    }
+  }
+
+  private fun addContinueButton() {
+    addButton(ButtonAction.CONTINUE, textId = R.string.continue_text)
+      .setOnClickListener { dataCollectionViewModel.onContinueClicked() }
+      .setOnTaskUpdated { button, taskData ->
+        button.updateState { isEnabled = taskData.isNotEmpty() }
+      }
+      .updateState { isEnabled = false }
+  }
+
+  private fun addSkipButton() {
+    addButton(ButtonAction.SKIP, textId = R.string.skip)
+      .setOnClickListener {
+        viewModel.clearResponse()
+        dataCollectionViewModel.onContinueClicked()
+      }
+      .updateState { visibility = if (viewModel.isTaskOptional()) View.VISIBLE else View.GONE }
+  }
+
+  fun addUndoButton() {
+    addButton(ButtonAction.UNDO, drawableId = R.drawable.ic_undo_black)
+      .setOnClickListener { viewModel.clearResponse() }
+      .setOnTaskUpdated { button, taskData ->
+        button.updateState { visibility = if (taskData.isEmpty()) View.GONE else View.VISIBLE }
+      }
+      .updateState {
+        visibility = View.GONE
+        isEnabled = true
+      }
+  }
+
+  private fun addButton(
+    action: ButtonAction,
+    @StringRes textId: Int? = null,
+    @DrawableRes drawableId: Int? = null,
+  ): TaskButton {
+    check(!buttons.contains(action)) { "Button $action already bound" }
+    val button =
+      TaskButton.createAndAttachButton(
+        action,
+        taskView.actionButtonsContainer,
+        layoutInflater,
+        drawableId,
+        textId
+      )
+    buttons[action] = button
+    return button
+  }
+
+  protected fun getButton(action: ButtonAction): TaskButton {
+    check(buttons.contains(action)) { "Expected key $action in $buttons" }
+    return buttons[action]!!
+  }
+}
+
+private fun TaskData?.isEmpty(): Boolean = this?.isEmpty() ?: true
+
+private fun TaskData?.isNotEmpty(): Boolean = !(this?.isEmpty() ?: true)

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -19,8 +19,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.google.android.ground.R
 import com.google.android.ground.model.submission.TaskData
@@ -102,7 +100,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> :
   }
 
   private fun addContinueButton() {
-    addButton(ButtonAction.CONTINUE, textId = R.string.continue_text)
+    addButton(ButtonAction.CONTINUE)
       .setOnClickListener { dataCollectionViewModel.onContinueClicked() }
       .setOnTaskUpdated { button, taskData ->
         button.updateState { isEnabled = taskData.isNotEmpty() }
@@ -111,7 +109,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> :
   }
 
   private fun addSkipButton() {
-    addButton(ButtonAction.SKIP, textId = R.string.skip)
+    addButton(ButtonAction.SKIP)
       .setOnClickListener {
         viewModel.clearResponse()
         dataCollectionViewModel.onContinueClicked()
@@ -120,7 +118,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> :
   }
 
   fun addUndoButton() {
-    addButton(ButtonAction.UNDO, drawableId = R.drawable.ic_undo_black)
+    addButton(ButtonAction.UNDO)
       .setOnClickListener { viewModel.clearResponse() }
       .setOnTaskUpdated { button, taskData ->
         button.updateState { visibility = if (taskData.isEmpty()) View.GONE else View.VISIBLE }
@@ -131,20 +129,10 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> :
       }
   }
 
-  private fun addButton(
-    action: ButtonAction,
-    @StringRes textId: Int? = null,
-    @DrawableRes drawableId: Int? = null,
-  ): TaskButton {
+  private fun addButton(action: ButtonAction): TaskButton {
     check(!buttons.contains(action)) { "Button $action already bound" }
     val button =
-      TaskButton.createAndAttachButton(
-        action,
-        taskView.actionButtonsContainer,
-        layoutInflater,
-        drawableId,
-        textId
-      )
+      TaskButton.createAndAttachButton(action, taskView.actionButtonsContainer, layoutInflater)
     buttons[action] = button
     return button
   }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskViewModel.kt
@@ -48,7 +48,10 @@ open class AbstractTaskViewModel internal constructor(private val resources: Res
   lateinit var task: Task
 
   init {
-    taskData = LiveDataReactiveStreams.fromPublisher(taskDataSubject.distinctUntilChanged())
+    taskData =
+      LiveDataReactiveStreams.fromPublisher(
+        taskDataSubject.distinctUntilChanged().startWith(Optional.empty())
+      )
     responseText = LiveDataReactiveStreams.fromPublisher(detailsTextFlowable())
   }
 
@@ -92,4 +95,6 @@ open class AbstractTaskViewModel internal constructor(private val resources: Res
   fun clearResponse() {
     setResponse(Optional.empty())
   }
+
+  fun isTaskOptional(): Boolean = !task.isRequired
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/date/DateTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/date/DateTaskFragment.kt
@@ -16,60 +16,28 @@
 package com.google.android.ground.ui.datacollection.tasks.date
 
 import android.app.DatePickerDialog
-import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.doOnAttach
-import androidx.fragment.app.activityViewModels
-import com.google.android.ground.BR
 import com.google.android.ground.databinding.DateTaskFragBinding
-import com.google.android.ground.ui.common.AbstractFragment
-import com.google.android.ground.ui.datacollection.DataCollectionViewModel
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment
+import com.google.android.ground.ui.datacollection.components.TaskView
+import com.google.android.ground.ui.datacollection.components.TaskViewWithHeader
+import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
-import kotlin.properties.Delegates
 
 @AndroidEntryPoint
-class DateTaskFragment : AbstractFragment(), TaskFragment<DateTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
-  override lateinit var viewModel: DateTaskViewModel
-  override var position by Delegates.notNull<Int>()
-  private lateinit var binding: DateTaskFragBinding
+class DateTaskFragment : AbstractTaskFragment<DateTaskViewModel>() {
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    if (savedInstanceState != null) {
-      position = savedInstanceState.getInt(TaskFragment.POSITION)
-    }
-  }
+  override fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView =
+    TaskViewWithHeader.create(inflater)
 
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    outState.putInt(TaskFragment.POSITION, position)
-  }
-
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
-  ): View {
-    super.onCreateView(inflater, container, savedInstanceState)
-    binding = DateTaskFragBinding.inflate(inflater, container, false)
-
-    return binding.root
-  }
-
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
-
-    view.doOnAttach {
-      viewModel = dataCollectionViewModel.getTaskViewModel(position) as DateTaskViewModel
-      binding.lifecycleOwner = this
-      binding.setVariable(BR.viewModel, viewModel)
-      binding.setVariable(BR.fragment, this)
-    }
+  override fun onCreateTaskBody(inflater: LayoutInflater): View {
+    val taskBinding = DateTaskFragBinding.inflate(inflater)
+    taskBinding.lifecycleOwner = this
+    taskBinding.fragment = this
+    taskBinding.viewModel = viewModel
+    return taskBinding.root
   }
 
   fun showDateDialog() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
@@ -15,83 +15,48 @@
  */
 package com.google.android.ground.ui.datacollection.tasks.multiplechoice
 
-import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.doOnAttach
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.recyclerview.selection.ItemDetailsLookup
 import androidx.recyclerview.selection.ItemKeyProvider
 import androidx.recyclerview.selection.SelectionTracker
 import androidx.recyclerview.selection.SelectionTracker.SelectionObserver
 import androidx.recyclerview.selection.StorageStrategy
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.ground.BR
-import com.google.android.ground.R
 import com.google.android.ground.databinding.MultipleChoiceTaskFragBinding
 import com.google.android.ground.model.task.MultipleChoice
-import com.google.android.ground.ui.common.AbstractFragment
-import com.google.android.ground.ui.datacollection.DataCollectionViewModel
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment.Companion.POSITION
+import com.google.android.ground.ui.datacollection.components.TaskView
+import com.google.android.ground.ui.datacollection.components.TaskViewWithHeader
+import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlin.properties.Delegates
 
 /**
  * Fragment allowing the user to answer single selection multiple choice questions to complete a
  * task.
  */
 @AndroidEntryPoint
-class MultipleChoiceTaskFragment : AbstractFragment(), TaskFragment<MultipleChoiceTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by
-    hiltNavGraphViewModels(R.id.data_collection)
-  override lateinit var viewModel: MultipleChoiceTaskViewModel
-  override var position by Delegates.notNull<Int>()
-  private lateinit var binding: MultipleChoiceTaskFragBinding
+class MultipleChoiceTaskFragment : AbstractTaskFragment<MultipleChoiceTaskViewModel>() {
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    if (savedInstanceState != null) {
-      position = savedInstanceState.getInt(POSITION)
-    }
-  }
+  override fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView =
+    TaskViewWithHeader.create(inflater)
 
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    outState.putInt(POSITION, position)
-  }
-
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
-  ): View {
-    super.onCreateView(inflater, container, savedInstanceState)
-    binding = MultipleChoiceTaskFragBinding.inflate(inflater, container, false)
-
+  override fun onCreateTaskBody(inflater: LayoutInflater): View {
+    val binding = MultipleChoiceTaskFragBinding.inflate(inflater)
+    setupMultipleChoice(binding.selectOptionList)
     return binding.root
   }
 
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
-
-    view.doOnAttach {
-      viewModel = dataCollectionViewModel.getTaskViewModel(position) as MultipleChoiceTaskViewModel
-      binding.lifecycleOwner = this
-      binding.setVariable(BR.viewModel, viewModel)
-
-      val multipleChoice = viewModel.task.multipleChoice!!
-      val optionListView = binding.root.findViewById<RecyclerView>(R.id.select_option_list)
-      optionListView.setHasFixedSize(true)
-      if (multipleChoice.cardinality == MultipleChoice.Cardinality.SELECT_MULTIPLE) {
-        val adapter = SelectMultipleOptionAdapter(multipleChoice.options, viewModel)
-        adapter.setHasStableIds(true)
-        optionListView.adapter = adapter
-        setupMultipleSelectionTracker(optionListView, adapter)
-      } else {
-        optionListView.adapter = SelectOneOptionAdapter(multipleChoice.options, viewModel)
-      }
+  private fun setupMultipleChoice(recyclerView: RecyclerView) {
+    val multipleChoice = viewModel.task.multipleChoice!!
+    recyclerView.setHasFixedSize(true)
+    if (multipleChoice.cardinality == MultipleChoice.Cardinality.SELECT_MULTIPLE) {
+      val adapter = SelectMultipleOptionAdapter(multipleChoice.options, viewModel)
+      adapter.setHasStableIds(true)
+      recyclerView.adapter = adapter
+      setupMultipleSelectionTracker(recyclerView, adapter)
+    } else {
+      recyclerView.adapter = SelectOneOptionAdapter(multipleChoice.options, viewModel)
     }
   }
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
@@ -15,61 +15,26 @@
  */
 package com.google.android.ground.ui.datacollection.tasks.number
 
-import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.doOnAttach
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
-import com.google.android.ground.BR
-import com.google.android.ground.R
 import com.google.android.ground.databinding.NumberTaskFragBinding
-import com.google.android.ground.ui.common.AbstractFragment
-import com.google.android.ground.ui.datacollection.DataCollectionViewModel
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment.Companion.POSITION
+import com.google.android.ground.ui.datacollection.components.TaskView
+import com.google.android.ground.ui.datacollection.components.TaskViewWithHeader
+import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlin.properties.Delegates
 
 /** Fragment allowing the user to answer questions to complete a task. */
 @AndroidEntryPoint
-class NumberTaskFragment : AbstractFragment(), TaskFragment<NumberTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by
-    hiltNavGraphViewModels(R.id.data_collection)
-  override lateinit var viewModel: NumberTaskViewModel
-  override var position by Delegates.notNull<Int>()
-  private lateinit var binding: NumberTaskFragBinding
+class NumberTaskFragment : AbstractTaskFragment<NumberTaskViewModel>() {
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    if (savedInstanceState != null) {
-      position = savedInstanceState.getInt(POSITION)
-    }
-  }
+  override fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView =
+    TaskViewWithHeader.create(layoutInflater)
 
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    outState.putInt(POSITION, position)
-  }
-
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
-  ): View {
-    super.onCreateView(inflater, container, savedInstanceState)
-    binding = NumberTaskFragBinding.inflate(inflater, container, false)
-
-    return binding.root
-  }
-
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
-
-    view.doOnAttach {
-      viewModel = dataCollectionViewModel.getTaskViewModel(position) as NumberTaskViewModel
-      binding.lifecycleOwner = this
-      binding.setVariable(BR.viewModel, viewModel)
-    }
+  override fun onCreateTaskBody(inflater: LayoutInflater): View {
+    val taskBinding = NumberTaskFragBinding.inflate(inflater)
+    taskBinding.lifecycleOwner = this
+    taskBinding.viewModel = viewModel
+    return taskBinding.root
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
@@ -24,23 +24,18 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
-import androidx.core.view.doOnAttach
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
-import com.google.android.ground.BR
 import com.google.android.ground.BuildConfig
-import com.google.android.ground.R
 import com.google.android.ground.coroutines.ApplicationScope
 import com.google.android.ground.databinding.PhotoTaskFragBinding
 import com.google.android.ground.repository.UserMediaRepository
 import com.google.android.ground.rx.RxAutoDispose.autoDisposable
 import com.google.android.ground.system.PermissionDeniedException
 import com.google.android.ground.system.PermissionsManager
-import com.google.android.ground.ui.common.AbstractFragment
-import com.google.android.ground.ui.datacollection.DataCollectionViewModel
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment
+import com.google.android.ground.ui.datacollection.components.TaskView
+import com.google.android.ground.ui.datacollection.components.TaskViewWithoutHeader
+import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlin.properties.Delegates
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
@@ -48,65 +43,50 @@ import timber.log.Timber
 
 /** Fragment allowing the user to capture a photo to complete a task. */
 @AndroidEntryPoint
-class PhotoTaskFragment : AbstractFragment(), TaskFragment<PhotoTaskViewModel> {
+class PhotoTaskFragment : AbstractTaskFragment<PhotoTaskViewModel>() {
   @Inject lateinit var userMediaRepository: UserMediaRepository
   @Inject @ApplicationScope lateinit var externalScope: CoroutineScope
   @Inject lateinit var permissionsManager: PermissionsManager
 
-  private val dataCollectionViewModel: DataCollectionViewModel by
-    hiltNavGraphViewModels(R.id.data_collection)
-  override lateinit var viewModel: PhotoTaskViewModel
-  override var position by Delegates.notNull<Int>()
   private lateinit var selectPhotoLauncher: ActivityResultLauncher<String>
   private lateinit var capturePhotoLauncher: ActivityResultLauncher<Uri>
-  private lateinit var binding: PhotoTaskFragBinding
   private var hasRequestedPermissionsOnResume = false
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    if (savedInstanceState != null) {
-      position = savedInstanceState.getInt(TaskFragment.POSITION)
-    }
-  }
+  override fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView =
+    TaskViewWithoutHeader.create(inflater)
 
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
-  ): View {
-    super.onCreateView(inflater, container, savedInstanceState)
-    binding = PhotoTaskFragBinding.inflate(inflater, container, false)
-
-    return binding.root
+  override fun onCreateTaskBody(inflater: LayoutInflater): View {
+    val taskBinding = PhotoTaskFragBinding.inflate(inflater)
+    taskBinding.lifecycleOwner = this
+    taskBinding.dataCollectionViewModel = dataCollectionViewModel
+    taskBinding.viewModel = viewModel
+    return taskBinding.root
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+    selectPhotoLauncher =
+      registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        viewModel.onSelectPhotoResult(uri)
+      }
+    capturePhotoLauncher =
+      registerForActivityResult(ActivityResultContracts.TakePicture()) { result: Boolean ->
+        viewModel.onCapturePhotoResult(result)
+      }
 
-    view.doOnAttach {
-      viewModel = dataCollectionViewModel.getTaskViewModel(position) as PhotoTaskViewModel
-      selectPhotoLauncher =
-        registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-          viewModel.onSelectPhotoResult(uri)
-        }
-      capturePhotoLauncher =
-        registerForActivityResult(ActivityResultContracts.TakePicture()) { result: Boolean ->
-          viewModel.onCapturePhotoResult(result)
-        }
+    viewModel.setEditable(true)
+    viewModel.setSurveyId(dataCollectionViewModel.surveyId)
+    viewModel.setSubmissionId(dataCollectionViewModel.submissionId)
+    viewModel.setTaskWaitingForPhoto(savedInstanceState?.getString(TASK_WAITING_FOR_PHOTO))
+    viewModel.setCapturedPhotoPath(savedInstanceState?.getString(CAPTURED_PHOTO_PATH))
 
-      binding.lifecycleOwner = this
-      binding.setVariable(BR.viewModel, viewModel)
-      binding.setVariable(BR.dataCollectionViewModel, dataCollectionViewModel)
+    observeSelectPhotoClicks()
+    observePhotoResults()
+  }
 
-      viewModel.setEditable(true)
-      viewModel.setSurveyId(dataCollectionViewModel.surveyId)
-      viewModel.setSubmissionId(dataCollectionViewModel.submissionId)
-      observeSelectPhotoClicks()
-      observePhotoResults()
-
-      viewModel.setTaskWaitingForPhoto(savedInstanceState?.getString(TASK_WAITING_FOR_PHOTO))
-      viewModel.setCapturedPhotoPath(savedInstanceState?.getString(CAPTURED_PHOTO_PATH))
-    }
+  override fun onCreateActionButtons() {
+    super.onCreateActionButtons()
+    addUndoButton()
   }
 
   override fun onResume() {
@@ -122,7 +102,6 @@ class PhotoTaskFragment : AbstractFragment(), TaskFragment<PhotoTaskViewModel> {
     super.onSaveInstanceState(outState)
     outState.putString(TASK_WAITING_FOR_PHOTO, viewModel.getTaskWaitingForPhoto())
     outState.putString(CAPTURED_PHOTO_PATH, viewModel.getCapturedPhotoPath())
-    outState.putInt(TaskFragment.POSITION, position)
   }
 
   private fun observeSelectPhotoClicks() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinTaskFragment.kt
@@ -20,7 +20,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.doOnAttach
-import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import com.google.android.ground.R
 import com.google.android.ground.databinding.BasemapLayoutBinding
 import com.google.android.ground.ui.MarkerIconFactory
 import com.google.android.ground.ui.common.AbstractMapContainerFragment
@@ -35,7 +36,8 @@ import kotlin.properties.Delegates
 
 @AndroidEntryPoint
 class DropAPinTaskFragment : AbstractMapContainerFragment(), TaskFragment<DropAPinTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
+  private val dataCollectionViewModel: DataCollectionViewModel by
+    hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: DropAPinTaskViewModel
   override var position by Delegates.notNull<Int>()
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingTaskFragment.kt
@@ -20,7 +20,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.doOnAttach
-import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import com.google.android.ground.R
 import com.google.android.ground.databinding.BasemapLayoutBinding
 import com.google.android.ground.databinding.PolygonDrawingTaskFragBinding
 import com.google.android.ground.model.geometry.Point
@@ -38,7 +39,8 @@ import kotlin.properties.Delegates
 @AndroidEntryPoint
 class PolygonDrawingTaskFragment :
   AbstractMapContainerFragment(), TaskFragment<PolygonDrawingViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
+  private val dataCollectionViewModel: DataCollectionViewModel by
+    hiltNavGraphViewModels(R.id.data_collection)
   override lateinit var viewModel: PolygonDrawingViewModel
   override var position by Delegates.notNull<Int>()
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/QuestionTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/QuestionTaskFragment.kt
@@ -15,61 +15,26 @@
  */
 package com.google.android.ground.ui.datacollection.tasks.text
 
-import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.doOnAttach
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
-import com.google.android.ground.BR
-import com.google.android.ground.R
 import com.google.android.ground.databinding.QuestionTaskFragBinding
-import com.google.android.ground.ui.common.AbstractFragment
-import com.google.android.ground.ui.datacollection.DataCollectionViewModel
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment.Companion.POSITION
+import com.google.android.ground.ui.datacollection.components.TaskView
+import com.google.android.ground.ui.datacollection.components.TaskViewWithHeader
+import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlin.properties.Delegates
 
 /** Fragment allowing the user to answer questions to complete a task. */
 @AndroidEntryPoint
-class QuestionTaskFragment : AbstractFragment(), TaskFragment<TextTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by
-    hiltNavGraphViewModels(R.id.data_collection)
-  override lateinit var viewModel: TextTaskViewModel
-  override var position by Delegates.notNull<Int>()
-  private lateinit var binding: QuestionTaskFragBinding
+class QuestionTaskFragment : AbstractTaskFragment<TextTaskViewModel>() {
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    if (savedInstanceState != null) {
-      position = savedInstanceState.getInt(POSITION)
-    }
-  }
+  override fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView =
+    TaskViewWithHeader.create(inflater)
 
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    outState.putInt(POSITION, position)
-  }
-
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
-  ): View {
-    super.onCreateView(inflater, container, savedInstanceState)
-    binding = QuestionTaskFragBinding.inflate(inflater, container, false)
-
-    return binding.root
-  }
-
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
-
-    view.doOnAttach {
-      viewModel = dataCollectionViewModel.getTaskViewModel(position) as TextTaskViewModel
-      binding.lifecycleOwner = this
-      binding.setVariable(BR.viewModel, viewModel)
-    }
+  override fun onCreateTaskBody(inflater: LayoutInflater): View {
+    val taskBinding = QuestionTaskFragBinding.inflate(inflater)
+    taskBinding.viewModel = viewModel
+    taskBinding.lifecycleOwner = this
+    return taskBinding.root
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/time/TimeTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/time/TimeTaskFragment.kt
@@ -16,58 +16,29 @@
 package com.google.android.ground.ui.datacollection.tasks.time
 
 import android.app.TimePickerDialog
-import android.os.Bundle
 import android.text.format.DateFormat
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.activityViewModels
-import com.google.android.ground.BR
 import com.google.android.ground.databinding.TimeTaskFragBinding
-import com.google.android.ground.ui.common.AbstractFragment
-import com.google.android.ground.ui.datacollection.DataCollectionViewModel
-import com.google.android.ground.ui.datacollection.tasks.TaskFragment
+import com.google.android.ground.ui.datacollection.components.TaskView
+import com.google.android.ground.ui.datacollection.components.TaskViewWithHeader
+import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
-import kotlin.properties.Delegates
 
 @AndroidEntryPoint
-class TimeTaskFragment : AbstractFragment(), TaskFragment<TimeTaskViewModel> {
-  private val dataCollectionViewModel: DataCollectionViewModel by activityViewModels()
-  override lateinit var viewModel: TimeTaskViewModel
-  override var position by Delegates.notNull<Int>()
-  private lateinit var binding: TimeTaskFragBinding
+class TimeTaskFragment : AbstractTaskFragment<TimeTaskViewModel>() {
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    if (savedInstanceState != null) {
-      position = savedInstanceState.getInt(TaskFragment.POSITION)
-    }
-  }
+  override fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView =
+    TaskViewWithHeader.create(inflater)
 
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    outState.putInt(TaskFragment.POSITION, position)
-  }
-
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
-  ): View {
-    super.onCreateView(inflater, container, savedInstanceState)
-    binding = TimeTaskFragBinding.inflate(inflater, container, false)
-
-    return binding.root
-  }
-
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
-
-    viewModel = dataCollectionViewModel.getTaskViewModel(position) as TimeTaskViewModel
-    binding.lifecycleOwner = this
-    binding.setVariable(BR.viewModel, viewModel)
-    binding.setVariable(BR.fragment, this)
+  override fun onCreateTaskBody(inflater: LayoutInflater): View {
+    val taskBinding = TimeTaskFragBinding.inflate(inflater)
+    taskBinding.lifecycleOwner = this
+    taskBinding.fragment = this
+    taskBinding.viewModel = viewModel
+    return taskBinding.root
   }
 
   fun showTimeDialog() {

--- a/ground/src/main/res/layout/data_collection_frag.xml
+++ b/ground/src/main/res/layout/data_collection_frag.xml
@@ -36,12 +36,12 @@
       android:layout_height="wrap_content"
       android:elevation="@dimen/toolbar_elevation"
       android:theme="@style/PrimaryToolbarTheme"
-      app:layout_constraintVertical_bias="0"
-      app:layout_constraintVertical_chainStyle="packed"
-      app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintBottom_toTopOf="@+id/pager"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintVertical_bias="0"
+      app:layout_constraintVertical_chainStyle="packed"
       app:subtitle="@{viewModel.loiName}"
       app:title="@{viewModel.jobName}" />
 
@@ -50,24 +50,10 @@
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:paddingTop="20dp"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/data_collection_toolbar"
-      app:layout_constraintBottom_toTopOf="@+id/data_collection_continue_button"/>
-
-    <Button
-      android:id="@+id/data_collection_continue_button"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="28dp"
-      android:text="@string/continue_text"
-      android:onClick="@{() -> viewModel.onContinueClicked()}"
-      app:layout_constraintWidth_default="wrap"
-      app:backgroundTint="@color/colorAccent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/pager" />
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/data_collection_toolbar" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/ground/src/main/res/layout/data_collection_header.xml
+++ b/ground/src/main/res/layout/data_collection_header.xml
@@ -17,7 +17,8 @@
   -->
 
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <data>
     <import type="android.view.View" />
@@ -35,18 +36,18 @@
       android:layout_height="wrap_content"
       android:text="@{@string/task_number(viewModel.task.index + 1)}"
       android:textSize="16sp"
-      app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
-      app:layout_constraintStart_toStartOf="parent" />
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
     <ImageView
       android:id="@+id/data_collection_task_icon"
       android:layout_width="24dp"
       android:layout_height="24dp"
       android:layout_marginStart="8dp"
       android:layout_marginEnd="8dp"
-      app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
       app:layout_constraintStart_toEndOf="@+id/data_collection_step_number"
+      app:layout_constraintTop_toTopOf="parent"
       app:srcCompat="@drawable/ic_question_answer" />
     <TextView
       android:id="@+id/data_collection_task_name"
@@ -56,9 +57,9 @@
       android:paddingEnd="8dp"
       android:text="@string/question_data_collection_title"
       android:textSize="16sp"
-      app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintBottom_toTopOf="@+id/data_collection_question"
-      app:layout_constraintStart_toEndOf="@+id/data_collection_task_icon" />
+      app:layout_constraintStart_toEndOf="@+id/data_collection_task_icon"
+      app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
       android:id="@+id/data_collection_question"
@@ -67,8 +68,9 @@
       android:paddingTop="24dp"
       android:text="@{viewModel.task.label}"
       android:textSize="16sp"
-      app:layout_constraintTop_toBottomOf="@+id/data_collection_step_number"
       app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/data_collection_step_number"
+      tools:text="Sample question?" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/ground/src/main/res/layout/date_task_frag.xml
+++ b/ground/src/main/res/layout/date_task_frag.xml
@@ -29,46 +29,24 @@
       type="com.google.android.ground.ui.datacollection.tasks.date.DateTaskFragment" />
   </data>
 
-  <ScrollView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingStart="20dp"
-    android:paddingEnd="20dp">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content">
-      <include
-        android:id="@+id/data_collection_header"
-        layout="@layout/data_collection_header"
-        app:layout_constraintBottom_toTopOf="@+id/number_input_layout"
-        app:layout_constraintTop_toTopOf="parent"
-        app:viewModel="@{viewModel}" />
-
-      <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/number_input_layout"
-        style="@style/EditSubmission.Task.Text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/data_collection_header">
-        <com.google.android.material.textfield.TextInputEditText
-          android:id="@+id/user_response_text"
-          android:layout_width="200dp"
-          android:layout_height="wrap_content"
-          android:clickable="true"
-          android:enabled="true"
-          android:focusable="false"
-          android:focusableInTouchMode="false"
-          android:inputType="datetime"
-          android:maxLines="1"
-          android:onClick="@{__ -> fragment.showDateDialog()}"
-          android:text="@{viewModel.responseText}"
-          app:error="@{viewModel.error}"
-          tools:text="@string/date" />
-      </com.google.android.material.textfield.TextInputLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ScrollView>
+  <com.google.android.material.textfield.TextInputLayout
+    android:id="@+id/number_input_layout"
+    style="@style/EditSubmission.Task.Text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <com.google.android.material.textfield.TextInputEditText
+      android:id="@+id/user_response_text"
+      android:layout_width="200dp"
+      android:layout_height="wrap_content"
+      android:clickable="true"
+      android:enabled="true"
+      android:focusable="false"
+      android:focusableInTouchMode="false"
+      android:inputType="datetime"
+      android:maxLines="1"
+      android:onClick="@{__ -> fragment.showDateDialog()}"
+      android:text="@{viewModel.responseText}"
+      app:error="@{viewModel.error}"
+      tools:text="@string/date" />
+  </com.google.android.material.textfield.TextInputLayout>
 </layout>

--- a/ground/src/main/res/layout/multiple_choice_task_frag.xml
+++ b/ground/src/main/res/layout/multiple_choice_task_frag.xml
@@ -19,37 +19,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <data>
-    <variable
-      name="viewModel"
-      type="com.google.android.ground.ui.datacollection.tasks.multiplechoice.MultipleChoiceTaskViewModel" />
-  </data>
-
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/select_option_list"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:paddingStart="20dp"
-    android:paddingEnd="20dp">
-    <include
-      android:id="@+id/data_collection_header"
-      app:viewModel="@{viewModel}"
-      app:layout_constraintTop_toTopOf="parent"
-      app:layout_constraintBottom_toTopOf="@+id/select_option_list"
-      layout="@layout/data_collection_header" />
+    android:divider="@null"
+    android:dividerHeight="0dp"
+    android:orientation="vertical"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/select_option_list"
-      android:layout_width="wrap_content"
-      android:layout_height="0dp"
-      android:layout_marginTop="4dp"
-      android:divider="@null"
-      android:dividerHeight="0dp"
-      android:orientation="vertical"
-      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-      app:layout_constrainedHeight="true"
-      app:layout_constraintTop_toBottomOf="@id/data_collection_header"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
-
-  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/ground/src/main/res/layout/number_task_frag.xml
+++ b/ground/src/main/res/layout/number_task_frag.xml
@@ -25,39 +25,21 @@
       type="com.google.android.ground.ui.datacollection.tasks.number.NumberTaskViewModel" />
   </data>
 
-  <ScrollView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingStart="20dp"
-    android:paddingEnd="20dp">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content">
-      <include
-        android:id="@+id/data_collection_header"
-        layout="@layout/data_collection_header"
-        app:layout_constraintBottom_toTopOf="@+id/number_input_layout"
-        app:layout_constraintTop_toTopOf="parent"
-        app:viewModel="@{viewModel}" />
-
-      <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/number_input_layout"
-        style="@style/EditSubmission.Task.Text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/data_collection_header">
-        <com.google.android.material.textfield.TextInputEditText
-          android:id="@+id/user_response_text"
-          android:layout_width="200dp"
-          android:layout_height="wrap_content"
-          android:inputType="number"
-          android:text="@{viewModel.responseText}"
-          app:onTextChanged="@{s -> viewModel.updateResponse((String)s)}" />
-      </com.google.android.material.textfield.TextInputLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ScrollView>
+  <com.google.android.material.textfield.TextInputLayout
+    android:id="@+id/number_input_layout"
+    style="@style/EditSubmission.Task.Text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingTop="16dp"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@+id/data_collection_header">
+    <com.google.android.material.textfield.TextInputEditText
+      android:id="@+id/user_response_text"
+      android:layout_width="200dp"
+      android:layout_height="wrap_content"
+      android:inputType="number"
+      android:text="@{viewModel.responseText}"
+      app:onTextChanged="@{s -> viewModel.updateResponse((String)s)}" />
+  </com.google.android.material.textfield.TextInputLayout>
 </layout>

--- a/ground/src/main/res/layout/photo_task_frag.xml
+++ b/ground/src/main/res/layout/photo_task_frag.xml
@@ -29,37 +29,24 @@
       type="com.google.android.ground.ui.datacollection.tasks.photo.PhotoTaskViewModel" />
   </data>
 
-  <ScrollView
+  <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fillViewport="true"
-    android:paddingStart="20dp"
-    android:paddingEnd="20dp">
-
-    <LinearLayout
-      android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <Button
+      android:id="@+id/btn_take_photo"
+      style="?attr/materialButtonOutlinedStyle"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:orientation="vertical">
-      <include
-        android:id="@+id/data_collection_header"
-        app:viewModel="@{viewModel}"
-        layout="@layout/data_collection_header" />
+      android:onClick="@{()-> viewModel.onTakePhotoClick()}"
+      android:text="@string/take_picture"
+      android:textColor="@color/colorAccent"
+      android:visibility="@{viewModel.isPhotoPresent() ? View.GONE : View.VISIBLE}" />
 
-      <Button
-        android:id="@+id/btn_take_photo"
-        style="?attr/materialButtonOutlinedStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:onClick="@{()-> viewModel.onTakePhotoClick()}"
-        android:text="@string/take_picture"
-        android:textColor="@color/colorAccent"
-        android:visibility="@{viewModel.isPhotoPresent() ? View.GONE : View.VISIBLE}" />
-
-      <include
-        layout="@layout/photo_task"
-        android:id="@+id/photo_task"
-        app:viewModel="@{viewModel}"
-        app:photoViewModel="@{dataCollectionViewModel}" />
-    </LinearLayout>
-  </ScrollView>
+    <include
+      android:id="@+id/photo_task"
+      layout="@layout/photo_task"
+      app:photoViewModel="@{dataCollectionViewModel}"
+      app:viewModel="@{viewModel}" />
+  </LinearLayout>
 </layout>

--- a/ground/src/main/res/layout/question_task_frag.xml
+++ b/ground/src/main/res/layout/question_task_frag.xml
@@ -25,39 +25,17 @@
       type="com.google.android.ground.ui.datacollection.tasks.text.TextTaskViewModel" />
   </data>
 
-  <ScrollView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingStart="20dp"
-    android:paddingEnd="20dp">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content">
-      <include
-        android:id="@+id/data_collection_header"
-        app:viewModel="@{viewModel}"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/text_input_layout"
-        layout="@layout/data_collection_header"/>
-
-      <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/text_input_layout"
-        style="@style/EditSubmission.Task.Text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/data_collection_header">
-        <com.google.android.material.textfield.TextInputEditText
-          android:id="@+id/user_response_text"
-          android:layout_width="200dp"
-          android:layout_height="wrap_content"
-          android:text="@{viewModel.responseText}"
-          app:onTextChanged="@{s -> viewModel.updateResponse((String)s)}"
-          android:inputType="text" />
-      </com.google.android.material.textfield.TextInputLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ScrollView>
+  <com.google.android.material.textfield.TextInputLayout
+    android:id="@+id/text_input_layout"
+    style="@style/EditSubmission.Task.Text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <com.google.android.material.textfield.TextInputEditText
+      android:id="@+id/user_response_text"
+      android:layout_width="200dp"
+      android:layout_height="wrap_content"
+      android:inputType="text"
+      android:text="@{viewModel.responseText}"
+      app:onTextChanged="@{s -> viewModel.updateResponse((String)s)}" />
+  </com.google.android.material.textfield.TextInputLayout>
 </layout>

--- a/ground/src/main/res/layout/time_task_frag.xml
+++ b/ground/src/main/res/layout/time_task_frag.xml
@@ -29,46 +29,24 @@
       type="com.google.android.ground.ui.datacollection.tasks.time.TimeTaskFragment" />
   </data>
 
-  <ScrollView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingStart="20dp"
-    android:paddingEnd="20dp">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content">
-      <include
-        android:id="@+id/data_collection_header"
-        layout="@layout/data_collection_header"
-        app:layout_constraintBottom_toTopOf="@+id/number_input_layout"
-        app:layout_constraintTop_toTopOf="parent"
-        app:viewModel="@{viewModel}" />
-
-      <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/number_input_layout"
-        style="@style/EditSubmission.Task.Text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/data_collection_header">
-        <com.google.android.material.textfield.TextInputEditText
-          android:id="@+id/user_response_text"
-          android:layout_width="200dp"
-          android:layout_height="wrap_content"
-          android:clickable="true"
-          android:enabled="true"
-          android:focusable="false"
-          android:focusableInTouchMode="false"
-          android:inputType="datetime"
-          android:maxLines="1"
-          android:onClick="@{__ -> fragment.showTimeDialog()}"
-          android:text="@{viewModel.responseText}"
-          app:error="@{viewModel.error}"
-          tools:text="@string/time" />
-      </com.google.android.material.textfield.TextInputLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ScrollView>
+  <com.google.android.material.textfield.TextInputLayout
+    android:id="@+id/number_input_layout"
+    style="@style/EditSubmission.Task.Text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <com.google.android.material.textfield.TextInputEditText
+      android:id="@+id/user_response_text"
+      android:layout_width="200dp"
+      android:layout_height="wrap_content"
+      android:clickable="true"
+      android:enabled="true"
+      android:focusable="false"
+      android:focusableInTouchMode="false"
+      android:inputType="datetime"
+      android:maxLines="1"
+      android:onClick="@{__ -> fragment.showTimeDialog()}"
+      android:text="@{viewModel.responseText}"
+      app:error="@{viewModel.error}"
+      tools:text="@string/time" />
+  </com.google.android.material.textfield.TextInputLayout>
 </layout>

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -150,5 +150,6 @@
   <string name="sync_dialog_subtitle">Your data will be synced shortly.</string>
   <string name="data_collected">Data collected</string>
   <string name="done">Done</string>
+  <string name="skip">Skip</string>
 
 </resources>


### PR DESCRIPTION
Fixes https://github.com/google/ground-android/issues/1621

Full prototype: https://github.com/google/ground-android/pull/1622

 * Removes "Continue" button from DataCollectionFragment
 * Creates a base class for task fragments
 * Apply shared ui components to non-map type tasks

Known bugs:
 * `Continue` for multi-select task doesn't get highlighted
 * `Skip` for select task doesn't clear response 

[Design doc](https://docs.google.com/document/d/15CGT-9LvgarzBvrC8kPPAEHlrGuZCqVL0i9lpmya2dU/r/0-OLrHylzybpz6_mkioEm7og/edit#)

@... PTAL?
