### PR TITLE
Job: Return null on unknown tasks

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/job/Job.kt
+++ b/ground/src/main/java/com/google/android/ground/model/job/Job.kt
@@ -33,17 +33,13 @@ data class Job(
     UNKNOWN
   }
 
-  class TaskNotFoundException(taskId: String) : Throwable(message = "unknown task $taskId")
-
   val canDataCollectorsAddLois: Boolean
     get() = strategy != DataCollectionStrategy.PREDEFINED
 
   val tasksSorted: List<Task>
     get() = tasks.values.sortedBy { it.index }
 
-  // TODO(#2216): Consider using nulls to indicate absence of value here instead of throwing
-  // an exception.
-  fun getTask(id: String): Task = tasks[id] ?: throw TaskNotFoundException(id)
+  fun getTask(id: String): Task? = tasks[id]
 
   /** Job must contain at-most 1 `AddLoiTask`. */
   fun getAddLoiTask(): Task? =

--- a/ground/src/main/java/com/google/android/ground/model/job/Job.kt
+++ b/ground/src/main/java/com/google/android/ground/model/job/Job.kt
@@ -33,13 +33,15 @@ data class Job(
     UNKNOWN
   }
 
+  class TaskNotFoundException(taskId: String): Throwable(message = "unknown task $taskId")
+
   val canDataCollectorsAddLois: Boolean
     get() = strategy != DataCollectionStrategy.PREDEFINED
 
   val tasksSorted: List<Task>
     get() = tasks.values.sortedBy { it.index }
 
-  fun getTask(id: String): Task = tasks[id] ?: error("Unknown task id $id")
+  fun getTask(id: String): Task = tasks[id] ?: throw TaskNotFoundException(id)
 
   fun getAddLoiTask(): Task? = tasks.values.firstOrNull { it.isAddLoiTask }
 

