### PR TITLE
Hide "Undo" button in area task when drawing

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskViewModel.kt
@@ -25,7 +25,6 @@ import com.google.android.ground.model.submission.Value
 import com.google.android.ground.model.submission.isNullOrEmpty
 import com.google.android.ground.model.task.Task
 import com.google.android.ground.ui.common.AbstractViewModel
-import com.google.android.ground.ui.datacollection.tasks.polygon.DrawAreaTaskIncompleteResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -66,18 +65,11 @@ open class AbstractTaskViewModel internal constructor(private val resources: Res
     return result
   }
 
-  // TODO: Check valid values.
-  private fun validate(task: Task, value: Value?): String? {
+  open fun validate(task: Task, value: Value?): String? {
     // Empty response for a required task.
     if (task.isRequired && (value == null || value.isEmpty())) {
       return resources.getString(R.string.required_task)
     }
-
-    // Invalid response for draw area task.
-    if (task.type == Task.Type.DRAW_AREA && value is DrawAreaTaskIncompleteResult) {
-      return resources.getString(R.string.incomplete_area)
-    }
-
     return null
   }
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskViewModel.kt
@@ -26,7 +26,6 @@ import com.google.android.ground.model.submission.isNullOrEmpty
 import com.google.android.ground.model.task.Task
 import com.google.android.ground.ui.common.AbstractViewModel
 import com.google.android.ground.ui.datacollection.tasks.polygon.DrawAreaTaskIncompleteResult
-import java8.util.Optional
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -45,7 +44,7 @@ open class AbstractTaskViewModel internal constructor(private val resources: Res
   val responseText: LiveData<String>
 
   /** Error message to be displayed for the current [Value]. */
-  val error: MutableLiveData<String> = MutableLiveData()
+  val error: MutableLiveData<String?> = MutableLiveData()
 
   lateinit var task: Task
 
@@ -62,24 +61,24 @@ open class AbstractTaskViewModel internal constructor(private val resources: Res
 
   /** Checks if the current value is valid and updates error value. */
   fun validate(): String? {
-    val result = validate(task, taskValue.value).orElse(null)
+    val result = validate(task, taskValue.value)
     error.postValue(result)
     return result
   }
 
   // TODO: Check valid values.
-  private fun validate(task: Task, value: Value?): Optional<String> {
+  private fun validate(task: Task, value: Value?): String? {
     // Empty response for a required task.
     if (task.isRequired && (value == null || value.isEmpty())) {
-      return Optional.of(resources.getString(R.string.required_task))
+      return resources.getString(R.string.required_task)
     }
 
     // Invalid response for draw area task.
     if (task.type == Task.Type.DRAW_AREA && value is DrawAreaTaskIncompleteResult) {
-      return Optional.of(resources.getString(R.string.incomplete_area))
+      return resources.getString(R.string.incomplete_area)
     }
 
-    return Optional.empty()
+    return null
   }
 
   fun setValue(value: Value?) {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskViewModel.kt
@@ -25,6 +25,7 @@ import com.google.android.ground.model.submission.Value
 import com.google.android.ground.model.submission.isNullOrEmpty
 import com.google.android.ground.model.task.Task
 import com.google.android.ground.ui.common.AbstractViewModel
+import com.google.android.ground.ui.datacollection.tasks.polygon.DrawAreaTaskIncompleteResult
 import java8.util.Optional
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -67,10 +68,19 @@ open class AbstractTaskViewModel internal constructor(private val resources: Res
   }
 
   // TODO: Check valid values.
-  private fun validate(task: Task, value: Value?): Optional<String> =
-    if (task.isRequired && (value == null || value.isEmpty()))
-      Optional.of(resources.getString(R.string.required_task))
-    else Optional.empty()
+  private fun validate(task: Task, value: Value?): Optional<String> {
+    // Empty response for a required task.
+    if (task.isRequired && (value == null || value.isEmpty())) {
+      return Optional.of(resources.getString(R.string.required_task))
+    }
+
+    // Invalid response for draw area task.
+    if (task.type == Task.Type.DRAW_AREA && value is DrawAreaTaskIncompleteResult) {
+      return Optional.of(resources.getString(R.string.incomplete_area))
+    }
+
+    return Optional.empty()
+  }
 
   fun setValue(value: Value?) {
     _valueFlow.value = value

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -45,7 +45,6 @@ class DrawAreaTaskFragment : Hilt_DrawAreaTaskFragment<DrawAreaTaskViewModel>() 
   private lateinit var completeButton: TaskButton
   private lateinit var addPointButton: TaskButton
   private lateinit var nextButton: TaskButton
-  private lateinit var undoButton: TaskButton
 
   private lateinit var drawAreaTaskMapFragment: DrawAreaTaskMapFragment
 
@@ -64,7 +63,7 @@ class DrawAreaTaskFragment : Hilt_DrawAreaTaskFragment<DrawAreaTaskViewModel>() 
 
   override fun onCreateActionButtons() {
     addSkipButton()
-    undoButton = addUndoButton()
+    addUndoButton()
     nextButton = addNextButton()
     addPointButton =
       addButton(ButtonAction.ADD_POINT).setOnClickListener { viewModel.addLastVertex() }
@@ -87,6 +86,5 @@ class DrawAreaTaskFragment : Hilt_DrawAreaTaskFragment<DrawAreaTaskViewModel>() 
     addPointButton.showIfTrue(!geometry.isClosed())
     completeButton.showIfTrue(geometry.isClosed() && !viewModel.isMarkedComplete())
     nextButton.showIfTrue(viewModel.isMarkedComplete())
-    undoButton.showIfTrue(!geometry.isEmpty())
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskIncompleteResult.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskIncompleteResult.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.datacollection.tasks.polygon
+
+import com.google.android.ground.model.geometry.LineString
+import com.google.android.ground.model.submission.GeometryTaskResult
+
+/** User-provided "ongoing" response to a "draw an area" data collection [Task]. */
+data class DrawAreaTaskIncompleteResult constructor(val lineString: LineString) :
+  GeometryTaskResult(lineString) {
+  override fun isEmpty(): Boolean = lineString.isEmpty()
+}

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskResult.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskResult.kt
@@ -20,5 +20,5 @@ import com.google.android.ground.model.submission.GeometryTaskResult
 
 /** User-provided response to a "draw an area" data collection [Task]. */
 data class DrawAreaTaskResult constructor(val area: Polygon) : GeometryTaskResult(area) {
-  override fun isEmpty(): Boolean = false
+  override fun isEmpty(): Boolean = area.isEmpty()
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
@@ -17,6 +17,7 @@ package com.google.android.ground.ui.datacollection.tasks.polygon
 
 import android.content.res.Resources
 import androidx.lifecycle.viewModelScope
+import com.google.android.ground.R
 import com.google.android.ground.model.geometry.Coordinates
 import com.google.android.ground.model.geometry.LineString
 import com.google.android.ground.model.geometry.LinearRing
@@ -40,8 +41,10 @@ import kotlinx.coroutines.flow.stateIn
 @SharedViewModel
 class DrawAreaTaskViewModel
 @Inject
-internal constructor(private val uuidGenerator: OfflineUuidGenerator, resources: Resources) :
-  AbstractTaskViewModel(resources) {
+internal constructor(
+  private val uuidGenerator: OfflineUuidGenerator,
+  private val resources: Resources
+) : AbstractTaskViewModel(resources) {
 
   /** Polygon [Feature] being drawn by the user. */
   private val _draftArea: MutableStateFlow<Feature?> = MutableStateFlow(null)
@@ -171,6 +174,14 @@ internal constructor(private val uuidGenerator: OfflineUuidGenerator, resources:
           clusterable = false
         )
       }
+  }
+
+  override fun validate(task: Task, value: Value?): String? {
+    // Invalid response for draw area task.
+    if (task.type == Task.Type.DRAW_AREA && value is DrawAreaTaskIncompleteResult) {
+      return resources.getString(R.string.incomplete_area)
+    }
+    return super.validate(task, value)
   }
 
   companion object {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
@@ -102,9 +102,17 @@ internal constructor(private val uuidGenerator: OfflineUuidGenerator, resources:
     isMarkedComplete = false
 
     // Remove last vertex and update polygon
-    val updatedVertices = vertices.toMutableList()
-    updatedVertices.removeLast()
-    updateVertices(updatedVertices.toImmutableList())
+    val updatedVertices = vertices.toMutableList().apply { removeLast() }.toImmutableList()
+
+    // Render changes to UI
+    updateVertices(updatedVertices)
+
+    // Update saved response.
+    if (updatedVertices.isEmpty()) {
+      setValue(null)
+    } else {
+      setValue(DrawAreaTaskIncompleteResult(LineString(updatedVertices)))
+    }
   }
 
   /** Adds the last vertex to the polygon. */
@@ -127,6 +135,11 @@ internal constructor(private val uuidGenerator: OfflineUuidGenerator, resources:
 
     // Render changes to UI
     updateVertices(updatedVertices.toImmutableList())
+
+    // Save response iff it is user initiated
+    if (!shouldOverwriteLastVertex) {
+      setValue(DrawAreaTaskIncompleteResult(LineString(updatedVertices.toImmutableList())))
+    }
   }
 
   private fun updateVertices(newVertices: List<Coordinates>) {

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -129,4 +129,5 @@
   <string name="network_error_when_signing_in">Connect to the internet to sign in</string>
   <string name="camera_permissions_needed">You need to grant this application camera permissions to submit photos.</string>
   <string name="error_message">Something went wrong</string>
+  <string name="incomplete_area">Incomplete area</string>
 </resources>

--- a/ground/src/main/res/values/styles.xml
+++ b/ground/src/main/res/values/styles.xml
@@ -116,6 +116,7 @@
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_margin">5dp</item>
     <item name="android:paddingStart">24dp</item>
+    <item name="android:maxLines">1</item>
     <item name="android:paddingEnd">24dp</item>
     <item name="android:paddingTop">10dp</item>
     <item name="android:paddingBottom">10dp</item>

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
@@ -19,6 +19,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.google.android.ground.model.geometry.Coordinates
+import com.google.android.ground.model.geometry.LineString
 import com.google.android.ground.model.geometry.LinearRing
 import com.google.android.ground.model.geometry.Polygon
 import com.google.android.ground.model.job.Job
@@ -106,8 +107,37 @@ class DrawAreaTaskFragmentTest :
   }
 
   @Test
+  fun testDrawArea_incompleteWhenTaskIsOptional() = runWithTestDispatcher {
+    setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
+
+    updateLastVertexAndAddPoint(COORDINATE_1)
+    updateLastVertexAndAddPoint(COORDINATE_2)
+    updateLastVertexAndAddPoint(COORDINATE_3)
+
+    hasValue(
+      DrawAreaTaskIncompleteResult(
+        LineString(
+          listOf(
+            Coordinates(0.0, 0.0),
+            Coordinates(10.0, 10.0),
+            Coordinates(20.0, 20.0),
+            Coordinates(20.0, 20.0),
+          )
+        )
+      )
+    )
+
+    // Only "Undo" and "Add point" buttons should be visible.
+    buttonIsHidden("Next")
+    buttonIsHidden("Skip")
+    buttonIsEnabled(ButtonAction.UNDO)
+    buttonIsEnabled("Add point")
+    buttonIsHidden("Complete")
+  }
+
+  @Test
   fun testDrawArea() = runWithTestDispatcher {
-    setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = true))
+    setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
 
     updateLastVertexAndAddPoint(COORDINATE_1)
     updateLastVertexAndAddPoint(COORDINATE_2)
@@ -129,6 +159,13 @@ class DrawAreaTaskFragmentTest :
         )
       )
     )
+
+    // Only "Undo" and "Complete" buttons should be visible.
+    buttonIsHidden("Next")
+    buttonIsHidden("Skip")
+    buttonIsEnabled(ButtonAction.UNDO)
+    buttonIsHidden("Add point")
+    buttonIsEnabled("Complete")
   }
 
   /** Overwrites the last vertex and also adds a new one. */


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2102

<!-- PR description. -->
Default behavior of "Undo" button is to display it only when the response is empty. In draw area task, we were only persisting the response when the drawing was complete. So, we also had to override the default "undo" behavior which wasn't working as expected. 

Proposed solution in this PR:
1. Save incomplete "linestring" to response map and remove overridden "undo" behavior.
2. Add validation to prevent navigating previous/next when the current response is incomplete

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
