### PR TITLE
[Data Collection] Show instructions dialog for draw area task when opened for the first time

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -346,7 +346,7 @@ naming:
     FunctionNaming:
         active: true
         excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
-        functionPattern: '[a-z][a-zA-Z0-9]*'
+        functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
         excludeClassPattern: '$^'
     FunctionParameterNaming:
         active: true

--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -140,8 +140,12 @@ android {
 
     buildFeatures {
         buildConfig true
+        compose true
         dataBinding true
         viewBinding true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion "1.5.5"
     }
     testOptions {
         unitTests {
@@ -182,9 +186,11 @@ dependencies {
 
     // UI widgets.
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation "androidx.compose.material3:material3:1.1.0"
+    implementation 'androidx.compose.ui:ui:1.6.1'
+    implementation 'androidx.compose.compiler:compiler:1.5.9'
+    implementation 'androidx.compose.material3:material3-android:1.2.0'
 
     // Google Play Services.
     implementation 'com.google.android.gms:play-services-auth:20.6.0'

--- a/ground/src/main/java/com/google/android/ground/persistence/local/LocalValueStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/LocalValueStore.kt
@@ -85,6 +85,13 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
       _offlineImageryEnabled.value = value
     }
 
+  /** Whether to display instructions when loading draw area task. */
+  var drawAreaInstructionsShown: Boolean
+    get() = allowThreadDiskReads { preferences.getBoolean(DRAW_AREA_INSTRUCTIONS_SHOWN, false) }
+    set(value) = allowThreadDiskReads {
+      preferences.edit().putBoolean(DRAW_AREA_INSTRUCTIONS_SHOWN, value).apply()
+    }
+
   /** Removes all values stored in the local store. */
   fun clear() = allowThreadDiskWrites { preferences.edit().clear().apply() }
 
@@ -120,5 +127,6 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
     const val TOS_ACCEPTED = "tos_accepted"
     const val LOCATION_LOCK_ENABLED = "location_lock_enabled"
     const val OFFLINE_MAP_IMAGERY = "offline_map_imagery"
+    const val DRAW_AREA_INSTRUCTIONS_SHOWN = "draw_area_instructions_shown"
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -19,6 +19,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
@@ -34,6 +35,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
 import com.google.android.ground.model.geometry.LineString
@@ -137,7 +139,7 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
           modifier = Modifier.width(48.dp).height(48.dp),
         )
       },
-      title = { Text(text = getString(R.string.draw_area_task_instruction)) },
+      title = { StyledText(getText(R.string.draw_area_task_instruction)) },
       onDismissRequest = {}, // Prevent dismissing the dialog by clicking outside
       confirmButton = {}, // Hide confirm button
       dismissButton = {
@@ -147,6 +149,21 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
             color = Color(MaterialColors.getColor(context, R.attr.colorPrimary, "")),
           )
         }
+      },
+    )
+  }
+
+  /**
+   * Supports annotated texts e.g. <b>Hello world</b>
+   */
+  @Composable
+  private fun StyledText(text: CharSequence, modifier: Modifier = Modifier) {
+    AndroidView(
+      modifier = modifier,
+      factory = { context -> TextView(context) },
+      update = {
+        it.text = text
+        it.textSize = 18.toFloat()
       },
     )
   }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
@@ -26,6 +26,7 @@ import com.google.android.ground.model.job.Job
 import com.google.android.ground.model.job.getDefaultColor
 import com.google.android.ground.model.submission.Value
 import com.google.android.ground.model.task.Task
+import com.google.android.ground.persistence.local.LocalValueStore
 import com.google.android.ground.persistence.uuid.OfflineUuidGenerator
 import com.google.android.ground.ui.common.SharedViewModel
 import com.google.android.ground.ui.datacollection.tasks.AbstractTaskViewModel
