### PR TITLE
Hide adhoc job cards if AddLoiTask is missing

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/job/Job.kt
+++ b/ground/src/main/java/com/google/android/ground/model/job/Job.kt
@@ -41,7 +41,12 @@ data class Job(
 
   fun getTask(id: String): Task = tasks[id] ?: error("Unknown task id $id")
 
-  fun getAddLoiTask(): Task? = tasks.values.firstOrNull { it.isAddLoiTask }
+  /** Job must contain at-most 1 `AddLoiTask`. */
+  fun getAddLoiTask(): Task? =
+    tasks.values
+      .filter { it.isAddLoiTask }
+      .apply { check(size <= 1) { "Expected 0 or 1, found $size AddLoiTasks" } }
+      .firstOrNull()
 
   /** Returns true if the job has one or more tasks. */
   fun hasTasks() = tasks.values.isNotEmpty()

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -130,14 +130,10 @@ internal constructor(
         .stateIn(viewModelScope, SharingStarted.Lazily, listOf())
 
     adHocLoiJobs =
-      activeSurvey
-        .combine(isZoomedInFlow) { survey, isZoomedIn -> Pair(survey, isZoomedIn) }
-        .flatMapLatest { (survey, isZoomedIn) ->
-          flowOf(
-            if (survey == null || !isZoomedIn) listOf()
-            else survey.jobs.filter { it.canDataCollectorsAddLois }
-          )
-        }
+      activeSurvey.combine(isZoomedInFlow) { survey, isZoomedIn ->
+        if (survey == null || !isZoomedIn) listOf()
+        else survey.jobs.filter { it.canDataCollectorsAddLois && it.getAddLoiTask() != null }
+      }
   }
 
   private fun updatedLoiSelectedStates(


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2176
Fixes #2192

#### Problem

Jobs without any tasks with `isAddLoiTask` bit are also getting included for `adHocLoiJobs`, causing problems when attempting to save the data.

#### Proposed solution

Don't include jobs for adhoc data collection if the job doesn't contain any tasks with `isAddLoiTask` set to true. Also add another validation to confirm that the job must contain exactly one add loi task

<!-- PR description. -->
#### Background

Steps for collecting data for `AdhocLoiJobs`:
1. App displays a job card without an LOI if it's data collection strategy is `AD_HOC`, `MIXED`, or `UNKNOWN`.
2. User clicks the job card
3. After data collection, the app first tries to create a new LOI
4. It attempts to get the first task with `isAddLoiTask` bit set to true. Else throws an exception.
5. After LOI is saved, it enqueues a new submission using the LOI created in the previous step.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m @scolsen  PTAL?
