### PR TITLE
Add ID formatting to job cards to parse out insignificant decimal bits

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/cards/LoiCardUtil.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/cards/LoiCardUtil.kt
@@ -23,15 +23,17 @@ import com.google.android.ground.model.geometry.Point
 import com.google.android.ground.model.geometry.Polygon
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.util.isNotNullOrEmpty
+import kotlin.math.floor
 
 /** Helper class for creating user-visible text. */
 object LoiCardUtil {
 
   fun getDisplayLoiName(context: Context, loi: LocationOfInterest): String {
     val loiId =
-      if (loi.customId.isNotNullOrEmpty()) loi.customId else loi.properties?.get("id")?.toString()
+      if (loi.customId.isNotNullOrEmpty()) loi.customId
+      else loi.properties["id"]?.toString()?.formatAsId()
     val geometry = loi.geometry
-    val name: String? = loi.properties?.get("name")?.toString()
+    val name: String? = loi.properties["name"]?.toString()
     return if (name.isNotNullOrEmpty() && loiId.isNotNullOrEmpty()) {
       "$name ($loiId)"
     } else if (name.isNotNullOrEmpty()) {
@@ -40,6 +42,23 @@ object LoiCardUtil {
       "${geometry.toType(context)} ($loiId)"
     } else {
       geometry.toDefaultName(context)
+    }
+  }
+
+  /**
+   * Converts float/double IDs into ints if the decimal portion is 0; ignores all other id types.
+   * * ex. "1234.00" -> "1234",
+   * * "1234.01" -> "1234.01",
+   * * "abcdefg" -> "abcdefg",
+   */
+  private fun String.formatAsId(): String {
+    return when {
+      toDoubleOrNull() != null && toDouble() - floor(toDouble()) == 0.0 -> {
+        String.format("%.0f", toDouble())
+      }
+      else -> {
+        this
+      }
     }
   }
 


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2137  

<!-- PR description. -->
This adds formatting to job cards so that IDs have insignificant decimals removed.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

<!-- Add steps to verify bug/feature. -->
1) Upload a LOI with an id that can be represented as a float or a double
2) Go to the survey in the app with the given jobId

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
Before:
<img width="287" alt="Screenshot 2024-01-22 at 2 23 35 PM" src="https://github.com/google/ground-android/assets/77077870/ab810f5f-20cd-4a2c-91b3-b5a6e9420de8">
After:
<img width="281" alt="Screenshot 2024-01-22 at 2 22 51 PM" src="https://github.com/google/ground-android/assets/77077870/5a133ef2-bba5-464e-882b-81510ca48999">


@gino-m  PTAL?
