### PR TITLE
Provider and downloaded for Maps optimized COGs

### DIFF
--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -299,6 +299,8 @@ dependencies {
     debugImplementation "androidx.fragment:fragment-testing:$fragmentVersion"
     //noinspection AndroidLintFragmentGradleConfiguration
     stagingImplementation "androidx.fragment:fragment-testing:$fragmentVersion"
+
+    implementation "mil.nga:tiff:3.0.0"
 }
 
 // Allow references to generated code.

--- a/ground/src/main/AndroidManifest.xml
+++ b/ground/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
     android:label="@string/app_name"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
+    android:largeHeap="true"
     android:theme="@style/AppTheme.Launcher">
 
     <service

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/LatLngBoundsExt.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/LatLngBoundsExt.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.LatLngBounds
+
+fun LatLngBounds.northwest() = LatLng(northeast.latitude, southwest.longitude)
+
+fun LatLngBounds.southeast() = LatLng(southwest.latitude, northeast.longitude)

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/Mog.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/Mog.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import com.google.android.gms.maps.model.Tile
+import java.io.InputStream
+import kotlinx.coroutines.flow.*
+import timber.log.Timber
+
+/**
+ * Contiguous tiles are fetched in a single request. To minimize the number of server requests, we
+ * also allow additional unneeded tiles to be fetched so that nearly contiguous tiles can be also
+ * fetched in a single request. This constant defines the maximum number of unneeded bytes which can
+ * be fetched per tile to allow nearly contiguous regions to be merged. Tiles are typically 10-20
+ * KB, so allowing 20 KB over fetch generally allows 1-2 extra tiles to be fetched.
+ */
+const val MAX_OVER_FETCH_PER_TILE = 1 * 20 * 1024
+
+data class RequestRange(
+  var byteRange: LongRange,
+  var tileCoordinates: MutableList<TileCoordinates>
+)
+
+/**
+ * A single Maps Optimized GeoTIFF (MOG). MOGs are [Cloud Optimized GeoTIFFs (COGs)](cogeo.org)
+ * clipped and configured for visualization with Google Maps Platform. This class stores metadata
+ * and fetches tiles on demand via [getTile] and [getTiles].
+ */
+class Mog(val url: String, images: List<MogImage>) {
+  private val imagesByZoom = images.associateBy { it.zoom }
+
+  suspend fun getTile(tileCoordinates: TileCoordinates): Tile? =
+    getTiles(listOf(tileCoordinates)).firstOrNull()?.second
+
+  fun getTiles(tileCoordinatesList: List<TileCoordinates>): Flow<Pair<TileCoordinates, Tile>> =
+    flow {
+      val requestRanges = mutableListOf<RequestRange>()
+      for (tileCoordinates in tileCoordinatesList) {
+        val byteRange = getByteRange(tileCoordinates) ?: continue
+        val prev = if (requestRanges.isEmpty()) null else requestRanges.last()
+        if (prev == null || byteRange.first - prev.byteRange.last - 1 > MAX_OVER_FETCH_PER_TILE) {
+          requestRanges.add(RequestRange(byteRange, mutableListOf(tileCoordinates)))
+        } else {
+          prev.byteRange = LongRange(prev.byteRange.first, byteRange.last)
+          prev.tileCoordinates.add(tileCoordinates)
+        }
+      }
+      // TODO: Use thread pool to request multiple ranges in parallel.
+      requestRanges.forEach { (byteRange, tileCoordinates) ->
+        UrlInputStream(url, byteRange).use { emitAll(parseTiles(tileCoordinates, it)) }
+      }
+    }
+  override fun toString(): String {
+    return "Mog(url=$url, imagesByZoom=$imagesByZoom)"
+  }
+
+  private fun parseTiles(
+    tileCoordinatesList: List<TileCoordinates>,
+    inputStream: InputStream
+  ): Flow<Pair<TileCoordinates, Tile>> = flow {
+    var pos: Long? = null
+    for (tileCoordinates in tileCoordinatesList) {
+      val image = imagesByZoom[tileCoordinates.zoom]!!
+      val byteRange =
+        image.getByteRange(tileCoordinates.x, tileCoordinates.y)
+          ?: error("$tileCoordinates out of image bounds")
+      if (pos != null && pos < byteRange.first) {
+        while (pos++ < byteRange.first) {
+          if (inputStream.read() == -1) {
+            error("Unexpected end of tile response")
+          }
+        }
+      }
+      val startTimeMillis = System.currentTimeMillis()
+      val imageBytes = image.parseTile(inputStream, byteRange.count())
+      val time = System.currentTimeMillis() - startTimeMillis
+      Timber.d("Fetched tile ${tileCoordinates}: ${imageBytes.size} in $time ms")
+      emit(Pair(tileCoordinates, Tile(image.tileWidth, image.tileLength, imageBytes)))
+      pos = byteRange.last + 1
+    }
+  }
+
+  private fun getByteRange(tileCoordinate: TileCoordinates): LongRange? =
+    imagesByZoom[tileCoordinate.zoom]?.getByteRange(tileCoordinate.x, tileCoordinate.y)
+}

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/MogCollection.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/MogCollection.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.LruCache
+import com.google.android.gms.maps.model.LatLngBounds
+import com.google.android.gms.maps.model.Tile
+import java.io.ByteArrayOutputStream
+import java.io.FileNotFoundException
+import java.io.InputStream
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import mil.nga.tiff.FieldTagType
+import mil.nga.tiff.TiffReader
+import mil.nga.tiff.util.TiffConstants
+import mil.nga.tiff.util.TiffException
+import timber.log.Timber
+
+/** A collection of Maps Optimized GeoTIFFs (MOGs). */
+class MogCollection(
+  private val worldMogUrl: String,
+  private val hiResMogUrlTemplate: String,
+  private val hiResMogMinZoom: Int,
+  val hiResMogMaxZoom: Int
+) {
+  private val cache: LruCache<String, Deferred<Mog?>> = LruCache(16)
+
+  /** Returns the tile for the specified tile coordinates, or `null` if not available. */
+  suspend fun getTile(tileCoordinates: TileCoordinates): Tile? =
+    getMogForTile(tileCoordinates)?.getTile(tileCoordinates)
+
+  /**
+   * Returns a [Flow] which emits the tiles for the specified tile coordinates along with each
+   * tile's respective coordinates.
+   */
+  fun getTiles(bounds: LatLngBounds, zoomRange: IntRange): Flow<Pair<TileCoordinates, Tile>> =
+    flow {
+      val (worldZoomLevels, sliceZoomLevels) = zoomRange.partition { it < hiResMogMinZoom }
+      if (worldZoomLevels.isNotEmpty()) {
+        emitAll(getTiles(TileCoordinates.WORLD, bounds, worldZoomLevels))
+      }
+      if (sliceZoomLevels.isNotEmpty()) {
+        // Compute extents of first and last region covered by specified bounds.
+        val nwSlice = TileCoordinates.fromLatLng(bounds.northwest(), hiResMogMinZoom)
+        val seSlice = TileCoordinates.fromLatLng(bounds.southeast(), hiResMogMinZoom)
+        for (y in nwSlice.y..seSlice.y) {
+          for (x in nwSlice.x..seSlice.x) {
+            emitAll(getTiles(TileCoordinates(x, y, hiResMogMinZoom), bounds, sliceZoomLevels))
+          }
+        }
+      }
+    }
+
+  /**
+   * Crude method of making missing pixels transparent. Ideally, rather than replacing dark pixels
+   * with transparent ones, we would use the image masks contained.
+   */
+  fun applyMask(tile: Tile?, tileCoordinates: TileCoordinates): Tile? {
+    // Only apply mask workaround to world COG for now.
+    if (tile?.data == null || tileCoordinates.zoom >= hiResMogMinZoom) {
+      return tile
+    }
+    val bitmap =
+      BitmapFactory.decodeByteArray(tile.data, 0, tile.data!!.size)
+        .copy(Bitmap.Config.ARGB_8888, true)
+    bitmap.setHasAlpha(true)
+    for (x in 0 until bitmap.width) {
+      for (y in 0 until bitmap.height) {
+        val color = bitmap.getPixel(x, y)
+        val r: Int = color shr 16 and 0xFF
+        val g: Int = color shr 8 and 0xFF
+        val b: Int = color shr 0 and 0xFF
+        if (r + g + b == 0) {
+          bitmap.setPixel(x, y, 0)
+        }
+      }
+    }
+    val out = ByteArrayOutputStream()
+    // Note: JPEG doesn't support transparency, so need to use PNG or BMP.
+    // TODO: Return raw BMP instead of recompressing to JPEG.
+    bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+    return Tile(tile.width, tile.height, out.toByteArray())
+  }
+
+  private fun getMogExtentForTile(tileCoordinates: TileCoordinates): TileCoordinates =
+    if (tileCoordinates.zoom < hiResMogMinZoom) TileCoordinates.WORLD
+    else tileCoordinates.originAtZoom(hiResMogMinZoom)
+
+  /** Returns the MOG containing the tile with the specified coordinates. */
+  private suspend fun getMogForTile(tileCoordinates: TileCoordinates): Mog? =
+    getMog(getMogExtentForTile(tileCoordinates))
+
+  private suspend fun getMog(extent: TileCoordinates): Mog? =
+    getOrFetchMogAsync(getMogUrl(extent), extent).await()
+
+  private fun getMogUrl(extent: TileCoordinates): String {
+    val (x, y, zoom) = extent
+    if (zoom == 0) {
+      return worldMogUrl
+    }
+    if (zoom < hiResMogMinZoom) {
+      error("Invalid zoom for this collection. Expected 0 or $hiResMogMinZoom, got $zoom")
+    }
+    return hiResMogUrlTemplate
+      .replace("{x}", x.toString())
+      .replace("{y}", y.toString())
+      .replace("{z}", zoom.toString())
+  }
+
+  /**
+   * Returns a future containing the [Mog] with the specified extent and URL. Metadata is either
+   * loaded from in-memory cache if present, or asynchronously fetched if necessary. The process of
+   * checking the cache and creating the new job is synchronized on the current instance to prevent
+   * duplicate parallel requests for the same resource.
+   */
+  private fun getOrFetchMogAsync(url: String, extent: TileCoordinates): Deferred<Mog?> =
+    synchronized(this) { cache.get(url) ?: fetchMogAsync(url, extent) }
+
+  /**
+   * Asynchronously fetches and returns the [Mog] with the specified extent and URL. The async job
+   * is added to the cache immediately to prevent duplicate fetches from other threads.
+   */
+  private fun fetchMogAsync(url: String, extent: TileCoordinates): Deferred<Mog?> = runBlocking {
+    // TODO: Exceptions get propagated as cancellation of the coroutine. Handle them!
+    @Suppress("DeferredResultUnused")
+    async { nullIfNotFound { UrlInputStream(url) }?.use { readHeader(url, extent, it) } }
+      .also { cache.put(url, it) }
+  }
+
+  private fun getTiles(
+    mogExtent: TileCoordinates,
+    bounds: LatLngBounds,
+    zoomLevels: List<Int>
+  ): Flow<Pair<TileCoordinates, Tile>> = flow {
+    val mog = getMog(mogExtent) ?: return@flow
+    for (zoom in zoomLevels) {
+      emitAll(mog.getTiles(TileCoordinates.withinBounds(bounds, zoom)))
+    }
+  }
+
+  private fun readHeader(url: String, extent: TileCoordinates, inputStream: InputStream): Mog {
+    val startTimeMillis = System.currentTimeMillis()
+    try {
+      // This reads only headers and not the whole file.
+      val tiff = TiffReader.readTiff(inputStream)
+      val images = mutableListOf<MogImage>()
+      // Only include image file directories with RGB image data. Mask images are skipped.
+      // TODO: Render masked areas as transparent.
+      val rgbIfds =
+        tiff.fileDirectories.filter {
+          it
+            .getIntegerEntryValue(FieldTagType.PhotometricInterpretation)
+            .and(TiffConstants.PHOTOMETRIC_INTERPRETATION_RGB) != 0
+        }
+      // IFDs are in decreasing detail (decreasing zoom), starting with max, ending with min zoom.
+      val maxZ = extent.zoom + rgbIfds.size - 1
+      rgbIfds.forEachIndexed { i, ifd ->
+        images.add(
+          MogImage(
+            ifd.getIntegerEntryValue(FieldTagType.TileWidth),
+            ifd.getIntegerEntryValue(FieldTagType.TileLength),
+            extent.originAtZoom(maxZ - i),
+            ifd.getLongListEntryValue(FieldTagType.TileOffsets),
+            ifd.getLongListEntryValue(FieldTagType.TileByteCounts),
+            ifd.getIntegerEntryValue(FieldTagType.ImageWidth),
+            ifd.getIntegerEntryValue(FieldTagType.ImageLength),
+            ifd.getLongListEntryValue(FieldTagType.JPEGTables)?.map(Long::toByte)?.toByteArray()
+              ?: byteArrayOf()
+          )
+        )
+      }
+      val time = System.currentTimeMillis() - startTimeMillis
+      Timber.d("Loaded headers from $url in $time ms")
+
+      return Mog(url, images.toList())
+    } catch (e: TiffException) {
+      error("Failed to read $url: ${e.message})")
+    } finally {
+      inputStream.close()
+    }
+  }
+}
+
+private inline fun <T> nullIfNotFound(fn: () -> T) =
+  try {
+    fn()
+  } catch (_: FileNotFoundException) {
+    null
+  }

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/MogImage.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/MogImage.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import java.io.InputStream
+import timber.log.Timber
+
+/* Circumference of the Earth (m) */
+private val START_OF_IMAGE = byteArrayOf(0xFF, 0xD8)
+private val APP0_MARKER = byteArrayOf(0xFF, 0xE0)
+// Marker segment length with no thumbnails.
+private const val APP0_MIN_LEN: Short = 16
+private const val JFIF_IDENTIFIER = "JFIF"
+private const val JFIF_MAJOR_VERSION = 1
+private const val JFIF_MINOR_VERSION = 2
+private const val NO_DENSITY_UNITS = 0
+private val END_OF_IMAGE = byteArrayOf(0xFF, 0xD9)
+
+private fun byteArrayOf(vararg elements: Int) = elements.map(Int::toByte).toByteArray()
+
+private fun Short.toByteArray() = byteArrayOf(this.toInt().shr(8).toByte(), this.toByte())
+
+private fun String.toNulTerminatedByteArray() = this.toByteArray() + 0x00.toByte()
+
+class MogImage(
+  val tileWidth: Int,
+  val tileLength: Int,
+  private val originTile: TileCoordinates,
+  private val offsets: List<Long>,
+  private val byteCounts: List<Long>,
+  private val imageWidth: Int,
+  private val imageLength: Int,
+  private val jpegTables: ByteArray
+) {
+  private val tileCountX = imageWidth / tileWidth
+  private val tileCountY = imageLength / tileLength
+
+  // TODO: Verify X and Y scales the same.
+  val zoom = originTile.zoom
+
+  private fun hasTile(x: Int, y: Int) =
+    x >= originTile.x &&
+      y >= originTile.y &&
+      x < tileCountX + originTile.x &&
+      y < tileCountY + originTile.y
+
+  override fun toString(): String {
+    return "MogImage(originTile=$originTile, offsets=.., byteCounts=.., tileWidth=$tileWidth, tileLength=$tileLength, imageWidth=$imageWidth, imageLength=$imageLength, tileCountX=$tileCountX, tileCountY=$tileCountY, jpegTables=.., zoom=$zoom)"
+  }
+
+  fun getByteRange(x: Int, y: Int): LongRange? {
+    if (!hasTile(x, y)) return null
+    val xIdx = x - originTile.x
+    val yIdx = y - originTile.y
+    val idx = yIdx * tileCountX + xIdx
+    if (idx > offsets.size) throw IllegalArgumentException("idx > offsets")
+    val from = offsets[idx]
+    val len = byteCounts[idx].toInt()
+    val to = from + len - 1
+    return from..to
+  }
+
+  /** Input stream is not closed. */
+  fun parseTile(inputStream: InputStream, numBytes: Int): ByteArray {
+    val imageBytes = ByteArray(numBytes)
+    var bytesRead = 0
+    while (bytesRead < numBytes) {
+      val b = inputStream.read()
+      if (b < 0) break
+      imageBytes[bytesRead++] = b.toByte()
+    }
+    if (bytesRead < numBytes) {
+      Timber.w("Too few bytes received. Expected $numBytes, got $bytesRead")
+    }
+
+    return buildJfifFile(imageBytes)
+  }
+
+  private fun buildJfifFile(imageBytes: ByteArray): ByteArray =
+    START_OF_IMAGE +
+      app0Segment(tileWidth, tileLength) +
+      rawJpegTables(jpegTables) +
+      imageBytes.drop(2) + // Drop leading SOI.
+      END_OF_IMAGE
+
+  private fun rawJpegTables(jpegTables: ByteArray): ByteArray =
+    jpegTables
+      .drop(2) // Drop leading SOI.
+      .dropLast(2) // Drop trailing EOI.
+      .toByteArray()
+
+  /** Build "Application Segment 0" section of header. */
+  private fun app0Segment(tileWidth: Int, tileHeight: Int) =
+    APP0_MARKER +
+      APP0_MIN_LEN.toByteArray() +
+      JFIF_IDENTIFIER.toNulTerminatedByteArray() +
+      JFIF_MAJOR_VERSION.toByte() +
+      JFIF_MINOR_VERSION.toByte() +
+      NO_DENSITY_UNITS.toByte() +
+      tileWidth.toShort().toByteArray() +
+      tileHeight.toShort().toByteArray() +
+      kotlin.byteArrayOf(0, 0) // Dimensions of empty thumbnail.
+}

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/MogTileDownloader.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/MogTileDownloader.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import com.google.android.gms.maps.model.LatLngBounds
+import java.io.File
+
+/**
+ * Downloads tiles across regions at multiple zoom levels.
+ *
+ * @param mogCollection the collection from which tiles will be fetched.
+ * @param outputBasePath the base path on the local file system where tiles should be written.
+ */
+class MogTileDownloader(
+  private val mogCollection: MogCollection,
+  private val outputBasePath: String
+) {
+  /**
+   * Downloads all tiles overlapping the Tiles are written to the object's [outputBasePath] in files
+   * with paths of the form `{z}/{x}/{y}.jpg`.
+   *
+   * @param bounds the bounds used to constrain which tiles are retrieved. Only tiles within or
+   *   overlapping these bounds are retrieved.
+   * @param zoomRange the min. and max. zoom levels for which tiles should be retrieved. Defaults to
+   *   all available tiles in the collection as determined by the
+   *   [MogCollection.hiResMogMaxZoom].
+   */
+  suspend fun downloadTiles(
+    bounds: LatLngBounds,
+    zoomRange: IntRange = 0..mogCollection.hiResMogMaxZoom
+  ) =
+    mogCollection.getTiles(bounds, zoomRange).collect { (coordinates, tile) ->
+      val (x, y, zoom) = coordinates
+      val path = File(outputBasePath, "$zoom/$x")
+      path.mkdirs()
+      File(path, "$y.jpg").writeBytes(tile.data!!)
+    }
+}

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/MogTileProvider.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/MogTileProvider.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import com.google.android.gms.maps.model.Tile
+import com.google.android.gms.maps.model.TileProvider
+import kotlinx.coroutines.runBlocking
+import timber.log.Timber
+
+class MogTileProvider(private val mogCollection: MogCollection) : TileProvider {
+  override fun getTile(x: Int, y: Int, zoom: Int): Tile? = runBlocking {
+    val tileCoordinates = TileCoordinates(x, y, zoom)
+    try {
+      val tile = mogCollection.getTile(tileCoordinates)
+      mogCollection.applyMask(tile, tileCoordinates)
+    } catch (e: Throwable) {
+      // Maps SDK doesn't log exceptions thrown by [getTile] implementations, so we log them here.
+      Timber.d(e, "Error fetching tile at $tileCoordinates")
+      null
+    }
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/README.md
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/README.md
@@ -1,0 +1,29 @@
+# Google Maps Optimized GeoTIFFs (MOGs)
+
+Google Maps Optimized GeoTIFFs (MOGs) are normal [Cloud Optimized GeoTIFFs](http://cogeo.org) which have been specially clipped and configured for download and rendering in Google Maps  Platform. This package supports real-time and batch download and rendering of map tiles defined in  collections of MOGs hosted in Google Cloud Storage or other HTTP file server.
+
+In this model, these specialized COGs are treated as tile pyramids, while each full-resolution and overview image in a COG provide a tile matrix for particular zoom level.
+
+To be considered a MOG, a file must satisfy the following constraints:
+
+* Format: [Cloud optimized GeoTIFF](https://github.com/cogeotiff/cog-spec/blob/master/spec.md)
+* Projection: Web Mercator ([EPSG:3857](https://epsg.io/3857))
+* Tile size: 256x256
+* Image compression: JPEG
+* Cloud Storage ACLs: Public read access
+* Extent: Clipped to the exact bounds of a web mercator tile. This ensures contained images tiles align properly with the web tile coordinate system.
+
+* Note that since the MOGs are sliced exactly along the extents of web mercator tiles, the width and
+  height of images at each zoom level are always integer multiples of 256, with the lowest
+  resolution image in each MOG consisting of a single 256x256 tile.
+
+To simplify discovery and retrieval, MOGs are organized in collections structured as follows:
+
+* *Hi-res MOGs*: A series of MOGs partitioned by the extents of web mercator tiles at a particular zoom level (`hiResMogMinZoom`). A MOG collection consists of one or more MOG files clipped to these extents. As such, each MOG can be uniquely identified by the (X, Y) coordinates of the web tile used to determine the extents of the MOG tile pyramid. Each hi-res MOGs contains one image for each zoom level from `hiResMogMinZoom` to `hiResMogMaxZoom`.
+* *World MOG*: A single lower resolution MOG whose extents cover the entire web mercator coordinate space, or tile (0, 0) at zoom level 0. The world MOG consists of one image for each zoom level from `0` to `hiResMogMinZoom - 1`. 
+
+See [Map and Tile Coordinates])https://developers.google.com/maps/documentation/android-sdk/coordinates)
+in the Google Maps Platform docs for info.
+
+<!-- TODO: Provide example usage. -->
+<!-- TODO: Provide illustration. -->

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/TileCoordinates.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/TileCoordinates.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.LatLngBounds
+import java.lang.Math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.ln
+import kotlin.math.tan
+
+/**
+ * Uniquely identifies the coordinates of a web mercator tile by its X and Y coordinates and its
+ * respective zoom level.
+ */
+data class TileCoordinates(val x: Int, val y: Int, val zoom: Int) {
+  /** Returns the coordinates of the tile at [targetZoom] with the same northwest corner. */
+  fun originAtZoom(targetZoom: Int): TileCoordinates {
+    val zoomDelta = targetZoom - zoom
+    val scale = { x: Int -> if (zoomDelta > 0) x shl zoomDelta else x shr abs(zoomDelta) }
+    return TileCoordinates(scale(x), scale(y), targetZoom)
+  }
+
+  override fun toString(): String {
+    return "($x, $y) at zoom $zoom"
+  }
+
+  companion object {
+    /** Tile coordinates of the world as a single tile (0, 0) at zoom level 0. */
+    val WORLD = TileCoordinates(0, 0, 0)
+
+    /**
+     * Returns the coordinates of the tile at a particular zoom containing the specified latitude
+     * and longitude coordinates.
+     */
+    fun fromLatLng(coordinates: LatLng, zoom: Int): TileCoordinates {
+      val zoomFactor = 1 shl zoom
+      val latRad = coordinates.latitude.toRadians()
+      val x = zoomFactor * (coordinates.longitude + 180) / 360
+      val y = zoomFactor * (1 - (ln(tan(latRad) + sec(latRad)) / PI)) / 2
+      return TileCoordinates(x.toInt(), y.toInt(), zoom)
+    }
+
+    /**
+     * Returns all tiles at a particular zoom contained within the specified latitude and longitude
+     * bounds.
+     */
+    fun withinBounds(bounds: LatLngBounds, zoom: Int): List<TileCoordinates> {
+      val results = mutableListOf<TileCoordinates>()
+      val nwTile = fromLatLng(bounds.northwest(), zoom)
+      val seTile = fromLatLng(bounds.southeast(), zoom)
+      for (y in nwTile.y..seTile.y) {
+        for (x in nwTile.x..seTile.x) {
+          results.add(TileCoordinates(x, y, zoom))
+        }
+      }
+      return results.toList()
+    }
+  }
+}
+
+/** Returns the secant of angle `x` given in radians. */
+private fun sec(x: Double) = 1 / cos(x)
+
+/** Converts degrees into radians. */
+private fun Double.toRadians() = this * (PI / 180)

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/UrlInputStream.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/UrlInputStream.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+const val READ_TIMEOUT_MS = 5 * 1000
+
+/**
+ * @constructor Creates a [UrlInputStream] by opening a connection to an actual URL, requesting the
+ *   specified [byteRange] if specified.
+ */
+class UrlInputStream(private val url: String, private val byteRange: LongRange? = null) :
+  InputStream() {
+  private val inputStream: InputStream
+
+  init {
+    inputStream = openStream()
+  }
+
+  private fun openStream(): InputStream {
+    val urlConnection = URL(url).openConnection() as HttpURLConnection
+    urlConnection.requestMethod = "GET"
+    urlConnection.readTimeout = READ_TIMEOUT_MS
+    if (byteRange != null) {
+      urlConnection.setRequestProperty("Range", "bytes=${byteRange.first}-${byteRange.last}")
+    }
+    urlConnection.connect()
+    val responseCode = urlConnection.responseCode
+    if (responseCode == 404) throw FileNotFoundException("$url not found")
+    val expectedResponseCode = if (byteRange == null) 200 else 206
+    if (responseCode != expectedResponseCode) {
+      throw IOException("HTTP $responseCode accessing $url")
+    }
+    return urlConnection.inputStream
+  }
+
+  override fun read(): Int = inputStream.read()
+
+  override fun close() {
+    inputStream.close()
+  }
+}

--- a/ground/src/test/java/com/google/android/ground/ui/map/gms/mog/MogCollectionTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/map/gms/mog/MogCollectionTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MogCollectionTest {
+  @Test
+  fun getTile() {
+    // TODO
+  }
+
+  @Test
+  fun getTiles() {
+    // TODO
+  }
+}

--- a/ground/src/test/java/com/google/android/ground/ui/map/gms/mog/MogTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/map/gms/mog/MogTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MogTest {
+  @Test
+  fun getTile() {
+    // TODO
+  }
+
+  @Test
+  fun getTiles() {
+    // TODO
+  }
+}

--- a/ground/src/test/java/com/google/android/ground/ui/map/gms/mog/MogTileDownloaderTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/map/gms/mog/MogTileDownloaderTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.map.gms.mog
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MogTileDownloaderTest {
+  @Test
+  fun downloadTiles() {
+    // TODO
+  }
+}


### PR DESCRIPTION
Towards #1596.

Still TBD:
- [ ] Unit tests for code in this PR,.
- [ ] Read MOG collection URLs and config from Ground survey.
- [ ] Display live MOG preview in offline download screen.
- [ ] Use downloader to batch fetch and store locally.
- [ ] Implement TileProvider to render imagery from JPEG files on local filesystem.
- [ ] Render full dataset. Currently blocked on issues with COG creation notebook. Will either to add support for BigTIFF to NGA TIFFReader, or figure out why rasterio `cog_translate` hangs.

@scolsen Let's discuss.