### PR TITLE
Add gradle task clean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,11 +97,13 @@ detekt {
     basePath = projectDir
 }
 
-task checkCode(type: GradleBuild) {
+tasks.register('checkCode', GradleBuild) {
     tasks = ['checkstyle', 'lintLocalDebug', 'ktfmtCheck', 'detekt']
 }
 
-// TODO(#2183): Add task to remove files in `build` on clean.
+tasks.register('clean', Delete) {
+    delete rootProject.buildDir
+}
 
 // https://github.com/passsy/gradle-gitVersioner-plugin
 apply plugin: "com.pascalwelsch.gitversioner"


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2183

<!-- PR description. -->
Verified at HEAD that running `gradlew clean` removes the android-ground/build dir

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
