### PR TITLE
Render polygons opaquely when Jobs lack a default style.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/job/Job.kt
+++ b/ground/src/main/java/com/google/android/ground/model/job/Job.kt
@@ -41,5 +41,5 @@ fun Job.getDefaultColor(): Int =
     Color.parseColor(style?.color ?: "")
   } catch (t: Throwable) {
     Timber.w(t, "Invalid or missing color ${style?.color} in job $id")
-    0
+    Color.BLACK
   }


### PR DESCRIPTION
Previously, if a Job lacked a default style value, we rendered features with the color value 0. We use ARGB color format, in which this value corresponds to a completely transparent color. In result, polygons and points in a survey would not be rendered at all if a survey's job lacked a proper default style.

We now instead render features with a default, opaque black color when the job lacks default styling. This is the same behavior as the web app.

<img width="304" alt="Screenshot 2023-12-15 at 1 23 51 PM" src="https://github.com/google/ground-android/assets/11237600/110b6cbc-b4af-4b16-9ab4-3c4046a6c85d">

Fixes #2092 