@@ -42,14 +43,18 @@ import kotlinx.coroutines.flow.stateIn
 class DrawAreaTaskViewModel
 @Inject
 internal constructor(
+  private val localValueStore: LocalValueStore,
   private val uuidGenerator: OfflineUuidGenerator,
-  private val resources: Resources
+  private val resources: Resources,
 ) : AbstractTaskViewModel(resources) {
 
   /** Polygon [Feature] being drawn by the user. */
   private val _draftArea: MutableStateFlow<Feature?> = MutableStateFlow(null)
   val draftArea: StateFlow<Feature?> =
     _draftArea.stateIn(viewModelScope, started = SharingStarted.Lazily, null)
+
+  /** Whether the instructions dialog has been shown or not. */
+  var instructionsDialogShown: Boolean by localValueStore::drawAreaInstructionsShown
 
   /**
    * User-specified vertices of the area being drawn. If [isMarkedComplete] is false, then the last
@@ -76,7 +81,7 @@ internal constructor(
    */
   fun updateLastVertexAndMaybeCompletePolygon(
     target: Coordinates,
-    calculateDistanceInPixels: (c1: Coordinates, c2: Coordinates) -> Double
+    calculateDistanceInPixels: (c1: Coordinates, c2: Coordinates) -> Double,
   ) {
     check(!isMarkedComplete) { "Attempted to update last vertex after completing the drawing" }
 
@@ -172,7 +177,7 @@ internal constructor(
           geometry = LineString(vertices),
           style = Feature.Style(strokeColor, Feature.VertexStyle.CIRCLE),
           clusterable = false,
-          selected = true
+          selected = true,
         )
       }
   }

--- a/ground/src/main/res/drawable/touch_app_24.xml
+++ b/ground/src/main/res/drawable/touch_app_24.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2024 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:tint="?attr/colorControlNormal"
+  android:viewportWidth="960"
+  android:viewportHeight="960">
+  <path
+    android:fillColor="@android:color/white"
+    android:pathData="M419,880Q391,880 366.5,868Q342,856 325,834L107,557L126,537Q146,516 174,512Q202,508 226,523L300,568L300,240Q300,223 311.5,211.5Q323,200 340,200Q357,200 369,211.5Q381,223 381,240L381,712L284,652L388,785Q394,792 402,796Q410,800 419,800L640,800Q673,800 696.5,776.5Q720,753 720,720L720,560Q720,543 708.5,531.5Q697,520 680,520L461,520L461,440L680,440Q730,440 765,475Q800,510 800,560L800,720Q800,786 753,833Q706,880 640,880L419,880ZM167,340Q154,318 147,292.5Q140,267 140,240Q140,157 198.5,98.5Q257,40 340,40Q423,40 481.5,98.5Q540,157 540,240Q540,267 533,292.5Q526,318 513,340L444,300Q452,286 456,271.5Q460,257 460,240Q460,190 425,155Q390,120 340,120Q290,120 255,155Q220,190 220,240Q220,257 224,271.5Q228,286 236,300L167,340ZM502,620L502,620L502,620L502,620Q502,620 502,620Q502,620 502,620L502,620Q502,620 502,620Q502,620 502,620L502,620Q502,620 502,620Q502,620 502,620L502,620L502,620L502,620Z" />
+</vector>

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -133,6 +133,6 @@
   <string name="error_message">Something went wrong</string>
   <string name="incomplete_area">Incomplete area</string>
   <string name="initializing">Initializing…</string>
-  <string name="draw_area_task_instruction">Move the map and tap the \"Add\" button to add points around the desired area.</string>
+  <string name="draw_area_task_instruction">Move the map and tap the “Add” button to add points around the desired area.</string>
   <string name="close">Close</string>
 </resources>

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -132,7 +132,7 @@
   <string name="error_message">Something went wrong</string>
   <string name="incomplete_area">Incomplete area</string>
   <string name="initializing">Initializing…</string>
