### PR TITLE
Active loi UI fix

### DIFF
--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -170,7 +170,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-maps:$rootProject.gmsMapsVersion"
     implementation 'com.google.android.gms:play-services-location:17.1.0'
 
-    implementation "com.google.maps.android:android-maps-utils:2.2.0"
+    implementation "com.google.maps.android:android-maps-utils:2.3.0"
 
     // GeoJSON support
     implementation 'com.google.code.gson:gson:2.10'

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/MapCardAdapter.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/MapCardAdapter.kt
@@ -80,6 +80,7 @@ class MapCardAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     // Add highlight border if selected.
     val borderDrawable =
       if (focusedIndex == position) {
+        cardFocusedListener.invoke(uiData)
         R.drawable.loi_card_selected_background
       } else {
         R.drawable.loi_card_default_background
@@ -99,8 +100,6 @@ class MapCardAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     focusedIndex = newIndex
     notifyDataSetChanged()
-
-    cardFocusedListener.invoke(itemsList[newIndex])
   }
 
   /** Overwrites existing cards. */
@@ -110,7 +109,6 @@ class MapCardAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     itemsList.addAll(newItemsList)
     focusedIndex = 0
     notifyDataSetChanged()
-    cardFocusedListener.invoke(null)
   }
 
   fun setLoiCardFocusedListener(listener: (MapCardUiData?) -> Unit) {

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/FeatureClusterRenderer.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/FeatureClusterRenderer.kt
@@ -131,8 +131,7 @@ class FeatureClusterRenderer(
   override fun shouldRender(
     oldClusters: MutableSet<out Cluster<FeatureClusterItem>>,
     newClusters: MutableSet<out Cluster<FeatureClusterItem>>
-  ): Boolean {
-    return previousActiveLoiId != clusterManager.activeLocationOfInterest ||
+  ): Boolean =
+    previousActiveLoiId != clusterManager.activeLocationOfInterest ||
       super.shouldRender(oldClusters, newClusters)
-  }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
@@ -96,11 +96,6 @@ class GoogleMapsFragment : SupportMapFragment(), MapFragment {
   private lateinit var clusterManager: FeatureClusterManager
 
   /**
-   * User selected [LocationOfInterest] by either clicking the bottom card or horizontal scrolling.
-   */
-  private var activeLocationOfInterest: String? = null
-
-  /**
    * References to Google Maps SDK CustomCap present on the map. Used to set the custom drawable to
    * start and end of polygon.
    */
@@ -319,7 +314,7 @@ class GoogleMapsFragment : SupportMapFragment(), MapFragment {
   override fun renderFeatures(features: Set<Feature>) {
     // Re-cluster and re-render
     if (features.isNotEmpty()) {
-      Timber.v("renderLocationsOfInterest() called with ${features.size} locations of interest")
+      Timber.v("renderFeatures() called with ${features.size} locations of interest")
       removeStaleFeatures(features)
       Timber.v("Updating ${features.size} features")
       features.forEach(this::addOrUpdateLocationOfInterest)
@@ -384,7 +379,7 @@ class GoogleMapsFragment : SupportMapFragment(), MapFragment {
   override fun addRemoteTileOverlays(urls: List<String>) = urls.forEach { addRemoteTileOverlay(it) }
 
   override fun setActiveLocationOfInterest(newLoiId: String?) {
-    if (activeLocationOfInterest == newLoiId) return
+    clusterRenderer.previousActiveLoiId = clusterManager.activeLocationOfInterest
     clusterManager.activeLocationOfInterest = newLoiId
 
     refresh()


### PR DESCRIPTION
Previously, we did not render the actively selected map feature LOI using the larger icon. This commit fixes that by doing a few things:

1. We upgrade to a newer version of the clustering utility. By default, the utility will only re-render clusters and individual markers when the underlying cluster set has changed. This is dependent on the clustering algortihm, and the algo we currently use has no knowledge of map feature selection. Luckily, this newer version of the API adds a shouldRender method that we can override to force the renderer to re-render on selection changes.
2. Moves calls to cardSelection callback invocations in the map adapter to view holder binding. This is the correct place to call it. Calling this in the updateData method will incorrectly reset active LOI state and calling it in the focus item method makes it impossible to correctly focus the default selection on the initial creation of the card set. The view holder binding method is called whenever the data set changes (which we call on focus change, in turn called on scroll callback) so this invokes at the correct time.

Fixes https://github.com/google/ground-android/issues/1457


https://user-images.githubusercontent.com/11237600/229562562-840b8e02-a348-4026-acb5-6a0d198ab133.mov

