### PR TITLE
feat: hide Offline BaseMaps menu item when no sources defined

### DIFF
--- a/ground/src/main/java/com/google/android/ground/domain/usecases/survey/ActivateSurveyUseCase.kt
+++ b/ground/src/main/java/com/google/android/ground/domain/usecases/survey/ActivateSurveyUseCase.kt
@@ -23,7 +23,8 @@ class ActivateSurveyUseCase
 @Inject
 constructor(
   private val surveyRepository: SurveyRepository,
-  private val makeSurveyAvailableOffline: MakeSurveyAvailableOfflineUseCase
+  private val makeSurveyAvailableOffline: MakeSurveyAvailableOfflineUseCase,
+  private val syncSurvey: SyncSurveyUseCase,
 ) {
   suspend operator fun invoke(surveyId: String) {
     // Do nothing if survey is already active.
@@ -32,6 +33,7 @@ constructor(
     }
 
     surveyRepository.activeSurvey =
-      surveyRepository.getOfflineSurveySuspend(surveyId) ?: makeSurveyAvailableOffline(surveyId)
+      surveyRepository.getOfflineSurveySuspend(surveyId)?.let { syncSurvey(it.id) }
+        ?: makeSurveyAvailableOffline(surveyId)
   }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomSurveyStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomSurveyStore.kt
@@ -119,6 +119,6 @@ class RoomSurveyStore @Inject internal constructor() : LocalSurveyStore {
 
   private fun insertOfflineBaseMapSources(survey: Survey): Completable =
     Observable.fromIterable(survey.baseMaps).flatMapCompletable {
-      baseMapDao.insert(it.toLocalDataStoreObject(surveyId = survey.id))
+      baseMapDao.insertOrUpdate(it.toLocalDataStoreObject(surveyId = survey.id))
     }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/SurveyConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/SurveyConverter.kt
@@ -63,6 +63,7 @@ internal object SurveyConverter {
         continue
       }
       try {
+        Timber.d("Converting base map source: $url")
         builder.add(BaseMap(URL(url), BaseMap.typeFromExtension(url)))
       } catch (e: MalformedURLException) {
         Timber.d("Skipping base map source in survey with malformed URL")

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
@@ -105,6 +105,10 @@ class HomeScreenFragment :
     binding.versionText.text = String.format(getString(R.string.build), BuildConfig.VERSION_NAME)
     // Ensure nav drawer cannot be swiped out, which would conflict with map pan gestures.
     binding.drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
+    homeScreenViewModel.showOfflineAreaMenuItem.observe(viewLifecycleOwner) {
+      binding.navView.menu.findItem(R.id.nav_offline_areas).isVisible = it
+    }
+
     binding.navView.setNavigationItemSelectedListener(this)
     requireView().viewTreeObserver.addOnGlobalLayoutListener(this)
     updateNavHeader()

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenViewModel.kt
@@ -15,8 +15,11 @@
  */
 package com.google.android.ground.ui.home
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asLiveData
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
+import com.google.android.ground.repository.SurveyRepository
 import com.google.android.ground.rx.Nil
 import com.google.android.ground.rx.annotations.Hot
 import com.google.android.ground.ui.common.AbstractViewModel
@@ -27,11 +30,16 @@ import com.google.android.ground.ui.home.BottomSheetState.Companion.visible
 import io.reactivex.processors.FlowableProcessor
 import io.reactivex.processors.PublishProcessor
 import javax.inject.Inject
+import kotlinx.coroutines.flow.map
 import timber.log.Timber
 
 @SharedViewModel
-class HomeScreenViewModel @Inject internal constructor(private val navigator: Navigator) :
-  AbstractViewModel() {
+class HomeScreenViewModel
+@Inject
+internal constructor(
+  private val navigator: Navigator,
+  private val surveyRepository: SurveyRepository
+) : AbstractViewModel() {
 
   @JvmField
   val isSubmissionButtonVisible: @Hot(replays = true) MutableLiveData<Boolean> =
@@ -40,6 +48,8 @@ class HomeScreenViewModel @Inject internal constructor(private val navigator: Na
   // TODO(#719): Move into LocationOfInterestDetailsViewModel.
   val openDrawerRequests: @Hot FlowableProcessor<Nil> = PublishProcessor.create()
   val bottomSheetState: @Hot(replays = true) MutableLiveData<BottomSheetState> = MutableLiveData()
+  val showOfflineAreaMenuItem: LiveData<Boolean> =
+    surveyRepository.activeSurveyFlow.map { it?.baseMaps?.isNotEmpty() ?: false }.asLiveData()
 
   fun openNavDrawer() {
     openDrawerRequests.onNext(Nil.NIL)


### PR DESCRIPTION
This alters the behavior of the home screen to hide the Basemaps menu item when the active survey has no basemap sources defined (i.e. we now only show the option when it's actually possible to download basemaps). I had to make a few small fixes to accomplish this:

1. Sync locally cached surveys upon activation; before, we were relying only on the Offline data, which lead to discrepancies between the offline and remote.
2. Update local basemap sources on survey sync.
3. Don't overwrite basemap sources on writing surveys to the local db

Fixes #812 

https://user-images.githubusercontent.com/11237600/229591348-2b2faaa2-dcf4-4465-bb09-87ced948ed8a.mov