-  <string name="draw_area_task_instruction">Move the map and tap the “Add” button to add points around the desired area.</string>
+  <string name="draw_area_task_instruction">Move the map and tap <b>Add point</b> to mark this location.</string>
   <string name="close">Close</string>
   <string name="map_location">Map location</string>
   <string name="sign_out_dialog_title">Unsynced data</string>

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -133,4 +133,6 @@
   <string name="error_message">Something went wrong</string>
   <string name="incomplete_area">Incomplete area</string>
   <string name="initializing">Initializing…</string>
+  <string name="draw_area_task_instruction">Move the map and tap the \"Add\" button to add points around the desired area.</string>
+  <string name="close">Close</string>
 </resources>

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
@@ -29,14 +29,15 @@ import com.google.android.ground.ui.common.ViewModelFactory
 import com.google.android.ground.ui.datacollection.DataCollectionViewModel
 import com.google.android.ground.ui.datacollection.components.ButtonAction
 import com.google.android.ground.ui.datacollection.tasks.BaseTaskFragmentTest
+import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
-import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowDialog
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
@@ -52,7 +53,7 @@ class DrawAreaTaskFragmentTest :
       index = 0,
       type = Task.Type.DRAW_AREA,
       label = "Task for drawing a polygon",
-      isRequired = false
+      isRequired = false,
     )
   private val job = Job("job", Style("#112233"))
 
@@ -80,7 +81,7 @@ class DrawAreaTaskFragmentTest :
       ButtonAction.UNDO,
       ButtonAction.NEXT,
       ButtonAction.ADD_POINT,
-      ButtonAction.COMPLETE
+      ButtonAction.COMPLETE,
     )
   }
 
@@ -109,6 +110,9 @@ class DrawAreaTaskFragmentTest :
   @Test
   fun testDrawArea_incompleteWhenTaskIsOptional() = runWithTestDispatcher {
     setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
+
+    // Dismiss the instructions dialog
+    ShadowDialog.getLatestDialog().dismiss()
 
     updateLastVertexAndAddPoint(COORDINATE_1)
     updateLastVertexAndAddPoint(COORDINATE_2)
@@ -139,6 +143,9 @@ class DrawAreaTaskFragmentTest :
   fun testDrawArea() = runWithTestDispatcher {
     setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
 
+    // Dismiss the instructions dialog
+    ShadowDialog.getLatestDialog().dismiss()
+
     updateLastVertexAndAddPoint(COORDINATE_1)
     updateLastVertexAndAddPoint(COORDINATE_2)
     updateLastVertexAndAddPoint(COORDINATE_3)
@@ -153,7 +160,7 @@ class DrawAreaTaskFragmentTest :
               Coordinates(0.0, 0.0),
               Coordinates(10.0, 10.0),
               Coordinates(20.0, 20.0),
-              Coordinates(0.0, 0.0)
+              Coordinates(0.0, 0.0),
             )
           )
         )
@@ -166,6 +173,25 @@ class DrawAreaTaskFragmentTest :
     buttonIsEnabled(ButtonAction.UNDO)
     buttonIsHidden("Add point")
     buttonIsEnabled("Complete")
+  }
+
+  @Test
+  fun `Instructions dialog is shown`() = runWithTestDispatcher {
+    setupTaskFragment<DrawAreaTaskFragment>(job, task)
+
+    assertThat(ShadowDialog.getLatestDialog()).isNotNull()
+  }
+
+  @Test
+  fun `Instructions dialog is not shown if shown previously`() = runWithTestDispatcher {
+    setupTaskFragment<DrawAreaTaskFragment>(job, task)
+
+    viewModel.instructionsDialogShown = true
+    ShadowDialog.reset()
+
+    setupTaskFragment<DrawAreaTaskFragment>(job, task)
+
+    assertThat(ShadowDialog.getLatestDialog()).isNull()
   }
 
   /** Overwrites the last vertex and also adds a new one. */


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2223

Uses jetpack compose to display an alert dialog when draw area task is opened for the first time by the user.

<!-- PR description. -->
[draw_area_instructions.webm](https://github.com/google/ground-android/assets/8918023/3e287dac-c890-44b0-884e-e077b2c1f26f)


<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