--- a/ground/src/main/java/com/google/android/ground/model/job/Job.kt
+++ b/ground/src/main/java/com/google/android/ground/model/job/Job.kt
@@ -41,6 +41,8 @@ data class Job(
   val tasksSorted: List<Task>
     get() = tasks.values.sortedBy { it.index }
 
+  // TODO(#2216): Consider using nulls to indicate absence of value here instead of throwing
+  // an exception.
   fun getTask(id: String): Task = tasks[id] ?: throw TaskNotFoundException(id)
 
   fun getAddLoiTask(): Task? = tasks.values.firstOrNull { it.isAddLoiTask }

--- a/ground/src/main/java/com/google/android/ground/model/job/Job.kt
+++ b/ground/src/main/java/com/google/android/ground/model/job/Job.kt
@@ -33,7 +33,7 @@ data class Job(
     UNKNOWN
   }
 
-  class TaskNotFoundException(taskId: String): Throwable(message = "unknown task $taskId")
+  class TaskNotFoundException(taskId: String) : Throwable(message = "unknown task $taskId")
 
   val canDataCollectorsAddLois: Boolean
     get() = strategy != DataCollectionStrategy.PREDEFINED

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/SubmissionDataConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/SubmissionDataConverter.kt
@@ -54,12 +54,10 @@ object SubmissionDataConverter {
       while (keys.hasNext()) {
         try {
           val taskId = keys.next()
-          val task = job.getTask(taskId)
+          val task = job.getTask(taskId) ?: continue
           ValueJsonConverter.toResponse(task, jsonObject[taskId])?.let { map[taskId] = it }
         } catch (e: LocalDataConsistencyException) {
           Timber.d("Bad submission data in local db: ${e.message}")
-        } catch (e: Job.TaskNotFoundException) {
-          Timber.d(e, "Ignoring data for unknown task")
         }
       }
     } catch (e: JSONException) {

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/SubmissionDataConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/SubmissionDataConverter.kt
@@ -58,6 +58,8 @@ object SubmissionDataConverter {
           ValueJsonConverter.toResponse(task, jsonObject[taskId])?.let { map[taskId] = it }
         } catch (e: LocalDataConsistencyException) {
           Timber.d("Bad submission data in local db: ${e.message}")
+        } catch (e: Job.TaskNotFoundException) {
+          Timber.d(e, "Ignoring data for unknown task")
         }
       }
     } catch (e: JSONException) {

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/SubmissionDeltasConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/SubmissionDeltasConverter.kt
@@ -77,6 +77,8 @@ object SubmissionDeltasConverter {
           Timber.d("Bad submission value in local db: " + e.message)
         } catch (e: DataStoreException) {
           Timber.d("Bad submission value in local db: " + e.message)
+        } catch (e: Job.TaskNotFoundException) {
+          Timber.d(e, "Ignoring delta for unknown task")
         }
       }
     } catch (e: JSONException) {

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/SubmissionDeltasConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/SubmissionDeltasConverter.kt
@@ -64,7 +64,7 @@ object SubmissionDeltasConverter {
       while (keys.hasNext()) {
         try {
           val taskId = keys.next()
-          val task = job.getTask(taskId)
+          val task = job.getTask(taskId) ?: continue
           val jsonDelta = jsonObject.getJSONObject(taskId)
           deltas.add(
             ValueDelta(
@@ -77,8 +77,6 @@ object SubmissionDeltasConverter {
           Timber.d("Bad submission value in local db: " + e.message)
         } catch (e: DataStoreException) {
           Timber.d("Bad submission value in local db: " + e.message)
-        } catch (e: Job.TaskNotFoundException) {
-          Timber.d(e, "Ignoring delta for unknown task")
         }
       }
     } catch (e: JSONException) {

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/SubmissionConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/SubmissionConverter.kt
@@ -85,23 +85,22 @@ internal object SubmissionConverter {
   }
 
   private fun putValue(taskId: String, job: Job, obj: Any, data: MutableMap<String, Value>) {
-    try {
-      val task = job.getTask(taskId)
-      when (task.type) {
-        Task.Type.PHOTO,
-        Task.Type.TEXT -> putTextResponse(taskId, obj, data)
-        Task.Type.MULTIPLE_CHOICE ->
-          putMultipleChoiceResponse(taskId, task.multipleChoice, obj, data)
-        Task.Type.NUMBER -> putNumberResponse(taskId, obj, data)
-        Task.Type.DATE -> putDateResponse(taskId, obj, data)
-        Task.Type.TIME -> putTimeResponse(taskId, obj, data)
-        Task.Type.DROP_PIN -> putDropPinTaskResult(taskId, obj, data)
-        Task.Type.DRAW_AREA -> putDrawAreaTaskResult(taskId, obj, data)
-        Task.Type.CAPTURE_LOCATION -> putCaptureLocationResult(taskId, obj, data)
-        else -> throw DataStoreException("Unknown type " + task.type)
-      }
-    } catch (e: Job.TaskNotFoundException) {
-      Timber.d(e, "cannot put value for unknown task")
+    val task = job.getTask(taskId)
+    if (task == null) {
+      Timber.d("ignorning unknown task: $taskId")
+      return
+    }
+    when (task.type) {
+      Task.Type.PHOTO,
+      Task.Type.TEXT -> putTextResponse(taskId, obj, data)
+      Task.Type.MULTIPLE_CHOICE -> putMultipleChoiceResponse(taskId, task.multipleChoice, obj, data)
+      Task.Type.NUMBER -> putNumberResponse(taskId, obj, data)
+      Task.Type.DATE -> putDateResponse(taskId, obj, data)
+      Task.Type.TIME -> putTimeResponse(taskId, obj, data)
+      Task.Type.DROP_PIN -> putDropPinTaskResult(taskId, obj, data)
+      Task.Type.DRAW_AREA -> putDrawAreaTaskResult(taskId, obj, data)
+      Task.Type.CAPTURE_LOCATION -> putCaptureLocationResult(taskId, obj, data)
+      else -> throw DataStoreException("Unknown type " + task.type)
     }
   }
 

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/SubmissionConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/SubmissionConverter.kt
@@ -85,18 +85,23 @@ internal object SubmissionConverter {
   }
 
   private fun putValue(taskId: String, job: Job, obj: Any, data: MutableMap<String, Value>) {
-    val task = job.getTask(taskId)
-    when (task.type) {
-      Task.Type.PHOTO,
-      Task.Type.TEXT -> putTextResponse(taskId, obj, data)
-      Task.Type.MULTIPLE_CHOICE -> putMultipleChoiceResponse(taskId, task.multipleChoice, obj, data)
-      Task.Type.NUMBER -> putNumberResponse(taskId, obj, data)
-      Task.Type.DATE -> putDateResponse(taskId, obj, data)
-      Task.Type.TIME -> putTimeResponse(taskId, obj, data)
-      Task.Type.DROP_PIN -> putDropPinTaskResult(taskId, obj, data)
-      Task.Type.DRAW_AREA -> putDrawAreaTaskResult(taskId, obj, data)
-      Task.Type.CAPTURE_LOCATION -> putCaptureLocationResult(taskId, obj, data)
-      else -> throw DataStoreException("Unknown type " + task.type)
+    try {
+      val task = job.getTask(taskId)
+      when (task.type) {
+        Task.Type.PHOTO,
+        Task.Type.TEXT -> putTextResponse(taskId, obj, data)
+        Task.Type.MULTIPLE_CHOICE ->
+          putMultipleChoiceResponse(taskId, task.multipleChoice, obj, data)
+        Task.Type.NUMBER -> putNumberResponse(taskId, obj, data)
+        Task.Type.DATE -> putDateResponse(taskId, obj, data)
+        Task.Type.TIME -> putTimeResponse(taskId, obj, data)
+        Task.Type.DROP_PIN -> putDropPinTaskResult(taskId, obj, data)
+        Task.Type.DRAW_AREA -> putDrawAreaTaskResult(taskId, obj, data)
+        Task.Type.CAPTURE_LOCATION -> putCaptureLocationResult(taskId, obj, data)
+        else -> throw DataStoreException("Unknown type " + task.type)
+      }
+    } catch (e: Job.TaskNotFoundException) {
+      Timber.d(e, "cannot put value for unknown task")
     }
   }
 


### PR DESCRIPTION
Return null when attempting to retrieve unknown tasks from a Job (instead of throwing an exception). Updates callers accordingly.

NOTE: Depends on https://github.com/google/ground-android/pull/2214

Fixes #2216