### PR TITLE
Minor renames of map abstractions

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
@@ -28,17 +28,17 @@ import com.google.android.ground.system.PermissionDeniedException
 import com.google.android.ground.system.SettingsChangeRequestCanceled
 import com.google.android.ground.ui.home.mapcontainer.MapTypeDialogFragmentDirections
 import com.google.android.ground.ui.map.CameraPosition
-import com.google.android.ground.ui.map.MapUi
+import com.google.android.ground.ui.map.MapFragment
 import javax.inject.Inject
 import kotlin.math.max
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-/** Injects a [MapUi] in the container with id "map" and provides shared map functionality. */
+/** Injects a [MapFragment] in the container with id "map" and provides shared map functionality. */
 abstract class AbstractMapContainerFragment : AbstractFragment() {
 
-  @Inject lateinit var map: MapUi
+  @Inject lateinit var map: MapFragment
   @Inject lateinit var navigator: Navigator
   @Inject lateinit var geocodingManager: GeocodingManager
   @Inject @DefaultDispatcher lateinit var defaultDispatcher: CoroutineDispatcher
@@ -51,7 +51,7 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
     lifecycleScope.launch { repeatOnLifecycle(Lifecycle.State.STARTED) { fn.invoke() } }
   }
 
-  private fun onMapAttached(map: MapUi) {
+  private fun onMapAttached(map: MapFragment) {
     val viewModel = getMapViewModel()
 
     // Removes all markers, overlays, polylines and polygons from the map.
@@ -70,7 +70,7 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
     onMapReady(map)
   }
 
-  private fun applyMapConfig(map: MapUi) {
+  private fun applyMapConfig(map: MapFragment) {
     val viewModel = getMapViewModel()
     val config = viewModel.mapConfig
 
@@ -103,7 +103,7 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
     navigator.navigate(MapTypeDialogFragmentDirections.showMapTypeDialogFragment(types))
   }
 
-  private fun onLocationLockStateChange(result: Result<Boolean>, map: MapUi) {
+  private fun onLocationLockStateChange(result: Result<Boolean>, map: MapFragment) {
     result.fold(
       onSuccess = {
         Timber.d("Location lock: $it")
@@ -125,7 +125,7 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
     Toast.makeText(context, messageId, Toast.LENGTH_LONG).show()
   }
 
-  private fun onCameraUpdateRequest(newPosition: CameraPosition, map: MapUi) {
+  private fun onCameraUpdateRequest(newPosition: CameraPosition, map: MapFragment) {
     Timber.v("Update camera: %s", newPosition)
     val bounds = newPosition.bounds
     val target = newPosition.target
@@ -148,7 +148,7 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
   }
 
   /** Called when the map is attached to the fragment. */
-  protected open fun onMapReady(map: MapUi) {}
+  protected open fun onMapReady(map: MapFragment) {}
 
   /** Provides an implementation of [BaseMapViewModel]. */
   protected abstract fun getMapViewModel(): BaseMapViewModel

--- a/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
@@ -45,7 +45,7 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    map.attachToFragment(this, R.id.map) { onMapAttached(it) }
+    map.attachToParent(this, R.id.map) { onMapAttached(it) }
   }
   private fun launchWhenStarted(fn: suspend () -> Unit) {
     lifecycleScope.launch { repeatOnLifecycle(Lifecycle.State.STARTED) { fn.invoke() } }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinMapFragment.kt
@@ -31,7 +31,7 @@ import com.google.android.ground.ui.common.BaseMapViewModel
 import com.google.android.ground.ui.datacollection.components.TaskHeaderPopupView
 import com.google.android.ground.ui.datacollection.tasks.point.LatLngConverter.processCoordinates
 import com.google.android.ground.ui.map.CameraPosition
-import com.google.android.ground.ui.map.MapUi
+import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -105,7 +105,7 @@ class DropAPinMapFragment(private val viewModel: DropAPinTaskViewModel) :
     }
   }
 
-  override fun onMapReady(map: MapUi) {
+  override fun onMapReady(map: MapFragment) {
     viewModel.features.observe(this) { map.renderFeatures(it) }
   }
 
@@ -116,7 +116,7 @@ class DropAPinMapFragment(private val viewModel: DropAPinTaskViewModel) :
   }
 
   companion object {
-    fun newInstance(viewModel: DropAPinTaskViewModel, map: MapUi) =
+    fun newInstance(viewModel: DropAPinTaskViewModel, map: MapFragment) =
       DropAPinMapFragment(viewModel).apply { this.map = map }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropAPinTaskFragment.kt
@@ -27,7 +27,7 @@ import com.google.android.ground.ui.datacollection.components.ButtonAction
 import com.google.android.ground.ui.datacollection.components.TaskView
 import com.google.android.ground.ui.datacollection.components.TaskViewFactory
 import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
-import com.google.android.ground.ui.map.MapUi
+import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -35,7 +35,7 @@ import javax.inject.Inject
 class DropAPinTaskFragment : Hilt_DropAPinTaskFragment<DropAPinTaskViewModel>() {
 
   @Inject lateinit var markerIconFactory: MarkerIconFactory
-  @Inject lateinit var map: MapUi
+  @Inject lateinit var map: MapFragment
 
   override fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView =
     TaskViewFactory.createWithCombinedHeader(

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingMapFragment.kt
@@ -28,7 +28,7 @@ import com.google.android.ground.ui.common.AbstractMapContainerFragment
 import com.google.android.ground.ui.common.BaseMapViewModel
 import com.google.android.ground.ui.map.CameraPosition
 import com.google.android.ground.ui.map.Feature
-import com.google.android.ground.ui.map.MapUi
+import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -79,7 +79,7 @@ class PolygonDrawingMapFragment(private val viewModel: PolygonDrawingViewModel) 
     }
   }
 
-  override fun onMapReady(map: MapUi) {
+  override fun onMapReady(map: MapFragment) {
     viewLifecycleOwner.lifecycleScope.launch {
       viewModel.featureValue.collect { feature: Feature? ->
         map.renderFeatures(if (feature == null) setOf() else setOf(feature))
@@ -99,7 +99,7 @@ class PolygonDrawingMapFragment(private val viewModel: PolygonDrawingViewModel) 
   }
 
   companion object {
-    fun newInstance(viewModel: PolygonDrawingViewModel, map: MapUi) =
+    fun newInstance(viewModel: PolygonDrawingViewModel, map: MapFragment) =
       PolygonDrawingMapFragment(viewModel).apply { this.map = map }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/PolygonDrawingTaskFragment.kt
@@ -28,7 +28,7 @@ import com.google.android.ground.ui.datacollection.components.TaskView
 import com.google.android.ground.ui.datacollection.components.TaskViewFactory
 import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import com.google.android.ground.ui.map.Feature
-import com.google.android.ground.ui.map.MapUi
+import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -37,7 +37,7 @@ import kotlinx.coroutines.launch
 class PolygonDrawingTaskFragment : Hilt_PolygonDrawingTaskFragment<PolygonDrawingViewModel>() {
 
   @Inject lateinit var markerIconFactory: MarkerIconFactory
-  @Inject lateinit var map: MapUi
+  @Inject lateinit var map: MapFragment
 
   override fun onCreateTaskView(inflater: LayoutInflater, container: ViewGroup?): TaskView =
     TaskViewFactory.createWithCombinedHeader(

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -40,7 +40,7 @@ import com.google.android.ground.ui.home.HomeScreenFragmentDirections
 import com.google.android.ground.ui.home.HomeScreenViewModel
 import com.google.android.ground.ui.home.mapcontainer.cards.MapCardAdapter
 import com.google.android.ground.ui.home.mapcontainer.cards.MapCardUiData
-import com.google.android.ground.ui.map.MapUi
+import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.flow.combine
@@ -170,7 +170,7 @@ class HomeScreenMapContainerFragment : Hilt_HomeScreenMapContainerFragment() {
     }
   }
 
-  override fun onMapReady(map: MapUi) {
+  override fun onMapReady(map: MapFragment) {
     // Observe events emitted by the ViewModel.
     viewLifecycleOwner.lifecycleScope.launch {
       mapContainerViewModel.mapLoiFeatures.collect { map.renderFeatures(it) }
@@ -191,7 +191,7 @@ class HomeScreenMapContainerFragment : Hilt_HomeScreenMapContainerFragment() {
 
   override fun getMapViewModel(): BaseMapViewModel = mapContainerViewModel
 
-  private fun onBottomSheetStateChange(state: BottomSheetState, map: MapUi) {
+  private fun onBottomSheetStateChange(state: BottomSheetState, map: MapFragment) {
     when (state.visibility) {
       BottomSheetState.Visibility.VISIBLE -> {
         map.disableGestures()

--- a/ground/src/main/java/com/google/android/ground/ui/map/MapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/MapFragment.kt
@@ -53,7 +53,7 @@ interface MapFragment {
   val cameraMovedEvents: SharedFlow<CameraPosition>
 
   /** Attaches this [MapFragment] to its parent [Fragment]. */
-  fun attachToFragment(
+  fun attachToParent(
     containerFragment: AbstractFragment,
     @IdRes containerId: Int,
     onMapReadyCallback: Consumer<MapFragment>

--- a/ground/src/main/java/com/google/android/ground/ui/map/MapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/MapFragment.kt
@@ -24,8 +24,8 @@ import com.google.android.ground.ui.common.AbstractFragment
 import java8.util.function.Consumer
 import kotlinx.coroutines.flow.SharedFlow
 
-/** Generalization of a map view. */
-interface MapUi {
+/** Implementation of Fragment which supports displaying a map. */
+interface MapFragment {
   /** A list of map types supported by the map implementation. */
   val supportedMapTypes: List<MapType>
 
@@ -52,11 +52,11 @@ interface MapUi {
    */
   val cameraMovedEvents: SharedFlow<CameraPosition>
 
-  /** Adds the [MapUi] to a fragment. */
+  /** Attaches this [MapFragment] to its parent [Fragment]. */
   fun attachToFragment(
     containerFragment: AbstractFragment,
     @IdRes containerId: Int,
-    onMapReadyCallback: Consumer<MapUi>
+    onMapReadyCallback: Consumer<MapFragment>
   )
 
   /** Enables map gestures like pan and zoom. */

--- a/ground/src/main/java/com/google/android/ground/ui/map/MapProviderModule.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/MapProviderModule.kt
@@ -24,5 +24,5 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 @Module
 object MapProviderModule {
-  @Provides fun providesGoogleMapFragment(): MapUi = GoogleMapsFragment()
+  @Provides fun providesGoogleMapFragment(): MapFragment = GoogleMapsFragment()
 }

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
@@ -156,7 +156,7 @@ class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapFragment {
       }
     }
 
-  override fun attachToFragment(
+  override fun attachToParent(
     containerFragment: AbstractFragment,
     @IdRes containerId: Int,
     onMapReadyCallback: Consumer<MapFragment>

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
@@ -41,7 +41,7 @@ import com.google.android.ground.model.imagery.TileSource.Type.TILED_WEB_MAP
 import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.map.*
 import com.google.android.ground.ui.map.CameraPosition
-import com.google.android.ground.ui.map.MapUi
+import com.google.android.ground.ui.map.MapFragment
 import com.google.android.ground.ui.map.gms.GmsExt.toBounds
 import com.google.android.ground.ui.map.gms.mog.MogCollection
 import com.google.android.ground.ui.map.gms.mog.MogTileProvider
@@ -70,7 +70,7 @@ const val MARKER_Z = 3f
  * on window insets.
  */
 @AndroidEntryPoint(SupportMapFragment::class)
-class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapUi {
+class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapFragment {
 
   private lateinit var clusterRenderer: FeatureClusterRenderer
 
@@ -159,7 +159,7 @@ class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapUi {
   override fun attachToFragment(
     containerFragment: AbstractFragment,
     @IdRes containerId: Int,
-    onMapReadyCallback: Consumer<MapUi>
+    onMapReadyCallback: Consumer<MapFragment>
   ) {
     containerFragment.replaceFragment(containerId, this)
     getMapAsync { googleMap: GoogleMap ->

--- a/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorFragment.kt
@@ -24,7 +24,7 @@ import com.google.android.ground.databinding.OfflineAreaSelectorFragBinding
 import com.google.android.ground.ui.common.AbstractMapContainerFragment
 import com.google.android.ground.ui.common.BaseMapViewModel
 import com.google.android.ground.ui.common.EphemeralPopups
-import com.google.android.ground.ui.map.MapUi
+import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -58,7 +58,7 @@ class OfflineAreaSelectorFragment : Hilt_OfflineAreaSelectorFragment() {
     return binding.root
   }
 
-  override fun onMapReady(map: MapUi) {
+  override fun onMapReady(map: MapFragment) {
     viewModel.remoteTileSources.forEach { map.addTileOverlay(it) }
   }
 


### PR DESCRIPTION
Labeling the interface "Fragment" makes it obvious wherever its used that it will always be referring to a Fragment and should be treated as such. Unfortunately Android `androidx.fragment.Fragment` is a concrete class, so we can't extend it in an interface.

Towards #1907

@JSunde PTAL?

