### PR TITLE
Re-anchoring progress data collection progress bar to bottom of buttons

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -46,7 +46,6 @@ class DataCollectionFragment : Hilt_DataCollectionFragment(), BackPressListener 
 
   private lateinit var binding: DataCollectionFragBinding
   private lateinit var progressBar: ProgressBar
-  private lateinit var guideline: Guideline
   private lateinit var viewPager: ViewPager2
 
   override fun onCreateView(
@@ -58,7 +57,6 @@ class DataCollectionFragment : Hilt_DataCollectionFragment(), BackPressListener 
     binding = DataCollectionFragBinding.inflate(inflater, container, false)
     viewPager = binding.pager
     progressBar = binding.progressBar
-    guideline = binding.progressBarGuideline
     getAbstractActivity().setSupportActionBar(binding.dataCollectionToolbar)
     return binding.root
   }
@@ -82,9 +80,6 @@ class DataCollectionFragment : Hilt_DataCollectionFragment(), BackPressListener 
           val buttonContainer = view.findViewById<View>(R.id.action_buttons_container) ?: return
           val anchorLocation = IntArray(2)
           buttonContainer.getLocationInWindow(anchorLocation)
-          val guidelineTop =
-            anchorLocation[1] - buttonContainer.rootWindowInsets.systemWindowInsetTop
-          guideline.setGuidelineBegin(guidelineTop)
         }
       }
     )

--- a/ground/src/main/res/layout/data_collection_frag.xml
+++ b/ground/src/main/res/layout/data_collection_frag.xml
@@ -42,6 +42,14 @@
       app:subtitleCentered="true"
       app:title="@{viewModel.jobName}" />
 
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+      android:id="@+id/progress_bar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/data_collection_toolbar" />
+
     <androidx.viewpager2.widget.ViewPager2
       android:id="@+id/pager"
       android:layout_width="match_parent"
@@ -49,21 +57,8 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/data_collection_toolbar" />
+      app:layout_constraintTop_toBottomOf="@id/progress_bar" />
 
-    <androidx.constraintlayout.widget.Guideline
-      android:id="@+id/progress_bar_guideline"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal" />
-
-    <com.google.android.material.progressindicator.LinearProgressIndicator
-      android:id="@+id/progress_bar"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="@id/progress_bar_guideline" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1975

<!-- PR description. -->
Re-anchors data collection progress bar so that it is visible.


<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Updates data collection xml to constraing progress to the bottom of the tool bar
- [x] Removes manual anchoring and refs in the fragment 

<!-- Add steps to verify bug/feature. -->
Run a survey and observe the progress bar is back.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
![Screenshot 2024-01-03 at 2 59 47 PM](https://github.com/google/ground-android/assets/77077870/03eb4b9b-65d4-4906-ac10-4b63a3c3677e)
![Screenshot 2024-01-03 at 3 00 08 PM](https://github.com/google/ground-android/assets/77077870/2f0737c6-ab95-4c01-9702-8f12d8e148d5)

@gino-m
