### PR TITLE
Move app initialization to onResume() to prevent blank screen

### DIFF
--- a/ground/src/main/java/com/google/android/ground/system/GoogleApiManager.kt
+++ b/ground/src/main/java/com/google/android/ground/system/GoogleApiManager.kt
@@ -20,13 +20,13 @@ import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.ground.rx.RxCompletable
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.android.scopes.ActivityScoped
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.rx2.await
 
 private val INSTALL_API_REQUEST_CODE = GoogleApiAvailability::class.java.hashCode() and 0xffff
 
-@ActivityScoped
+@Singleton
 class GoogleApiManager
 @Inject
 constructor(
@@ -44,7 +44,7 @@ constructor(
     if (status == ConnectionResult.SUCCESS) return
 
     val requestCode = INSTALL_API_REQUEST_CODE
-    startResolution(status, requestCode, Exception("Google play services not available"))
+    startResolution(status, requestCode, GooglePlayServicesMissingException())
     getNextResult(requestCode)
   }
 
@@ -66,4 +66,6 @@ constructor(
         )
       }
       .await()
+
+  class GooglePlayServicesMissingException : Error("Google play services not available")
 }

--- a/ground/src/main/java/com/google/android/ground/ui/common/ViewModelModule.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/ViewModelModule.kt
@@ -39,6 +39,7 @@ import com.google.android.ground.ui.offlineareas.OfflineAreasViewModel
 import com.google.android.ground.ui.offlineareas.selector.OfflineAreaSelectorViewModel
 import com.google.android.ground.ui.offlineareas.viewer.OfflineAreaViewerViewModel
 import com.google.android.ground.ui.signin.SignInViewModel
+import com.google.android.ground.ui.startup.StartupViewModel
 import com.google.android.ground.ui.submissiondetails.SubmissionDetailsViewModel
 import com.google.android.ground.ui.surveyselector.SurveySelectorViewModel
 import com.google.android.ground.ui.syncstatus.SyncStatusViewModel
@@ -188,6 +189,11 @@ abstract class ViewModelModule {
   @IntoMap
   @ViewModelKey(CaptureLocationMapViewModel::class)
   abstract fun bindCaptureLocationMapViewModel(viewModel: CaptureLocationMapViewModel): ViewModel
+
+  @Binds
+  @IntoMap
+  @ViewModelKey(StartupViewModel::class)
+  abstract fun bindStartupViewModel(viewModel: StartupViewModel): ViewModel
 
   @Binds abstract fun bindViewModelFactory(factory: ViewModelFactory): ViewModelProvider.Factory
 }

--- a/ground/src/main/java/com/google/android/ground/ui/startup/StartupFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/startup/StartupFragment.kt
@@ -19,14 +19,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
 import com.google.android.ground.repository.UserRepository
-import com.google.android.ground.rx.RxAutoDispose
 import com.google.android.ground.system.GoogleApiManager
 import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.common.EphemeralPopups
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint(AbstractFragment::class)
@@ -44,10 +45,14 @@ class StartupFragment : Hilt_StartupFragment() {
 
   override fun onResume() {
     super.onResume()
-    googleApiManager
-      .installGooglePlayServices()
-      .`as`(RxAutoDispose.autoDisposable<Any>(requireActivity()))
-      .subscribe({ onGooglePlayServicesReady() }) { t: Throwable -> onGooglePlayServicesFailed(t) }
+    viewLifecycleOwner.lifecycleScope.launch {
+      try {
+        googleApiManager.installGooglePlayServices()
+        onGooglePlayServicesReady()
+      } catch (t: Throwable) {
+        onGooglePlayServicesFailed(t)
+      }
+    }
   }
 
   private fun onGooglePlayServicesReady() {

--- a/ground/src/main/java/com/google/android/ground/ui/startup/StartupFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/startup/StartupFragment.kt
@@ -15,7 +15,6 @@
  */
 package com.google.android.ground.ui.startup
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -43,8 +42,8 @@ class StartupFragment : Hilt_StartupFragment() {
     savedInstanceState: Bundle?
   ): View? = inflater.inflate(R.layout.startup_frag, container, false)
 
-  override fun onAttach(context: Context) {
-    super.onAttach(context)
+  override fun onResume() {
+    super.onResume()
     googleApiManager
       .installGooglePlayServices()
       .`as`(RxAutoDispose.autoDisposable<Any>(requireActivity()))

--- a/ground/src/main/java/com/google/android/ground/ui/startup/StartupViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/startup/StartupViewModel.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.startup
+
+import com.google.android.ground.repository.UserRepository
+import com.google.android.ground.system.GoogleApiManager
+import com.google.android.ground.ui.common.AbstractViewModel
+import javax.inject.Inject
+
+class StartupViewModel
+@Inject
+internal constructor(
+  private val googleApiManager: GoogleApiManager,
+  private val userRepository: UserRepository
+) : AbstractViewModel() {
+
+  /** Checks & installs Google Play Services and initializes the login flow. */
+  suspend fun initializeLogin() {
+    googleApiManager.installGooglePlayServices()
+    userRepository.init()
+  }
+}


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #901
Fixes #1881

<!-- PR description. -->
The app gets stuck with a blank screen as the initialization flow is called in `onAttach()` but this method is only called once during creation and not when resuming the fragment from background.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
Verified by running the below steps manually:

1. Turn off the device screen
2. Install the app using AS
3. Wake the device

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m @JSunde  PTAL?
