### PR TITLE
Process mutations in the order in which they were created

### DIFF
--- a/ground/src/main/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorker.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorker.kt
@@ -23,9 +23,7 @@ import androidx.work.ListenableWorker.Result.retry
 import androidx.work.ListenableWorker.Result.success
 import androidx.work.WorkerParameters
 import com.google.android.ground.model.User
-import com.google.android.ground.model.mutation.LocationOfInterestMutation
 import com.google.android.ground.model.mutation.Mutation
-import com.google.android.ground.model.mutation.Mutation.Type.CREATE
 import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
 import com.google.android.ground.persistence.local.stores.LocalUserStore
 import com.google.android.ground.persistence.remote.RemoteDataStore
@@ -96,11 +94,7 @@ constructor(
     val userIds = mutationsByUserId.keys
     var noErrors = true
     for (userId in userIds) {
-      // Handle "Create LOI" mutations first.
-      val mutations =
-        mutationsByUserId[userId]?.sortedBy {
-          it is LocationOfInterestMutation && it.type == CREATE
-        }
+      val mutations = mutationsByUserId[userId]
       val user = getUser(userId)
       if (mutations == null || user == null) {
         continue

--- a/ground/src/main/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorker.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorker.kt
@@ -23,7 +23,9 @@ import androidx.work.ListenableWorker.Result.retry
 import androidx.work.ListenableWorker.Result.success
 import androidx.work.WorkerParameters
 import com.google.android.ground.model.User
+import com.google.android.ground.model.mutation.LocationOfInterestMutation
 import com.google.android.ground.model.mutation.Mutation
+import com.google.android.ground.model.mutation.Mutation.Type.CREATE
 import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
 import com.google.android.ground.persistence.local.stores.LocalUserStore
 import com.google.android.ground.persistence.remote.RemoteDataStore
@@ -94,7 +96,11 @@ constructor(
     val userIds = mutationsByUserId.keys
     var noErrors = true
     for (userId in userIds) {
-      val mutations = mutationsByUserId[userId]
+      // Handle "Create LOI" mutations first.
+      val mutations =
+        mutationsByUserId[userId]?.sortedBy {
+          it is LocationOfInterestMutation && it.type == CREATE
+        }
       val user = getUser(userId)
       if (mutations == null || user == null) {
         continue

--- a/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
@@ -67,21 +67,21 @@ constructor(
 
   /**
    * Returns all LOI and submission mutations in the local mutation queue relating to LOI with the
-   * specified id.
+   * specified id, sorted by creation timestamp (oldest first).
    */
   suspend fun getMutations(
-    loidId: String,
+    loiId: String,
     vararg entitySyncStatus: MutationEntitySyncStatus
   ): List<Mutation> {
     val loiMutations =
       localLocationOfInterestStore
-        .findByLocationOfInterestId(loidId, *entitySyncStatus)
+        .findByLocationOfInterestId(loiId, *entitySyncStatus)
         .map(LocationOfInterestMutationEntity::toModelObject)
     val submissionMutations =
-      localSubmissionStore.findByLocationOfInterestId(loidId, *entitySyncStatus).map {
+      localSubmissionStore.findByLocationOfInterestId(loiId, *entitySyncStatus).map {
         it.toSubmissionMutation()
       }
-    return loiMutations + submissionMutations
+    return (loiMutations + submissionMutations).sortedBy { it.clientTimestamp }
   }
 
   private suspend fun SubmissionMutationEntity.toSubmissionMutation(): SubmissionMutation =

--- a/ground/src/test/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorkerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorkerTest.kt
@@ -43,6 +43,7 @@ import com.sharedtest.persistence.remote.FakeRemoteDataStore
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
@@ -60,10 +61,15 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
   @Mock private lateinit var mockMediaUploadWorkManager: MediaUploadWorkManager
 
   @Inject lateinit var fakeRemoteDataStore: FakeRemoteDataStore
+
   @Inject lateinit var localLocationOfInterestStore: LocalLocationOfInterestStore
+
   @Inject lateinit var localSubmissionStore: LocalSubmissionStore
+
   @Inject lateinit var localSurveyStore: LocalSurveyStore
+
   @Inject lateinit var localUserStore: LocalUserStore
+
   @Inject lateinit var mutationRepository: MutationRepository
 
   private val factory =
@@ -87,6 +93,10 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
   override fun setUp() {
     super.setUp()
     context = ApplicationProvider.getApplicationContext()
+    runBlocking {
+      localUserStore.insertOrUpdateUser(FakeData.USER.copy(id = TEST_USER_ID))
+      localSurveyStore.insertOrUpdateSurvey(FakeData.SURVEY.copy(id = TEST_SURVEY_ID))
+    }
   }
 
   @Test
@@ -187,18 +197,7 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
   }
 
   private suspend fun addPendingMutations() {
-    localUserStore.insertOrUpdateUser(FakeData.USER.copy(id = TEST_USER_ID))
-    localSurveyStore.insertOrUpdateSurvey(FakeData.SURVEY.copy(id = TEST_SURVEY_ID))
-
-    addPendingLois()
-    addPendingSubmission()
-  }
-
-  private suspend fun addPendingLois() {
     localLocationOfInterestStore.applyAndEnqueue(createLoiMutation())
-  }
-
-  private suspend fun addPendingSubmission() {
     localSubmissionStore.applyAndEnqueue(createSubmissionMutation())
   }
 


### PR DESCRIPTION
Fixes #2129.

Not sure how to test this, open to suggestions.

This also ensures "create LOI" occurs before "create submission". See #2235 for additional fixes.

@shobhitagarwal1612 PTAL?