### PR TITLE
Don't reset viewport when resuming from data collection flow

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/common/BaseMapViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/BaseMapViewModel.kt
@@ -252,6 +252,7 @@ constructor(
     Timber.d("Camera moved : ${newCameraPosition.target}")
     lastCameraPosition = currentCameraPosition.value
     currentCameraPosition.value = newCameraPosition
+    mapStateRepository.setCameraPosition(newCameraPosition)
   }
 
   companion object {

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -53,7 +53,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @SharedViewModel
@@ -61,7 +60,7 @@ class HomeScreenMapContainerViewModel
 @Inject
 internal constructor(
   private val loiRepository: LocationOfInterestRepository,
-  private val mapStateRepository: MapStateRepository,
+  mapStateRepository: MapStateRepository,
   private val submissionRepository: SubmissionRepository,
   locationManager: LocationManager,
   settingsManager: SettingsManager,
@@ -152,9 +151,7 @@ internal constructor(
 
   override fun onMapCameraMoved(newCameraPosition: CameraPosition) {
     super.onMapCameraMoved(newCameraPosition)
-    Timber.d("Setting position to $newCameraPosition")
     onZoomChange(lastCameraPosition?.zoomLevel, newCameraPosition.zoomLevel)
-    mapStateRepository.setCameraPosition(newCameraPosition)
   }
 
   private fun onZoomChange(oldZoomLevel: Float?, newZoomLevel: Float?) {


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2173
Fixes #1892
Fixes #2163

<!-- PR description. -->
We were only persisting the current camera position to shared prefs only for home screen. This PR extends this for all map based screens (data collection tasks, offline area screen, home screen)

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
Verified by moving the map within a task and navigating back to the home screen and confirming that the viewport is not reset.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
