### PR TITLE
[Bug] Prevent app crash when submitting data as a viewer

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/Role.kt
+++ b/ground/src/main/java/com/google/android/ground/model/Role.kt
@@ -16,8 +16,8 @@
 package com.google.android.ground.model
 
 enum class Role {
-  UNKNOWN,
+  DATA_COLLECTOR,
   OWNER,
   SURVEY_ORGANIZER,
-  DATA_COLLECTOR
+  VIEWER
 }

--- a/ground/src/main/java/com/google/android/ground/model/Survey.kt
+++ b/ground/src/main/java/com/google/android/ground/model/Survey.kt
@@ -33,15 +33,12 @@ data class Survey(
 
   fun getJob(jobId: String): Optional<Job> = Optional.ofNullable(jobMap[jobId])
 
-  fun getRole(email: String): Role {
-    return when (
-      val aclValue = acl[email] ?: error("ACL not found for email $email in survey $title")
-    ) {
+  fun getRole(email: String): Role =
+    when (val aclValue = acl[email] ?: error("ACL not found for email $email in survey $title")) {
       "owner" -> Role.OWNER
       "viewer" -> Role.VIEWER
       "data-collector" -> Role.DATA_COLLECTOR
       "survey-organizer" -> Role.SURVEY_ORGANIZER
       else -> error("Unknown acl $aclValue in survey $title for user $email")
     }
-  }
 }

--- a/ground/src/main/java/com/google/android/ground/model/Survey.kt
+++ b/ground/src/main/java/com/google/android/ground/model/Survey.kt
@@ -32,4 +32,16 @@ data class Survey(
     get() = jobMap.values
 
   fun getJob(jobId: String): Optional<Job> = Optional.ofNullable(jobMap[jobId])
+
+  fun getRole(email: String): Role {
+    return when (
+      val aclValue = acl[email] ?: error("ACL not found for email $email in survey $title")
+    ) {
+      "owner" -> Role.OWNER
+      "viewer" -> Role.VIEWER
+      "data-collector" -> Role.DATA_COLLECTOR
+      "survey-organizer" -> Role.SURVEY_ORGANIZER
+      else -> error("Unknown acl $aclValue in survey $title for user $email")
+    }
+  }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -82,7 +82,7 @@ class HomeScreenMapContainerFragment : Hilt_HomeScreenMapContainerFragment() {
       .`as`(RxAutoDispose.autoDisposable(this))
       .subscribe { onZoomThresholdCrossed() }
 
-    val userRole = surveyRepository.activeSurvey!!.getRole(userRepository.currentUser.email)
+    val userRole = surveyRepository.activeSurvey?.getRole(userRepository.currentUser.email)
     val canSubmitData = userRole != Role.VIEWER
 
     adapter = MapCardAdapter(submissionRepository, lifecycleScope)

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -161,4 +161,5 @@
   <string name="data_deletion_warning">Data you entered in this step won\'t be saved. Are you sure you want to continue?</string>
   <string name="go_back_button_label">Go back</string>
   <string name="confirm_button_label">Confirm</string>
+  <string name="collect_data_viewer_error">Can\'t to collect data as user is a VIEWER</string>
 </resources>

--- a/ground/src/test/java/com/google/android/ground/model/SurveyTest.kt
+++ b/ground/src/test/java/com/google/android/ground/model/SurveyTest.kt
@@ -16,7 +16,7 @@
 package com.google.android.ground.model
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assert.assertThrows
+import kotlin.test.assertFailsWith
 import org.junit.Test
 
 class SurveyTest {
@@ -52,9 +52,16 @@ class SurveyTest {
     assertThat(testSurvey.getRole(surveyOrganizerEmail)).isEqualTo(Role.SURVEY_ORGANIZER)
 
     // unknown acl
-    assertThrows(IllegalStateException::class.java) { testSurvey.getRole(randomEmail) }
+    assertFailsWith<IllegalStateException> { testSurvey.getRole(randomEmail) }
+      .hasMessage("Unknown acl random-acl in survey Survey title for user random_email@gmail.com")
 
     // missing email
-    assertThrows(IllegalStateException::class.java) { testSurvey.getRole("") }
+    assertFailsWith<IllegalStateException>("") { testSurvey.getRole("") }
+      .hasMessage("ACL not found for email  in survey Survey title")
+    assertFailsWith<IllegalStateException>("") { testSurvey.getRole("some-email") }
+      .hasMessage("ACL not found for email some-email in survey Survey title")
   }
+
+  private fun Throwable.hasMessage(actualMessage: String) =
+    assertThat(message).isEqualTo(actualMessage)
 }

--- a/ground/src/test/java/com/google/android/ground/model/SurveyTest.kt
+++ b/ground/src/test/java/com/google/android/ground/model/SurveyTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class SurveyTest {
+
+  private val ownerEmail = "owner_email@gmail.com"
+  private val viewerEmail = "viewer_email@gmail.com"
+  private val dataCollectorEmail = "data_collector_email@gmail.com"
+  private val surveyOrganizerEmail = "survey_organizer_email@gmail.com"
+  private val randomEmail = "random_email@gmail.com"
+  private val testSurvey =
+    Survey(
+      id = "survey 1",
+      title = "Survey title",
+      description = "Survey description",
+      jobMap = mapOf(),
+      tileSources = listOf(),
+      acl =
+        mapOf(
+          Pair(ownerEmail, "owner"),
+          Pair(viewerEmail, "viewer"),
+          Pair(dataCollectorEmail, "data-collector"),
+          Pair(surveyOrganizerEmail, "survey-organizer"),
+          Pair(randomEmail, "random-acl")
+        )
+    )
+
+  @Test
+  fun getRole() {
+    // known acl
+    assertThat(testSurvey.getRole(ownerEmail)).isEqualTo(Role.OWNER)
+    assertThat(testSurvey.getRole(viewerEmail)).isEqualTo(Role.VIEWER)
+    assertThat(testSurvey.getRole(dataCollectorEmail)).isEqualTo(Role.DATA_COLLECTOR)
+    assertThat(testSurvey.getRole(surveyOrganizerEmail)).isEqualTo(Role.SURVEY_ORGANIZER)
+
+    // unknown acl
+    assertThrows(IllegalStateException::class.java) { testSurvey.getRole(randomEmail) }
+
+    // missing email
+    assertThrows(IllegalStateException::class.java) { testSurvey.getRole("") }
+  }
+}


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #1667 

<!-- PR description. -->
If we try to submit data as a viewer, the app crashes due to PermissionDeniedException and the user is unable to open the app afterwards until app data is cleared.

This PR fixes this problem by showing a error toast when attempting to open DataCollectionFragment as a viewer.
This is only a workaround to fix the bug. The UX can still be improved in future PRs.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m PTAL?
