### PR TITLE
Adding sign out warning dialog to the home screen

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/common/SignOutConfirmationDialogViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/SignOutConfirmationDialogViewModel.kt
@@ -1,0 +1,35 @@
+package com.google.android.ground.ui.common
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.android.ground.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SignOutConfirmationDialogViewModel
+@Inject
+internal constructor(private val navigator: Navigator, private val userRepository: UserRepository) :
+  AbstractViewModel() {
+
+  fun closeDialog() {
+    navigator.navigateUp()
+  }
+
+  fun signOut() {
+    userRepository.signOut()
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/ui/common/SignOutConfirmationFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/SignOutConfirmationFragment.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.common
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.os.Bundle
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import com.google.android.ground.R
+import com.google.android.ground.databinding.SignOutConfirmationDialogBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SignOutConfirmationFragment : AbstractDialogFragment() {
+  private val viewModel: SignOutConfirmationDialogViewModel by hiltNavGraphViewModels(R.id.navGraph)
+
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+    super.onCreateDialog(savedInstanceState)
+    val inflater = requireActivity().layoutInflater
+    val binding = SignOutConfirmationDialogBinding.inflate(inflater)
+    binding.viewModel = viewModel
+    return AlertDialog.Builder(requireActivity()).setView(binding.root).create()
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
@@ -35,6 +35,7 @@ import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.common.BackPressListener
 import com.google.android.ground.ui.common.EphemeralPopups
 import com.google.android.ground.ui.common.LocationOfInterestHelper
+import com.google.android.ground.ui.common.SignOutConfirmationFragmentDirections
 import com.google.android.material.navigation.NavigationView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -126,7 +127,7 @@ class HomeScreenFragment :
       R.id.sync_status -> homeScreenViewModel.showSyncStatus()
       R.id.nav_offline_areas -> homeScreenViewModel.showOfflineAreas()
       R.id.nav_settings -> homeScreenViewModel.showSettings()
-      R.id.nav_sign_out -> userRepository.signOut()
+      R.id.nav_sign_out -> homeScreenViewModel.showSignOutConfirmation()
     }
     closeDrawer()
     return true

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenViewModel.kt
@@ -65,4 +65,8 @@ internal constructor(
   fun showSyncStatus() {
     navigator.navigate(HomeScreenFragmentDirections.showSyncStatus())
   }
+
+  fun showSignOutConfirmation() {
+    navigator.navigate(HomeScreenFragmentDirections.showSignOutConfirmationDialogFragment())
+  }
 }

--- a/ground/src/main/res/layout/sign_out_confirmation_dialog.xml
+++ b/ground/src/main/res/layout/sign_out_confirmation_dialog.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2024 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <data>
+    <variable
+      name="viewModel"
+      type="com.google.android.ground.ui.common.SignOutConfirmationDialogViewModel" />
+  </data>
+
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="20dp"
+    app:layout_constraintCircleRadius="32dp">
+
+    <TextView
+      android:id="@+id/title"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/sign_out_question"
+      android:textAppearance="@style/TextAppearance.AppCompat.Large"
+      android:textColor="?attr/colorOnSurface"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+      android:id="@+id/warning"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="12dp"
+      android:text="@string/warning_sign_out"
+      android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/title" />
+
+    <Button
+      android:id="@+id/close"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="10dp"
+      android:layout_marginTop="32dp"
+      android:layout_marginEnd="10dp"
+      android:onClick="@{() -> viewModel.closeDialog()}"
+      android:text="@string/cancel"
+      app:backgroundTint="?attr/colorPrimary"
+      app:layout_constraintEnd_toStartOf="@+id/sign_out"
+      app:layout_constraintTop_toBottomOf="@+id/warning" />
+
+    <Button
+      android:id="@+id/sign_out"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="24dp"
+      android:onClick="@{() -> viewModel.signOut()}"
+      android:text="@string/sign_out"
+      app:backgroundTint="?attr/colorError"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/subtitle"
+      app:layout_constraintTop_toTopOf="@id/close" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/ground/src/main/res/navigation/nav_graph.xml
+++ b/ground/src/main/res/navigation/nav_graph.xml
@@ -70,6 +70,9 @@
     <action
       android:id="@+id/action_home_screen_fragment_to_dataCollectionFragment"
       app:destination="@id/data_collection" />
+    <action
+      android:id="@+id/showSignOutConfirmationDialogFragment"
+      app:destination="@id/signOutConfirmationFragment" />
   </fragment>
   <fragment
     android:id="@+id/sync_status_fragment"
@@ -253,4 +256,8 @@
     android:id="@+id/cameraPermissionDeniedDialogFragment"
     android:name="com.google.android.ground.ui.common.CameraPermissionDeniedDialogFragment"
     android:label="CameraPermissionDeniedDialogFragment" />
+  <dialog
+    android:id="@+id/signOutConfirmationFragment"
+    android:name="com.google.android.ground.ui.common.SignOutConfirmationFragment"
+    android:label="SignOutConfirmationFragment" />
 </navigation>

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -102,8 +102,10 @@
   <string name="offline_map_imagery_download_progress_dialog_message">Downloading offline map imagery…</string>
   <string name="multiple_regions">Multiple regions</string>
   <string name="permission_denied">Permission denied</string>
+  <string name="sign_out_question">Are you sure you want to sign out?</string>
   <string name="contact_survey_organizer_to_obtain_access">Contact your system administrator to request access</string>
   <string name="close_app">Close app</string>
+  <string name="cancel">Cancel</string>
   <string name="warning_sign_out">Warning: If you sign out, all unsaved data will be lost</string>
   <string name="no_imagery_available_for_area">No imagery for this area. Select an area with imagery to download to your device.</string>
   <string name="selected_offline_area_size">The selected area may take up to %s\u00A0MB of space on your device</string>


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->
Adds a sign out warning dialog informing users their unsaved data will be lost.
<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1683

<!-- PR description. -->
Adds a sign out confirmation screen to Ground, warning users that unsaved data will be lost on sign out. Currently this is only implemented for sign outs from the home screen fragment.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Adds sign out dialog, fragment and viewmodel
- [x] Replaces navigation call on home screen with launch of sign out
- [ ] Copy sign off
- [ ] Sign out from other screens
<!-- Add steps to verify bug/feature. -->
Sign out of ground from the hamburger menu and verify that the screen comes up.
Clicking cancel should exit the dialog.
Clicking sign out should sign the user out.
<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
https://github.com/google/ground-android/assets/77077870/fc4ea211-5796-4802-92bb-79e12d20d683

@shobhitagarwal1612   PTAL?
