### PR TITLE
Remove reference to hilt generated classes

### DIFF
--- a/ground/src/main/java/com/google/android/ground/MainActivity.kt
+++ b/ground/src/main/java/com/google/android/ground/MainActivity.kt
@@ -26,7 +26,15 @@ import com.google.android.ground.databinding.MainActBinding
 import com.google.android.ground.repository.UserRepository
 import com.google.android.ground.system.ActivityStreams
 import com.google.android.ground.system.SettingsManager
-import com.google.android.ground.ui.common.*
+import com.google.android.ground.ui.common.BackPressListener
+import com.google.android.ground.ui.common.EphemeralPopups
+import com.google.android.ground.ui.common.FinishApp
+import com.google.android.ground.ui.common.NavigateTo
+import com.google.android.ground.ui.common.NavigateUp
+import com.google.android.ground.ui.common.NavigationRequest
+import com.google.android.ground.ui.common.Navigator
+import com.google.android.ground.ui.common.ProgressDialogs
+import com.google.android.ground.ui.common.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import java8.util.function.Consumer
 import javax.inject.Inject
@@ -36,8 +44,8 @@ import timber.log.Timber
 /**
  * The app's main activity. The app consists of multiples Fragments that live under this activity.
  */
-@AndroidEntryPoint(AbstractActivity::class)
-class MainActivity : Hilt_MainActivity() {
+@AndroidEntryPoint
+class MainActivity : AbstractActivity() {
   @Inject lateinit var activityStreams: ActivityStreams
   @Inject lateinit var viewModelFactory: ViewModelFactory
   @Inject lateinit var settingsManager: SettingsManager
@@ -96,7 +104,7 @@ class MainActivity : Hilt_MainActivity() {
   override fun onRequestPermissionsResult(
     requestCode: Int,
     permissions: Array<String>,
-    grantResults: IntArray
+    grantResults: IntArray,
   ) {
     Timber.d("Permission result received")
     super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/ground/src/main/java/com/google/android/ground/SettingsActivity.kt
+++ b/ground/src/main/java/com/google/android/ground/SettingsActivity.kt
@@ -19,8 +19,8 @@ import android.os.Bundle
 import com.google.android.ground.databinding.SettingsActivityBinding
 import dagger.hilt.android.AndroidEntryPoint
 
-@AndroidEntryPoint(AbstractActivity::class)
-class SettingsActivity : Hilt_SettingsActivity() {
+@AndroidEntryPoint
+class SettingsActivity : AbstractActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/base/FluentCollectionReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/base/FluentCollectionReference.kt
@@ -30,7 +30,7 @@ open class FluentCollectionReference
 protected constructor(
   private val reference: CollectionReference,
   protected val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-  protected val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+  protected val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
 
   private val context = reference.firestore.app.applicationContext
@@ -42,7 +42,7 @@ protected constructor(
    */
   protected suspend fun <T> runQuery(
     query: Query,
-    mappingFunction: Function<DocumentSnapshot, T>
+    mappingFunction: Function<DocumentSnapshot, T>,
   ): List<T> {
     NetworkManager(context).requireNetworkConnection()
     val querySnapshot = query.get().await()
@@ -53,7 +53,7 @@ protected constructor(
 
   private fun <T> applyFunctionAndIgnoreFailures(
     value: DocumentSnapshot,
-    mappingFunction: Function<DocumentSnapshot, T>
+    mappingFunction: Function<DocumentSnapshot, T>,
   ): T? =
     try {
       mappingFunction.apply(value)

--- a/ground/src/main/java/com/google/android/ground/ui/common/CameraPermissionDeniedDialogFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/CameraPermissionDeniedDialogFragment.kt
@@ -23,8 +23,8 @@ import com.google.android.ground.R
 import com.google.android.ground.databinding.CameraPermissionDeniedDialogBinding
 import dagger.hilt.android.AndroidEntryPoint
 
-@AndroidEntryPoint(AbstractDialogFragment::class)
-class CameraPermissionDeniedDialogFragment : Hilt_CameraPermissionDeniedDialogFragment() {
+@AndroidEntryPoint
+class CameraPermissionDeniedDialogFragment : AbstractDialogFragment() {
   private val viewModel: CameraPermissionDeniedDialogViewModel by
     hiltNavGraphViewModels(R.id.navGraph)
 

--- a/ground/src/main/java/com/google/android/ground/ui/common/PermissionDeniedDialogFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/PermissionDeniedDialogFragment.kt
@@ -24,8 +24,8 @@ import com.google.android.ground.R
 import com.google.android.ground.databinding.PermissionDeniedDialogBinding
 import dagger.hilt.android.AndroidEntryPoint
 
-@AndroidEntryPoint(AbstractDialogFragment::class)
-class PermissionDeniedDialogFragment : Hilt_PermissionDeniedDialogFragment() {
+@AndroidEntryPoint
+class PermissionDeniedDialogFragment : AbstractDialogFragment() {
 
   private val viewModel: PermissionDeniedDialogViewModel by hiltNavGraphViewModels(R.id.navGraph)
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -37,8 +37,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 
 /** Fragment allowing the user to collect data to complete a task. */
-@AndroidEntryPoint(AbstractFragment::class)
-class DataCollectionFragment : Hilt_DataCollectionFragment(), BackPressListener {
+@AndroidEntryPoint
+class DataCollectionFragment : AbstractFragment(), BackPressListener {
   @Inject lateinit var navigator: Navigator
   @Inject lateinit var viewPagerAdapterFactory: DataCollectionViewPagerAdapterFactory
 
@@ -52,7 +52,7 @@ class DataCollectionFragment : Hilt_DataCollectionFragment(), BackPressListener 
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
     binding = DataCollectionFragBinding.inflate(inflater, container, false)

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationDialogFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationDialogFragment.kt
@@ -22,8 +22,8 @@ import com.google.android.ground.databinding.DataSubmissionConfirmationDialogBin
 import com.google.android.ground.ui.common.AbstractDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
-@AndroidEntryPoint(AbstractDialogFragment::class)
-class DataSubmissionConfirmationDialogFragment : Hilt_DataSubmissionConfirmationDialogFragment() {
+@AndroidEntryPoint
+class DataSubmissionConfirmationDialogFragment : AbstractDialogFragment() {
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     super.onCreateDialog(savedInstanceState)

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/date/DateTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/date/DateTaskFragment.kt
@@ -26,8 +26,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 import org.jetbrains.annotations.TestOnly
 
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class DateTaskFragment : Hilt_DateTaskFragment<DateTaskViewModel>() {
+@AndroidEntryPoint
+class DateTaskFragment : AbstractTaskFragment<DateTaskViewModel>() {
 
   private var datePickerDialog: DatePickerDialog? = null
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
@@ -29,9 +29,8 @@ import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class CaptureLocationTaskFragment :
-  Hilt_CaptureLocationTaskFragment<CaptureLocationTaskViewModel>() {
+@AndroidEntryPoint
+class CaptureLocationTaskFragment : AbstractTaskFragment<CaptureLocationTaskViewModel>() {
 
   @Inject lateinit var map: MapFragment
 
@@ -45,7 +44,7 @@ class CaptureLocationTaskFragment :
       .add(
         rowLayout.id,
         CaptureLocationTaskMapFragment.newInstance(viewModel, map),
-        CaptureLocationTaskMapFragment::class.java.simpleName
+        CaptureLocationTaskMapFragment::class.java.simpleName,
       )
       .commit()
     return rowLayout

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskMapFragment.kt
@@ -26,9 +26,9 @@ import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
-@AndroidEntryPoint(AbstractMapFragmentWithControls::class)
+@AndroidEntryPoint
 class CaptureLocationTaskMapFragment(private val viewModel: CaptureLocationTaskViewModel) :
-  Hilt_CaptureLocationTaskMapFragment() {
+  AbstractMapFragmentWithControls() {
 
   private lateinit var mapViewModel: CaptureLocationTaskMapViewModel
 
@@ -42,7 +42,7 @@ class CaptureLocationTaskMapFragment(private val viewModel: CaptureLocationTaskV
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View {
     val root = super.onCreateView(inflater, container, savedInstanceState)
     viewLifecycleOwner.lifecycleScope.launch {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragment.kt
@@ -29,8 +29,8 @@ import dagger.hilt.android.AndroidEntryPoint
  * Fragment allowing the user to answer single selection multiple choice questions to complete a
  * task.
  */
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class MultipleChoiceTaskFragment : Hilt_MultipleChoiceTaskFragment<MultipleChoiceTaskViewModel>() {
+@AndroidEntryPoint
+class MultipleChoiceTaskFragment : AbstractTaskFragment<MultipleChoiceTaskViewModel>() {
   private lateinit var binding: MultipleChoiceTaskFragBinding
 
   override fun onCreateTaskView(inflater: LayoutInflater): TaskView =

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/number/NumberTaskFragment.kt
@@ -24,8 +24,8 @@ import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 /** Fragment allowing the user to answer questions to complete a task. */
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class NumberTaskFragment : Hilt_NumberTaskFragment<NumberTaskViewModel>() {
+@AndroidEntryPoint
+class NumberTaskFragment : AbstractTaskFragment<NumberTaskViewModel>() {
 
   override fun onCreateTaskView(inflater: LayoutInflater): TaskView =
     TaskViewFactory.createWithHeader(layoutInflater)

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/photo/PhotoTaskFragment.kt
@@ -40,8 +40,8 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /** Fragment allowing the user to capture a photo to complete a task. */
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class PhotoTaskFragment : Hilt_PhotoTaskFragment<PhotoTaskViewModel>() {
+@AndroidEntryPoint
+class PhotoTaskFragment : AbstractTaskFragment<PhotoTaskViewModel>() {
   @Inject lateinit var userMediaRepository: UserMediaRepository
   @Inject @ApplicationScope lateinit var externalScope: CoroutineScope
   @Inject lateinit var permissionsManager: PermissionsManager

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskFragment.kt
@@ -30,8 +30,8 @@ import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class DropPinTaskFragment : Hilt_DropPinTaskFragment<DropPinTaskViewModel>() {
+@AndroidEntryPoint
+class DropPinTaskFragment : AbstractTaskFragment<DropPinTaskViewModel>() {
 
   @Inject lateinit var markerIconFactory: IconFactory
   @Inject lateinit var map: MapFragment

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskMapFragment.kt
@@ -30,9 +30,9 @@ import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
-@AndroidEntryPoint(AbstractMapFragmentWithControls::class)
+@AndroidEntryPoint
 class DropPinTaskMapFragment(private val viewModel: DropPinTaskViewModel) :
-  Hilt_DropPinTaskMapFragment() {
+  AbstractMapFragmentWithControls() {
 
   private lateinit var mapViewModel: BaseMapViewModel
   private lateinit var mapContainerViewModel: HomeScreenMapContainerViewModel
@@ -46,7 +46,7 @@ class DropPinTaskMapFragment(private val viewModel: DropPinTaskViewModel) :
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View {
     val root = super.onCreateView(inflater, container, savedInstanceState)
     binding.hintIcon.setOnClickListener {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -35,8 +35,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class DrawAreaTaskFragment : Hilt_DrawAreaTaskFragment<DrawAreaTaskViewModel>() {
+@AndroidEntryPoint
+class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
 
   @Inject lateinit var markerIconFactory: IconFactory
   @Inject lateinit var map: MapFragment

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskMapFragment.kt
@@ -26,9 +26,9 @@ import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
-@AndroidEntryPoint(AbstractMapFragmentWithControls::class)
+@AndroidEntryPoint
 class DrawAreaTaskMapFragment(private val viewModel: DrawAreaTaskViewModel) :
-  Hilt_DrawAreaTaskMapFragment() {
+  AbstractMapFragmentWithControls() {
 
   private lateinit var mapViewModel: BaseMapViewModel
   private lateinit var mapContainerViewModel: HomeScreenMapContainerViewModel

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/TextTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/text/TextTaskFragment.kt
@@ -24,8 +24,8 @@ import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 /** Fragment allowing the user to answer questions to complete a task. */
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class TextTaskFragment : Hilt_TextTaskFragment<TextTaskViewModel>() {
+@AndroidEntryPoint
+class TextTaskFragment : AbstractTaskFragment<TextTaskViewModel>() {
 
   override fun onCreateTaskView(inflater: LayoutInflater): TaskView =
     TaskViewFactory.createWithHeader(inflater)

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/time/TimeTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/time/TimeTaskFragment.kt
@@ -27,8 +27,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 import org.jetbrains.annotations.TestOnly
 
-@AndroidEntryPoint(AbstractTaskFragment::class)
-class TimeTaskFragment : Hilt_TimeTaskFragment<TimeTaskViewModel>() {
+@AndroidEntryPoint
+class TimeTaskFragment : AbstractTaskFragment<TimeTaskViewModel>() {
 
   private var timePickerDialog: TimePickerDialog? = null
 

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
@@ -16,7 +16,10 @@
 package com.google.android.ground.ui.home
 
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import androidx.core.view.GravityCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.drawerlayout.widget.DrawerLayout
@@ -28,7 +31,10 @@ import com.google.android.ground.databinding.HomeScreenFragBinding
 import com.google.android.ground.databinding.NavDrawerHeaderBinding
 import com.google.android.ground.repository.LocationOfInterestRepository
 import com.google.android.ground.repository.UserRepository
-import com.google.android.ground.ui.common.*
+import com.google.android.ground.ui.common.AbstractFragment
+import com.google.android.ground.ui.common.BackPressListener
+import com.google.android.ground.ui.common.EphemeralPopups
+import com.google.android.ground.ui.common.LocationOfInterestHelper
 import com.google.android.material.navigation.NavigationView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -39,9 +45,9 @@ import kotlinx.coroutines.launch
  * side drawer. This is the default view in the application, and gets swapped out for other
  * fragments (e.g., view submission and edit submission) at runtime.
  */
-@AndroidEntryPoint(AbstractFragment::class)
+@AndroidEntryPoint
 class HomeScreenFragment :
-  Hilt_HomeScreenFragment(), BackPressListener, NavigationView.OnNavigationItemSelectedListener {
+  AbstractFragment(), BackPressListener, NavigationView.OnNavigationItemSelectedListener {
 
   // TODO: It's not obvious which locations of interest are in HomeScreen vs MapContainer;
   //  make this more intuitive.
@@ -67,7 +73,7 @@ class HomeScreenFragment :
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
     binding = HomeScreenFragBinding.inflate(inflater, container, false)

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -53,8 +53,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /** Main app view, displaying the map and related controls (center cross-hairs, add button, etc). */
-@AndroidEntryPoint(AbstractMapContainerFragment::class)
-class HomeScreenMapContainerFragment : Hilt_HomeScreenMapContainerFragment() {
+@AndroidEntryPoint
+class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
 
   @Inject lateinit var ephemeralPopups: EphemeralPopups
   @Inject lateinit var submissionRepository: SubmissionRepository

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/MapTypeDialogFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/MapTypeDialogFragment.kt
@@ -30,8 +30,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 /** Dialog fragment containing a list of [MapType] for updating basemap layer. */
-@AndroidEntryPoint(BottomSheetDialogFragment::class)
-class MapTypeDialogFragment : Hilt_MapTypeDialogFragment() {
+@AndroidEntryPoint
+class MapTypeDialogFragment : BottomSheetDialogFragment() {
 
   @Inject lateinit var mapStateRepository: MapStateRepository
   @Inject lateinit var viewModelFactory: ViewModelFactory
@@ -51,7 +51,7 @@ class MapTypeDialogFragment : Hilt_MapTypeDialogFragment() {
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View {
     mapTypes = MapTypeDialogFragmentArgs.fromBundle(arguments!!).mapTypes.toList()
     binding = MapTypeDialogFragmentBinding.inflate(inflater, container, false)

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
@@ -64,8 +64,8 @@ const val MARKER_Z = 3f
  * Customization of Google Maps API Fragment that automatically adjusts the Google watermark based
  * on window insets.
  */
-@AndroidEntryPoint(SupportMapFragment::class)
-class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapFragment {
+@AndroidEntryPoint
+class GoogleMapsFragment : SupportMapFragment(), MapFragment {
   /** Map drag events. Emits items when the map drag has started. */
   override val startDragEvents = MutableSharedFlow<Unit>()
 
@@ -127,7 +127,7 @@ class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapFragment {
   override fun onCreateView(
     layoutInflater: LayoutInflater,
     viewGroup: ViewGroup?,
-    bundle: Bundle?
+    bundle: Bundle?,
   ): View {
     Timber.v("Lifecyle event: onCreateView()")
     return super.onCreateView(layoutInflater, viewGroup, bundle).apply {
@@ -140,7 +140,7 @@ class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapFragment {
   override fun attachToParent(
     containerFragment: AbstractFragment,
     @IdRes containerId: Int,
-    onMapReadyCallback: (MapFragment) -> Unit
+    onMapReadyCallback: (MapFragment) -> Unit,
   ) {
     containerFragment.replaceFragment(containerId, this)
     getMapAsync { googleMap: GoogleMap ->
@@ -197,7 +197,7 @@ class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapFragment {
   override fun moveCamera(coordinates: Coordinates, zoomLevel: Float, shouldAnimate: Boolean) =
     moveCamera(
       CameraUpdateFactory.newLatLngZoom(coordinates.toGoogleMapsObject(), zoomLevel),
-      shouldAnimate
+      shouldAnimate,
     )
 
   override fun moveCamera(bounds: Bounds, shouldAnimate: Boolean) =
@@ -237,7 +237,7 @@ class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapFragment {
         CameraPosition(
           cameraPosition.target.toCoordinates(),
           cameraPosition.zoom,
-          projection.visibleRegion.latLngBounds.toModelObject()
+          projection.visibleRegion.latLngBounds.toModelObject(),
         )
       )
     }
@@ -295,7 +295,7 @@ class GoogleMapsFragment : Hilt_GoogleMapsFragment(), MapFragment {
       mapOf(
         MapType.ROAD to GoogleMap.MAP_TYPE_NORMAL,
         MapType.TERRAIN to GoogleMap.MAP_TYPE_TERRAIN,
-        MapType.SATELLITE to GoogleMap.MAP_TYPE_HYBRID
+        MapType.SATELLITE to GoogleMap.MAP_TYPE_HYBRID,
       )
     private val MAP_TYPES_BY_ID = IDS_BY_MAP_TYPE.invert()
   }

--- a/ground/src/main/java/com/google/android/ground/ui/offlineareas/OfflineAreasFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/offlineareas/OfflineAreasFragment.kt
@@ -29,8 +29,8 @@ import dagger.hilt.android.AndroidEntryPoint
  * tiles. Users can manage their areas within this fragment. They can delete areas they no longer
  * need or access the UI used to select and download a new area to the device.
  */
-@AndroidEntryPoint(AbstractFragment::class)
-class OfflineAreasFragment : Hilt_OfflineAreasFragment() {
+@AndroidEntryPoint
+class OfflineAreasFragment : AbstractFragment() {
 
   private lateinit var offlineAreaListAdapter: OfflineAreaListAdapter
   private lateinit var viewModel: OfflineAreasViewModel

--- a/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/DownloadProgressDialogFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/DownloadProgressDialogFragment.kt
@@ -25,8 +25,8 @@ import com.google.android.ground.databinding.DownloadProgressDialogFragBinding
 import com.google.android.ground.ui.common.AbstractDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
-@AndroidEntryPoint(AbstractDialogFragment::class)
-class DownloadProgressDialogFragment : Hilt_DownloadProgressDialogFragment() {
+@AndroidEntryPoint
+class DownloadProgressDialogFragment : AbstractDialogFragment() {
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     val inflater = requireActivity().layoutInflater
     val binding = DownloadProgressDialogFragBinding.inflate(inflater)

--- a/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorFragment.kt
@@ -32,8 +32,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 
 /** Map UI used to select areas for download and viewing offline. */
-@AndroidEntryPoint(AbstractMapContainerFragment::class)
-class OfflineAreaSelectorFragment : Hilt_OfflineAreaSelectorFragment() {
+@AndroidEntryPoint
+class OfflineAreaSelectorFragment : AbstractMapContainerFragment() {
 
   @Inject lateinit var popups: EphemeralPopups
 

--- a/ground/src/main/java/com/google/android/ground/ui/offlineareas/viewer/OfflineAreaViewerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/offlineareas/viewer/OfflineAreaViewerFragment.kt
@@ -31,8 +31,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 
 /** The fragment provides a UI for managing a single offline area on the user's device. */
-@AndroidEntryPoint(AbstractMapContainerFragment::class)
-class OfflineAreaViewerFragment @Inject constructor() : Hilt_OfflineAreaViewerFragment() {
+@AndroidEntryPoint
+class OfflineAreaViewerFragment @Inject constructor() : AbstractMapContainerFragment() {
 
   private lateinit var viewModel: OfflineAreaViewerViewModel
 
@@ -55,7 +55,7 @@ class OfflineAreaViewerFragment @Inject constructor() : Hilt_OfflineAreaViewerFr
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
     val binding = OfflineAreaViewerFragBinding.inflate(inflater, container, false)

--- a/ground/src/main/java/com/google/android/ground/ui/signin/SignInFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/signin/SignInFragment.kt
@@ -29,8 +29,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-@AndroidEntryPoint(AbstractFragment::class)
-class SignInFragment : Hilt_SignInFragment(), BackPressListener {
+@AndroidEntryPoint
+class SignInFragment : AbstractFragment(), BackPressListener {
 
   private lateinit var binding: SignInFragBinding
   private lateinit var viewModel: SignInViewModel

--- a/ground/src/main/java/com/google/android/ground/ui/startup/StartupFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/startup/StartupFragment.kt
@@ -29,8 +29,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-@AndroidEntryPoint(AbstractFragment::class)
-class StartupFragment : Hilt_StartupFragment() {
+@AndroidEntryPoint
+class StartupFragment : AbstractFragment() {
 
   @Inject lateinit var popups: EphemeralPopups
 

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
@@ -34,8 +34,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
 /** User interface implementation of survey selector screen. */
-@AndroidEntryPoint(AbstractFragment::class)
-class SurveySelectorFragment : Hilt_SurveySelectorFragment(), BackPressListener {
+@AndroidEntryPoint
+class SurveySelectorFragment : AbstractFragment(), BackPressListener {
 
   private lateinit var viewModel: SurveySelectorViewModel
   private lateinit var binding: SurveySelectorFragBinding

--- a/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusFragment.kt
@@ -27,8 +27,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 /** Fragment containing a list of mutations and their respective upload statuses. */
-@AndroidEntryPoint(AbstractFragment::class)
-class SyncStatusFragment : Hilt_SyncStatusFragment() {
+@AndroidEntryPoint
+class SyncStatusFragment : AbstractFragment() {
 
   @Inject lateinit var locationOfInterestHelper: LocationOfInterestHelper
   lateinit var viewModel: SyncStatusViewModel

--- a/ground/src/main/java/com/google/android/ground/ui/tos/TermsOfServiceFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/tos/TermsOfServiceFragment.kt
@@ -41,7 +41,7 @@ class TermsOfServiceFragment : AbstractFragment(), BackPressListener {
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?,
+    savedInstanceState: Bundle?
   ): View {
     val binding = FragmentTermsServiceBinding.inflate(inflater, container, false)
     binding.viewModel = viewModel

--- a/ground/src/main/java/com/google/android/ground/ui/tos/TermsOfServiceFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/tos/TermsOfServiceFragment.kt
@@ -26,8 +26,8 @@ import com.google.android.ground.ui.common.EphemeralPopups
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
-@AndroidEntryPoint(AbstractFragment::class)
-class TermsOfServiceFragment : Hilt_TermsOfServiceFragment(), BackPressListener {
+@AndroidEntryPoint
+class TermsOfServiceFragment : AbstractFragment(), BackPressListener {
 
   @Inject lateinit var popups: EphemeralPopups
 
@@ -41,7 +41,7 @@ class TermsOfServiceFragment : Hilt_TermsOfServiceFragment(), BackPressListener 
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View {
     val binding = FragmentTermsServiceBinding.inflate(inflater, container, false)
     binding.viewModel = viewModel


### PR DESCRIPTION
This was added to fix jacoco test coverage issue where all classes with `@AndroidEntryPoint` annotation were reporting 0% coverage. It appears that the underlying issue has been resolved.

Context: https://github.com/google/ground-android/issues/1675

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
