### PR TITLE
Tweak splash screen background color

### DIFF
--- a/ground/src/main/res/drawable/launch_screen.xml
+++ b/ground/src/main/res/drawable/launch_screen.xml
@@ -19,13 +19,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android"
   android:opacity="opaque">
 
-  <item android:drawable="@android:color/white" />
-
-  <item>
-    <bitmap
-      android:gravity="fill"
-      android:src="@drawable/splash_background" />
-  </item>
+  <item android:drawable="@color/lightBackground" />
 
   <item>
     <bitmap

--- a/ground/src/main/res/values/colors.xml
+++ b/ground/src/main/res/values/colors.xml
@@ -21,6 +21,7 @@
   <color name="clusterColor">#6DDD81</color>
   <color name="polyLineColor">#55ffffff</color>
   <color name="blackMapOverlay">#000000</color>
+  <color name="lightBackground">#EDEEE9</color>
 
   <!-- Updated Color palette -->
   <color name="md_theme_primary">#006E2C</color>


### PR DESCRIPTION
Background was white, making border around logo invisible. Updated to same background color used in web app

![Screenshot_20230909_113856](https://github.com/google/ground-android/assets/228050/ca2e9413-7fd3-4700-b3be-a9e50c3ae6c3)

@vittorino FYI

@JSunde PTAL?
