### PR TITLE
Log StrictMode thread warnings except reads

### DIFF
--- a/ground/src/main/java/com/google/android/ground/GroundApplication.kt
+++ b/ground/src/main/java/com/google/android/ground/GroundApplication.kt
@@ -55,10 +55,11 @@ class GroundApplication : MultiDexApplication(), Configuration.Provider {
     Configuration.Builder().setWorkerFactory(workerFactory).build()
 
   private fun setStrictMode() {
-    // NOTE: Enabling strict thread policy causes Maps SDK to lag on pan and zoom. Enabled
-    // only as needed when debugging.
-    // https://github.com/google/ground-android/issues/1758#issuecomment-1720243538
-    // StrictMode.setThreadPolicy(ThreadPolicy.Builder().detectAll().penaltyLog().build())
+    // `permitDiskReads()` is required to present Maps and Firebase SDKs from lagging and from
+    // generating log warnings.
+    StrictMode.setThreadPolicy(
+      StrictMode.ThreadPolicy.Builder().detectAll().penaltyLog().permitDiskReads().build()
+    )
     StrictMode.setVmPolicy(VmPolicy.Builder().detectLeakedSqlLiteObjects().penaltyLog().build())
   }
 


### PR DESCRIPTION
This is the solution recommended by Firebase support. It also solves Maps SDK lag when strict policy is enabled. Related to https://github.com/firebase/firebase-android-sdk/issues/3795

Closes #1882

@shobhitagarwal1612 @JSunde FYI