### PR TITLE
Handle exceptions when attempting to activate survey

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
@@ -23,6 +23,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
+import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
 import com.google.android.ground.databinding.SurveySelectorFragBinding
@@ -49,6 +50,11 @@ class SurveySelectorFragment : Hilt_SurveySelectorFragment(), BackPressListener 
     lifecycleScope.launch { viewModel.getSurveyList().collect { adapter.updateData(it) } }
     lifecycleScope.launch {
       viewModel.surveyListState.collect { state -> state?.let { handleSurveyListState(it) } }
+    }
+    lifecycleScope.launch {
+      viewModel.errorFlow.collect {
+        Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+      }
     }
   }
 

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -128,4 +128,5 @@
   <string name="previous">Previous</string>
   <string name="network_error_when_signing_in">Connect to the internet to sign in</string>
   <string name="camera_permissions_needed">You need to grant this application camera permissions to submit photos.</string>
+  <string name="error_message">Something went wrong</string>
 </resources>

--- a/ground/src/test/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragmentTest.kt
@@ -56,6 +56,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowPopupMenu
+import org.robolectric.shadows.ShadowToast
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest
@@ -139,6 +140,8 @@ class SurveySelectorFragmentTest : BaseHiltTest() {
     verify(activateSurvey).invoke(TEST_SURVEY_2.id)
     // Assert that navigation to home screen was requested
     verify(navigator).navigate(HomeScreenFragmentDirections.showHomeScreen())
+    // No error toast should be displayed
+    assertThat(ShadowToast.shownToastCount()).isEqualTo(0)
   }
 
   @Test
@@ -156,8 +159,10 @@ class SurveySelectorFragmentTest : BaseHiltTest() {
 
     // Assert survey is activated.
     verify(activateSurvey).invoke(TEST_SURVEY_2.id)
-    // Assert that navigation to home screen was requested
+    // Assert that navigation to home screen was not requested
     verify(navigator, times(0)).navigate(HomeScreenFragmentDirections.showHomeScreen())
+    // Error toast message
+    assertThat(ShadowToast.shownToastCount()).isEqualTo(1)
   }
 
   @Test

--- a/ground/src/test/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragmentTest.kt
@@ -50,6 +50,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -138,6 +139,25 @@ class SurveySelectorFragmentTest : BaseHiltTest() {
     verify(activateSurvey).invoke(TEST_SURVEY_2.id)
     // Assert that navigation to home screen was requested
     verify(navigator).navigate(HomeScreenFragmentDirections.showHomeScreen())
+  }
+
+  @Test
+  fun click_activatesSurvey_whenActiveSurveyFails() = runWithTestDispatcher {
+    whenever(activateSurvey(any())).thenThrow(Error("Some exception"))
+
+    setSurveyList(listOf(TEST_SURVEY_1, TEST_SURVEY_2))
+    setLocalSurveys(listOf())
+    setUpFragment()
+
+    // Click second item
+    onView(withId(R.id.recycler_view))
+      .perform(actionOnItemAtPosition<SurveyListAdapter.ViewHolder>(1, click()))
+    advanceUntilIdle()
+
+    // Assert survey is activated.
+    verify(activateSurvey).invoke(TEST_SURVEY_2.id)
+    // Assert that navigation to home screen was requested
+    verify(navigator, times(0)).navigate(HomeScreenFragmentDirections.showHomeScreen())
   }
 
   @Test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1497
Fixes #2095 

<!-- PR description. -->
Add exception handling if any error occurs when activating a survey in survey selector fragment. Currently it logs the exception message for debugging and shows a generic message "Something went wrong" to the user. 

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
