### PR TITLE
Convert a bunch of mutations related streams to Flow and suspend funs.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/LocationOfInterestMutationDao.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/LocationOfInterestMutationDao.kt
@@ -19,8 +19,7 @@ import androidx.room.Dao
 import androidx.room.Query
 import com.google.android.ground.persistence.local.room.entity.LocationOfInterestMutationEntity
 import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
-import com.google.android.ground.rx.annotations.Cold
-import io.reactivex.Flowable
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Provides low-level read/write operations of [LocationOfInterestMutationEntity] to/from the local
@@ -29,14 +28,14 @@ import io.reactivex.Flowable
 @Dao
 interface LocationOfInterestMutationDao : BaseDao<LocationOfInterestMutationEntity> {
   @Query("SELECT * FROM location_of_interest_mutation")
-  fun loadAllOnceAndStream(): Flowable<List<LocationOfInterestMutationEntity>>
+  fun getAllMutations(): Flow<List<LocationOfInterestMutationEntity>>
 
   @Query(
     "SELECT * FROM location_of_interest_mutation " +
       "WHERE location_of_interest_id = :locationOfInterestId " +
       "AND state IN (:allowedStates)"
   )
-  suspend fun findByLocationOfInterestId(
+  suspend fun getMutations(
     locationOfInterestId: String,
     vararg allowedStates: MutationEntitySyncStatus
   ): List<LocationOfInterestMutationEntity>?
@@ -46,8 +45,8 @@ interface LocationOfInterestMutationDao : BaseDao<LocationOfInterestMutationEnti
       "WHERE location_of_interest_id = :locationOfInterestId " +
       "AND state IN (:allowedStates)"
   )
-  fun findByLocationOfInterestIdOnceAndStream(
+  fun getMutationsFlow(
     locationOfInterestId: String,
-    vararg allowedStates: MutationEntitySyncStatus
-  ): @Cold(terminates = false) Flowable<List<LocationOfInterestMutationEntity>>
+    vararg allowedStates: MutationEntitySyncStatus,
+  ): Flow<List<LocationOfInterestMutationEntity>>
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/LocationOfInterestMutationDao.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/LocationOfInterestMutationDao.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface LocationOfInterestMutationDao : BaseDao<LocationOfInterestMutationEntity> {
   @Query("SELECT * FROM location_of_interest_mutation")
-  fun getAllMutations(): Flow<List<LocationOfInterestMutationEntity>>
+  fun getAllMutationsFlow(): Flow<List<LocationOfInterestMutationEntity>>
 
   @Query(
     "SELECT * FROM location_of_interest_mutation " +

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/SubmissionMutationDao.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/SubmissionMutationDao.kt
@@ -20,14 +20,13 @@ import androidx.room.Query
 import com.google.android.ground.persistence.local.room.entity.SubmissionMutationEntity
 import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
 import com.google.android.ground.persistence.local.room.fields.MutationEntityType
-import com.google.android.ground.rx.annotations.Cold
-import io.reactivex.Flowable
+import kotlinx.coroutines.flow.Flow
 
 /** Data access object for database operations related to [SubmissionMutationEntity]. */
 @Dao
 interface SubmissionMutationDao : BaseDao<SubmissionMutationEntity> {
   @Query("SELECT * FROM submission_mutation")
-  fun loadAllOnceAndStream(): Flowable<List<SubmissionMutationEntity>>
+  fun getAllMutations(): Flow<List<SubmissionMutationEntity>>
 
   @Query(
     "SELECT * FROM submission_mutation " +
@@ -62,8 +61,8 @@ interface SubmissionMutationDao : BaseDao<SubmissionMutationEntity> {
     "SELECT * FROM submission_mutation " +
       "WHERE location_of_interest_id = :locationOfInterestId AND state IN (:allowedStates)"
   )
-  fun findByLocationOfInterestIdOnceAndStream(
+  fun findByLocationOfInterestIdFlow(
     locationOfInterestId: String,
     vararg allowedStates: MutationEntitySyncStatus
-  ): @Cold(terminates = false) Flowable<List<SubmissionMutationEntity>>
+  ): Flow<List<SubmissionMutationEntity>>
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/SubmissionMutationDao.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/SubmissionMutationDao.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface SubmissionMutationDao : BaseDao<SubmissionMutationEntity> {
   @Query("SELECT * FROM submission_mutation")
-  fun getAllMutations(): Flow<List<SubmissionMutationEntity>>
+  fun getAllMutationsFlow(): Flow<List<SubmissionMutationEntity>>
 
   @Query(
     "SELECT * FROM submission_mutation " +
@@ -61,7 +61,7 @@ interface SubmissionMutationDao : BaseDao<SubmissionMutationEntity> {
     "SELECT * FROM submission_mutation " +
       "WHERE location_of_interest_id = :locationOfInterestId AND state IN (:allowedStates)"
   )
-  fun findByLocationOfInterestIdFlow(
+  fun findByLoiIdFlow(
     locationOfInterestId: String,
     vararg allowedStates: MutationEntitySyncStatus
   ): Flow<List<SubmissionMutationEntity>>

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomLocationOfInterestStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomLocationOfInterestStore.kt
@@ -136,7 +136,7 @@ class RoomLocationOfInterestStore @Inject internal constructor() : LocalLocation
     }
 
   override fun getAllSurveyMutations(survey: Survey): Flow<List<LocationOfInterestMutation>> =
-    locationOfInterestMutationDao.getAllMutations().map { mutations ->
+    locationOfInterestMutationDao.getAllMutationsFlow().map { mutations ->
       mutations.filter { it.surveyId == survey.id }.map { it.toModelObject() }
     }
 

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomLocationOfInterestStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomLocationOfInterestStore.kt
@@ -36,6 +36,7 @@ import io.reactivex.Flowable
 import io.reactivex.Maybe
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 
@@ -125,22 +126,25 @@ class RoomLocationOfInterestStore @Inject internal constructor() : LocalLocation
     }
   }
 
-  override fun getLocationOfInterestMutationsByLocationOfInterestIdOnceAndStream(
+  override fun getMutationsFlow(
     locationOfInterestId: String,
     vararg allowedStates: MutationEntitySyncStatus
-  ): Flowable<List<LocationOfInterestMutation>> =
-    locationOfInterestMutationDao
-      .findByLocationOfInterestIdOnceAndStream(locationOfInterestId, *allowedStates)
-      .map { list: List<LocationOfInterestMutationEntity> -> list.map { it.toModelObject() } }
+  ): Flow<List<LocationOfInterestMutation>> =
+    locationOfInterestMutationDao.getMutationsFlow(locationOfInterestId, *allowedStates).map {
+      mutations ->
+      mutations.map { it.toModelObject() }
+    }
 
-  override fun getAllMutationsAndStream(): Flowable<List<LocationOfInterestMutationEntity>> =
-    locationOfInterestMutationDao.loadAllOnceAndStream()
+  override fun getAllSurveyMutations(survey: Survey): Flow<List<LocationOfInterestMutation>> =
+    locationOfInterestMutationDao.getAllMutations().map { mutations ->
+      mutations.filter { it.surveyId == survey.id }.map { it.toModelObject() }
+    }
 
   override suspend fun findByLocationOfInterestId(
     id: String,
     vararg states: MutationEntitySyncStatus
   ): List<LocationOfInterestMutationEntity> =
-    locationOfInterestMutationDao.findByLocationOfInterestId(id, *states) ?: listOf()
+    locationOfInterestMutationDao.getMutations(id, *states) ?: listOf()
 
   override suspend fun insertOrUpdate(loi: LocationOfInterest) =
     locationOfInterestDao.insertOrUpdate(loi.toLocalDataStoreObject())

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomSubmissionStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomSubmissionStore.kt
@@ -196,14 +196,15 @@ class RoomSubmissionStore @Inject internal constructor() : LocalSubmissionStore 
     submissionDao.findByIdSuspend(submissionId)?.let { submissionDao.delete(it) }
   }
 
-  override fun getSubmissionMutationsByLocationOfInterestIdOnceAndStream(
+  override fun getSubmissionMutationsByLoiIdFlow(
     survey: Survey,
     locationOfInterestId: String,
     vararg allowedStates: MutationEntitySyncStatus
   ): Flow<List<SubmissionMutation>> =
-    submissionMutationDao
-      .findByLocationOfInterestIdFlow(locationOfInterestId, *allowedStates)
-      .map { list: List<SubmissionMutationEntity> -> list.map { it.toModelObject(survey) } }
+    submissionMutationDao.findByLoiIdFlow(locationOfInterestId, *allowedStates).map {
+      list: List<SubmissionMutationEntity> ->
+      list.map { it.toModelObject(survey) }
+    }
 
   override suspend fun applyAndEnqueue(mutation: SubmissionMutation) {
     try {
@@ -217,8 +218,8 @@ class RoomSubmissionStore @Inject internal constructor() : LocalSubmissionStore 
     }
   }
 
-  override fun getAllSurveyMutations(survey: Survey): Flow<List<SubmissionMutation>> =
-    submissionMutationDao.getAllMutations().map { mutations ->
+  override fun getAllSurveyMutationsFlow(survey: Survey): Flow<List<SubmissionMutation>> =
+    submissionMutationDao.getAllMutationsFlow().map { mutations ->
       mutations.filter { it.surveyId == survey.id }.map { it.toModelObject(survey) }
     }
 

--- a/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalLocationOfInterestStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalLocationOfInterestStore.kt
@@ -21,7 +21,6 @@ import com.google.android.ground.model.mutation.LocationOfInterestMutation
 import com.google.android.ground.persistence.local.room.entity.LocationOfInterestMutationEntity
 import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
 import com.google.android.ground.rx.annotations.Cold
-import io.reactivex.Flowable
 import io.reactivex.Maybe
 import kotlinx.coroutines.flow.Flow
 
@@ -46,12 +45,17 @@ interface LocalLocationOfInterestStore :
    * Emits the list of [LocationOfInterestMutation] instances for a given LOI which match the
    * provided `allowedStates`. A new list is emitted on each subsequent change.
    */
-  fun getLocationOfInterestMutationsByLocationOfInterestIdOnceAndStream(
+  fun getMutationsFlow(
     locationOfInterestId: String,
     vararg allowedStates: MutationEntitySyncStatus
-  ): Flowable<List<LocationOfInterestMutation>>
+  ): Flow<List<LocationOfInterestMutation>>
 
-  fun getAllMutationsAndStream(): Flowable<List<LocationOfInterestMutationEntity>>
+  /**
+   * Returns a [Flow] that emits a [List] of all [LocationOfInterestMutation]s stored in the local
+   * db related to a given [Survey]. A new [List] is emitted on each change to the underlying saved
+   * data.
+   */
+  fun getAllSurveyMutations(survey: Survey): Flow<List<LocationOfInterestMutation>>
 
   suspend fun findByLocationOfInterestId(
     id: String,

--- a/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalSubmissionStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalSubmissionStore.kt
@@ -46,7 +46,7 @@ interface LocalSubmissionStore : LocalMutationStore<SubmissionMutation, Submissi
    * Returns a [Flow] that emits the list of [SubmissionMutation] instances for a given LOI which
    * match the provided `allowedStates`. A new list is emitted on each subsequent change.
    */
-  fun getSubmissionMutationsByLocationOfInterestIdOnceAndStream(
+  fun getSubmissionMutationsByLoiIdFlow(
     survey: Survey,
     locationOfInterestId: String,
     vararg allowedStates: MutationEntitySyncStatus
@@ -56,7 +56,7 @@ interface LocalSubmissionStore : LocalMutationStore<SubmissionMutation, Submissi
    * Returns a [Flow] that emits a list of all [SubmissionMutation]s associated with a given
    * [Survey]. The list is newly emitted each time the underlying local data changes.
    */
-  fun getAllSurveyMutations(survey: Survey): Flow<List<SubmissionMutation>>
+  fun getAllSurveyMutationsFlow(survey: Survey): Flow<List<SubmissionMutation>>
 
   suspend fun findByLocationOfInterestId(
     loidId: String,

--- a/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalSubmissionStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalSubmissionStore.kt
@@ -21,7 +21,7 @@ import com.google.android.ground.model.mutation.SubmissionMutation
 import com.google.android.ground.model.submission.Submission
 import com.google.android.ground.persistence.local.room.entity.SubmissionMutationEntity
 import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
-import io.reactivex.Flowable
+import kotlinx.coroutines.flow.Flow
 
 interface LocalSubmissionStore : LocalMutationStore<SubmissionMutation, Submission> {
   /**
@@ -43,16 +43,20 @@ interface LocalSubmissionStore : LocalMutationStore<SubmissionMutation, Submissi
   suspend fun deleteSubmission(submissionId: String)
 
   /**
-   * Emits the list of [SubmissionMutation] instances for a given LOI which match the provided
-   * `allowedStates`. A new list is emitted on each subsequent change.
+   * Returns a [Flow] that emits the list of [SubmissionMutation] instances for a given LOI which
+   * match the provided `allowedStates`. A new list is emitted on each subsequent change.
    */
   fun getSubmissionMutationsByLocationOfInterestIdOnceAndStream(
     survey: Survey,
     locationOfInterestId: String,
     vararg allowedStates: MutationEntitySyncStatus
-  ): Flowable<List<SubmissionMutation>>
+  ): Flow<List<SubmissionMutation>>
 
-  fun getAllMutationsAndStream(): Flowable<List<SubmissionMutationEntity>>
+  /**
+   * Returns a [Flow] that emits a list of all [SubmissionMutation]s associated with a given
+   * [Survey]. The list is newly emitted each time the underlying local data changes.
+   */
+  fun getAllSurveyMutations(survey: Survey): Flow<List<SubmissionMutation>>
 
   suspend fun findByLocationOfInterestId(
     loidId: String,

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -41,6 +41,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.rx2.asFlowable
+import kotlinx.coroutines.rx2.awaitSingleOrNull
 
 /**
  * Coordinates persistence and retrieval of [LocationOfInterest] instances from remote, local, and
@@ -73,6 +75,7 @@ constructor(
   }
 
   /** This only works if the survey and location of interests are already cached to local db. */
+  @Deprecated("Prefer getOfflineLocationOfInterestSuspend")
   fun getOfflineLocationOfInterest(
     surveyId: String,
     locationOfInterest: String
@@ -83,6 +86,15 @@ constructor(
       .switchIfEmpty(
         Single.error { NotFoundException("Location of interest not found $locationOfInterest") }
       )
+
+  suspend fun getOfflineLocationOfInterestSuspend(
+    surveyId: String,
+    locationOfInterest: String
+  ): LocationOfInterest =
+    localSurveyStore.getSurveyByIdSuspend(surveyId)?.let {
+      localLoiStore.getLocationOfInterest(it, locationOfInterest).awaitSingleOrNull()
+    }
+      ?: throw NotFoundException("Location of interest not found $locationOfInterest")
 
   fun createLocationOfInterest(geometry: Geometry, job: Job, surveyId: String): LocationOfInterest {
     val auditInfo = AuditInfo(authManager.currentUser)
@@ -118,12 +130,14 @@ constructor(
   fun getIncompleteLocationOfInterestMutationsOnceAndStream(
     locationOfInterestId: String
   ): Flowable<List<LocationOfInterestMutation>> =
-    localLoiStore.getLocationOfInterestMutationsByLocationOfInterestIdOnceAndStream(
-      locationOfInterestId,
-      MutationEntitySyncStatus.PENDING,
-      MutationEntitySyncStatus.IN_PROGRESS,
-      MutationEntitySyncStatus.FAILED
-    )
+    localLoiStore
+      .getMutationsFlow(
+        locationOfInterestId,
+        MutationEntitySyncStatus.PENDING,
+        MutationEntitySyncStatus.IN_PROGRESS,
+        MutationEntitySyncStatus.FAILED
+      )
+      .asFlowable()
 
   /** Returns a flow of all [LocationOfInterest] associated with the given [Survey]. */
   fun getLocationsOfInterests(survey: Survey): Flow<Set<LocationOfInterest>> =

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -87,7 +87,7 @@ constructor(
         Single.error { NotFoundException("Location of interest not found $locationOfInterest") }
       )
 
-  suspend fun getOfflineLocationOfInterestSuspend(
+  suspend fun getOfflineLoiSuspend(
     surveyId: String,
     locationOfInterest: String
   ): LocationOfInterest =
@@ -127,7 +127,7 @@ constructor(
    * have not yet been marked as [SyncStatus.COMPLETED], including pending, in progress, and failed
    * mutations. A new list is emitted on each subsequent change.
    */
-  fun getIncompleteLocationOfInterestMutationsOnceAndStream(
+  fun getIncompleteLoiMutationsOnceAndStream(
     locationOfInterestId: String
   ): Flowable<List<LocationOfInterestMutation>> =
     localLoiStore

--- a/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
@@ -51,7 +51,7 @@ constructor(
   fun getSurveyMutationsFlow(survey: Survey): Flow<List<Mutation>> {
     // TODO: Show mutations for all surveys, not just current one.
     val locationOfInterestMutations = localLocationOfInterestStore.getAllSurveyMutations(survey)
-    val submissionMutations = localSubmissionStore.getAllSurveyMutations(survey)
+    val submissionMutations = localSubmissionStore.getAllSurveyMutationsFlow(survey)
 
     return locationOfInterestMutations.combine(submissionMutations, this::combineAndSortMutations)
   }

--- a/ground/src/main/java/com/google/android/ground/repository/SubmissionRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SubmissionRepository.kt
@@ -36,7 +36,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.coroutines.rx2.rxSingle
 
@@ -141,19 +141,15 @@ constructor(
     surveyId: String,
     locationOfInterestId: String
   ): Flow<List<SubmissionMutation>> {
-    val survey = localSurveyStore.getSurveyByIdSuspend(surveyId)
+    val survey = localSurveyStore.getSurveyByIdSuspend(surveyId) ?: return flowOf()
 
-    return if (survey != null) {
-      localSubmissionStore.getSubmissionMutationsByLocationOfInterestIdOnceAndStream(
-        survey,
-        locationOfInterestId,
-        MutationEntitySyncStatus.PENDING,
-        MutationEntitySyncStatus.IN_PROGRESS,
-        MutationEntitySyncStatus.FAILED
-      )
-    } else {
-      flow {}
-    }
+    return localSubmissionStore.getSubmissionMutationsByLoiIdFlow(
+      survey,
+      locationOfInterestId,
+      MutationEntitySyncStatus.PENDING,
+      MutationEntitySyncStatus.IN_PROGRESS,
+      MutationEntitySyncStatus.FAILED
+    )
   }
 
   suspend fun getTotalSubmissionCount(loi: LocationOfInterest) =

--- a/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusViewModel.kt
@@ -64,7 +64,7 @@ internal constructor(
     mutation: Mutation
   ): Pair<LocationOfInterest, Mutation> {
     val loi =
-      locationOfInterestRepository.getOfflineLocationOfInterestSuspend(
+      locationOfInterestRepository.getOfflineLoiSuspend(
         mutation.surveyId,
         mutation.locationOfInterestId
       )

--- a/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTests.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTests.kt
@@ -137,12 +137,8 @@ class LocalDataStoreTests : BaseHiltTest() {
     advanceUntilIdle()
 
     localLoiStore
-      .getLocationOfInterestMutationsByLocationOfInterestIdOnceAndStream(
-        TEST_LOI_MUTATION.locationOfInterestId,
-        MutationEntitySyncStatus.PENDING
-      )
-      .test()
-      .assertValue(listOf(TEST_LOI_MUTATION))
+      .getMutationsFlow(TEST_LOI_MUTATION.locationOfInterestId, MutationEntitySyncStatus.PENDING)
+      .test { assertThat(expectMostRecentItem()).isEqualTo(listOf(TEST_LOI_MUTATION)) }
   }
 
   @Test
@@ -165,12 +161,11 @@ class LocalDataStoreTests : BaseHiltTest() {
     localLoiStore.applyAndEnqueue(TEST_POLYGON_LOI_MUTATION)
 
     localLoiStore
-      .getLocationOfInterestMutationsByLocationOfInterestIdOnceAndStream(
+      .getMutationsFlow(
         TEST_POLYGON_LOI_MUTATION.locationOfInterestId,
         MutationEntitySyncStatus.PENDING
       )
-      .test()
-      .assertValue(listOf(TEST_POLYGON_LOI_MUTATION))
+      .test { assertThat(expectMostRecentItem()).isEqualTo(listOf(TEST_POLYGON_LOI_MUTATION)) }
   }
 
   @Test
@@ -226,8 +221,7 @@ class LocalDataStoreTests : BaseHiltTest() {
         TEST_LOI_MUTATION.locationOfInterestId,
         MutationEntitySyncStatus.PENDING
       )
-      .test()
-      .assertValue(listOf(TEST_SUBMISSION_MUTATION))
+      .test { assertThat(expectMostRecentItem()).isEqualTo(listOf(TEST_SUBMISSION_MUTATION)) }
     val loi = localLoiStore.getLocationOfInterest(TEST_SURVEY, "loi id").blockingGet()
     var submission = localSubmissionStore.getSubmission(loi, "submission id")
     assertEquivalent(TEST_SUBMISSION_MUTATION, submission)
@@ -252,8 +246,9 @@ class LocalDataStoreTests : BaseHiltTest() {
         TEST_LOI_MUTATION.locationOfInterestId,
         MutationEntitySyncStatus.PENDING
       )
-      .test()
-      .assertValue(listOf(TEST_SUBMISSION_MUTATION, mutation))
+      .test {
+        assertThat(expectMostRecentItem()).isEqualTo(listOf(TEST_SUBMISSION_MUTATION, mutation))
+      }
 
     // check if the submission was updated in the local database
     submission = localSubmissionStore.getSubmission(loi, "submission id")

--- a/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTests.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTests.kt
@@ -216,7 +216,7 @@ class LocalDataStoreTests : BaseHiltTest() {
     localSubmissionStore.applyAndEnqueue(TEST_SUBMISSION_MUTATION)
 
     localSubmissionStore
-      .getSubmissionMutationsByLocationOfInterestIdOnceAndStream(
+      .getSubmissionMutationsByLoiIdFlow(
         TEST_SURVEY,
         TEST_LOI_MUTATION.locationOfInterestId,
         MutationEntitySyncStatus.PENDING
@@ -241,7 +241,7 @@ class LocalDataStoreTests : BaseHiltTest() {
     localSubmissionStore.applyAndEnqueue(mutation)
 
     localSubmissionStore
-      .getSubmissionMutationsByLocationOfInterestIdOnceAndStream(
+      .getSubmissionMutationsByLoiIdFlow(
         TEST_SURVEY,
         TEST_LOI_MUTATION.locationOfInterestId,
         MutationEntitySyncStatus.PENDING

--- a/ground/src/test/java/com/google/android/ground/repository/LocationOfInterestRepositoryTest.kt
+++ b/ground/src/test/java/com/google/android/ground/repository/LocationOfInterestRepositoryTest.kt
@@ -99,7 +99,7 @@ class LocationOfInterestRepositoryTest : BaseHiltTest() {
     locationOfInterestRepository.applyAndEnqueue(mutation)
 
     locationOfInterestRepository
-      .getIncompleteLocationOfInterestMutationsOnceAndStream(LOCATION_OF_INTEREST.id)
+      .getIncompleteLoiMutationsOnceAndStream(LOCATION_OF_INTEREST.id)
       .test()
       .assertNoErrors()
       .assertValue(listOf(mutation.copy(id = 1)))


### PR DESCRIPTION
Updates mutations, submission and LOI, to use FLow and suspend functions. Also updates tests accordingly. I've verified the sync UI works as expected after this change.

In one or two places, I've used RX interop to avoid needing to scope-bloat the conversions at this time, but we should be able to eliminate those calls relatively soon.