### PR TITLE
Disable StrictMode for quick reads/writes

### DIFF
--- a/ground/src/main/java/com/google/android/ground/persistence/local/SharedPreferencesModule.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/SharedPreferencesModule.kt
@@ -21,6 +21,7 @@ import com.google.android.ground.Config
 import com.google.android.ground.persistence.local.room.dao.*
 import com.google.android.ground.persistence.local.room.stores.*
 import com.google.android.ground.persistence.local.stores.*
+import com.google.android.ground.util.allowThreadDiskReads
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,5 +35,7 @@ object SharedPreferencesModule {
   @Provides
   @Singleton
   fun sharedPreferences(@ApplicationContext context: Context): SharedPreferences =
-    context.getSharedPreferences(Config.SHARED_PREFS_NAME, Config.SHARED_PREFS_MODE)
+    allowThreadDiskReads {
+      context.getSharedPreferences(Config.SHARED_PREFS_NAME, Config.SHARED_PREFS_MODE)
+    }
 }

--- a/ground/src/main/java/com/google/android/ground/util/StrictModeExtensions.kt
+++ b/ground/src/main/java/com/google/android/ground/util/StrictModeExtensions.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.util
+
+import android.os.StrictMode
+
+/**
+ * Disables StrictMode warnings for on-thread disk reads made from the provided block.
+ *
+ * **IMPORTANT**: Use with caution! This should only be used to execute code which is guaranteed to
+ * execute small, quick reads.
+ */
+inline fun <T> allowThreadDiskReads(block: () -> T): T {
+  val oldPolicy = StrictMode.allowThreadDiskReads()
+  val returnValue = block()
+  StrictMode.setThreadPolicy(oldPolicy)
+  return returnValue
+}
+
+/**
+ * Disables StrictMode warnings for on-thread disk writes made from the provided block.
+ *
+ * **IMPORTANT**: Use with caution! This should only be used to execute code which is guaranteed to
+ * execute small, quick writes.
+ */
+inline fun <T> allowThreadDiskWrites(block: () -> T): T {
+  val oldPolicy = StrictMode.allowThreadDiskWrites()
+  val returnValue = block()
+  StrictMode.setThreadPolicy(oldPolicy)
+  return returnValue
+}


### PR DESCRIPTION
Fixes #1624.

Note that it's not currently easily disable StrictMode warnings caused by Firebase Crashlytics initialization. Alternatives are currently being investigated by Firebase team: https://github.com/firebase/firebase-android-sdk/issues/3795

@shobhitagarwal1612 PTAL?