### PR TITLE
Photo Task: Fix crash on photo permissions denial.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/common/CameraPermissionDeniedDialogFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/CameraPermissionDeniedDialogFragment.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.common
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.os.Bundle
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import com.google.android.ground.R
+import com.google.android.ground.databinding.CameraPermissionDeniedDialogBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint(AbstractDialogFragment::class)
+class CameraPermissionDeniedDialogFragment : Hilt_CameraPermissionDeniedDialogFragment() {
+  private val viewModel: CameraPermissionDeniedDialogViewModel by
+    hiltNavGraphViewModels(R.id.navGraph)
+
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+    super.onCreateDialog(savedInstanceState)
+    val inflater = requireActivity().layoutInflater
+    val binding = CameraPermissionDeniedDialogBinding.inflate(inflater)
+    binding.viewModel = viewModel
+    return AlertDialog.Builder(requireActivity()).setView(binding.root).create()
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/ui/common/CameraPermissionDeniedDialogViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/CameraPermissionDeniedDialogViewModel.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.common
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CameraPermissionDeniedDialogViewModel
+@Inject
+internal constructor(private val navigator: Navigator) : AbstractViewModel() {
+  fun closeDialog() {
+    navigator.navigateUp()
+  }
+
+  fun exitDataCollectionFlow() {
+    navigator.navigate(CameraPermissionDeniedDialogFragmentDirections.showHomeScreen())
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
@@ -29,6 +29,7 @@ import com.google.android.ground.databinding.PhotoTaskFragBinding
 import com.google.android.ground.repository.UserMediaRepository
 import com.google.android.ground.system.PermissionDeniedException
 import com.google.android.ground.system.PermissionsManager
+import com.google.android.ground.ui.common.Navigator
 import com.google.android.ground.ui.datacollection.components.TaskView
 import com.google.android.ground.ui.datacollection.components.TaskViewFactory
 import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
@@ -44,6 +45,7 @@ class PhotoTaskFragment : Hilt_PhotoTaskFragment<PhotoTaskViewModel>() {
   @Inject lateinit var userMediaRepository: UserMediaRepository
   @Inject @ApplicationScope lateinit var externalScope: CoroutineScope
   @Inject lateinit var permissionsManager: PermissionsManager
+  @Inject lateinit var navigator: Navigator
 
   private lateinit var selectPhotoLauncher: ActivityResultLauncher<String>
   private lateinit var capturePhotoLauncher: ActivityResultLauncher<Uri>
@@ -113,7 +115,7 @@ class PhotoTaskFragment : Hilt_PhotoTaskFragment<PhotoTaskViewModel>() {
 
         onPermissionsGranted()
       } catch (_: PermissionDeniedException) {
-        // TODO: Handle permission denied case
+        navigator.navigate(PhotoTaskFragmentDirections.showCameraPermissionDeniedFragment())
       }
     }
   }

--- a/ground/src/main/res/layout/camera_permission_denied_dialog.xml
+++ b/ground/src/main/res/layout/camera_permission_denied_dialog.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2023 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+    <variable
+      name="viewModel"
+      type="com.google.android.ground.ui.common.CameraPermissionDeniedDialogViewModel" />
+  </data>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="20dp"
+    app:layout_constraintCircleRadius="32dp">
+
+    <TextView
+      android:id="@+id/title"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/permission_denied"
+      android:textAppearance="@style/TextAppearance.AppCompat.Large"
+      android:textColor="?attr/colorOnSurface"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+      android:id="@+id/subtitle"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="12dp"
+      android:text="@string/camera_permissions_needed"
+      android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+      android:textColor="?attr/colorOnSurfaceVariant"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/title" />
+
+    <Button
+      android:id="@+id/acknowledge"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="10dp"
+      android:layout_marginTop="32dp"
+      android:layout_marginEnd="10dp"
+      android:onClick="@{() -> viewModel.closeDialog()}"
+      android:text="@string/ok"
+      app:backgroundTint="?attr/colorPrimary"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/subtitle"
+      app:layout_constraintStart_toStartOf="parent"/>
+
+    <Button
+      android:id="@+id/close"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="10dp"
+      android:layout_marginTop="32dp"
+      android:layout_marginEnd="10dp"
+      android:onClick="@{() -> viewModel.exitDataCollectionFlow()}"
+      android:text="@string/exit"
+      app:backgroundTint="?attr/colorError"
+      app:layout_constraintTop_toBottomOf="@id/subtitle"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent" />
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/ground/src/main/res/navigation/nav_graph.xml
+++ b/ground/src/main/res/navigation/nav_graph.xml
@@ -99,6 +99,9 @@
       <argument
         android:name="jobId"
         type="string" />
+      <action
+        android:id="@+id/showCameraPermissionDeniedFragment"
+        app:destination="@id/cameraPermissionDeniedDialogFragment" />
     </fragment>
 
     <fragment
@@ -123,7 +126,11 @@
       android:id="@+id/photo_task_fragment"
       android:name="com.google.android.ground.ui.datacollection.tasks.photo.PhotoTaskFragment"
       android:label="@string/collect_data"
-      tools:layout="@layout/text_task_frag" />
+      tools:layout="@layout/text_task_frag">
+     <action
+       android:id="@+id/showCameraPermissionDeniedFragment"
+       app:destination="@id/cameraPermissionDeniedDialogFragment" />
+      </fragment>
 
     <fragment
       android:id="@+id/polygon_task_fragment"
@@ -247,4 +254,8 @@
     android:id="@+id/permissionDeniedDialogFragment"
     android:name="com.google.android.ground.ui.common.PermissionDeniedDialogFragment"
     android:label="PermissionDeniedDialogFragment" />
+  <dialog
+    android:id="@+id/cameraPermissionDeniedDialogFragment"
+    android:name="com.google.android.ground.ui.common.CameraPermissionDeniedDialogFragment"
+    android:label="CameraPermissionDeniedDialogFragment" />
 </navigation>

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
   <string name="unexpected_error">An unexpected error has occurred</string>
   <string name="google_api_install_failed">Google Play Services installation failed</string>
   <string name="sign_out">Sign out</string>
+  <string name="ok">OK</string>
+  <string name="exit">Exit</string>
   <string name="change_survey">Surveys</string>
   <string name="collect_data">Collect data</string>
 
@@ -125,4 +127,5 @@
   <string name="no_surveys_available">No surveys available. Contact your survey organizer to get access.</string>
   <string name="previous">Previous</string>
   <string name="network_error_when_signing_in">Connect to the internet to sign in</string>
+  <string name="camera_permissions_needed">You need to grant this application camera permissions to submit photos.</string>
 </resources>


### PR DESCRIPTION
Adds a new dialog that informs users that we need camera permissions to submit photos. The user can select OK and attempt a submission again by granting permissions, or exit the data collection task.

Fixes #2087.

<img width="396" alt="Screenshot 2023-12-01 at 1 38 34 PM" src="https://github.com/google/ground-android/assets/11237600/2c0c507e-fff1-43aa-878a-dbb8c4d5156b">

video: https://github.com/google/ground-android/assets/11237600/d3ca4083-9d8c-4c1c-99a3-ff5f3721ea7a


@gino-m @shobhitagarwal1612 