### PR TITLE
Use InvalidGeometryException instead of IllegalStateException when geometry is invalid

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/geometry/Geometry.kt
+++ b/ground/src/main/java/com/google/android/ground/model/geometry/Geometry.kt
@@ -87,7 +87,7 @@ data class LinearRing(val coordinates: List<Coordinate>) : Geometry {
       return
     }
     if (coordinates.firstOrNull() != coordinates.lastOrNull()) {
-      error("Invalid linear ring")
+      throw InvalidGeometryException("Invalid linear ring")
     }
   }
 

--- a/ground/src/main/java/com/google/android/ground/model/geometry/InvalidGeometryException.kt
+++ b/ground/src/main/java/com/google/android/ground/model/geometry/InvalidGeometryException.kt
@@ -21,4 +21,4 @@ package com.google.android.ground.model.geometry
  * Typically thrown when a construction does not satisfy definitional constraints for a given
  * geometry.
  */
-sealed class InvalidGeometryException(override val message: String) : Throwable(message)
+class InvalidGeometryException(override val message: String) : Throwable(message)

--- a/ground/src/test/java/com/google/android/ground/model/geometry/GeometryValidatorTest.kt
+++ b/ground/src/test/java/com/google/android/ground/model/geometry/GeometryValidatorTest.kt
@@ -31,7 +31,7 @@ class GeometryValidatorTest {
 
   @Test
   fun validateLinearRing_firstAndLastNotSame_throws() {
-    assertThrows("Invalid linear ring", IllegalStateException::class.java) {
+    assertThrows("Invalid linear ring", InvalidGeometryException::class.java) {
       LinearRing(OPEN_LOOP).validate()
     }
   }


### PR DESCRIPTION


<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@JSunde  PTAL?
