### PR TITLE
Prevent horizontal scrolling for map type selector

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -153,9 +153,7 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
     )
   }
 
-  /**
-   * Supports annotated texts e.g. <b>Hello world</b>
-   */
+  /** Supports annotated texts e.g. <b>Hello world</b> */
   @Composable
   private fun StyledText(text: CharSequence, modifier: Modifier = Modifier) {
     AndroidView(

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/AdaptiveSpacingItemDecorator.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/AdaptiveSpacingItemDecorator.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.ground.ui.home.mapcontainer
+
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * Provides equal spacing between recycler view items in portrait mode. Otherwise, uses the given
+ * [defaultSpacing].
+ */
+class AdaptiveSpacingItemDecorator(resources: Resources, private val defaultSpacing: Int) :
+  RecyclerView.ItemDecoration() {
+
+  private val isPortraitMode =
+    resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+
+  override fun getItemOffsets(
+    outRect: Rect,
+    view: View,
+    parent: RecyclerView,
+    state: RecyclerView.State,
+  ) {
+    val position = parent.getChildAdapterPosition(view)
+    val itemCount = state.itemCount
+
+    // Skip last item
+    if (position == itemCount - 1) {
+      return
+    }
+
+    outRect.right =
+      if (isPortraitMode) calculateSpacing(view, parent, itemCount) else defaultSpacing
+  }
+
+  /** Calculates the spacing between items based on available empty space. */
+  private fun calculateSpacing(view: View, parent: RecyclerView, itemCount: Int): Int {
+    // Since the view hasn't gone through the layout phase, we need to first call measure()
+    view.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+    val cardWidth: Int = view.measuredWidth
+
+    val totalWidth = parent.measuredWidth
+    val totalSpace = totalWidth - cardWidth * itemCount
+    return totalSpace / (itemCount - 1)
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/MapTypeDialogFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/MapTypeDialogFragment.kt
@@ -65,5 +65,6 @@ class MapTypeDialogFragment : BottomSheetDialogFragment() {
     val index = mapTypes.indexOfFirst { it == viewModel.mapType }
     binding.recyclerView.adapter =
       MapTypeAdapter(requireContext(), mapTypes, index) { viewModel.mapType = mapTypes[it] }
+    binding.recyclerView.addItemDecoration(AdaptiveSpacingItemDecorator(resources, 80))
   }
 }

--- a/ground/src/main/res/layout/map_type_dialog_item.xml
+++ b/ground/src/main/res/layout/map_type_dialog_item.xml
@@ -21,14 +21,12 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="wrap_content"
   android:layout_height="wrap_content"
-  android:layout_marginLeft="4dp"
-  android:layout_marginRight="4dp"
   android:orientation="vertical">
 
   <com.google.android.material.card.MaterialCardView
     android:id="@+id/card"
-    android:layout_width="116dp"
-    android:layout_height="116dp"
+    android:layout_width="96dp"
+    android:layout_height="96dp"
     app:cardCornerRadius="16dp"
     app:strokeColor="?attr/colorPrimary">
 
@@ -46,7 +44,7 @@
     android:layout_height="wrap_content"
     android:layout_gravity="center"
     android:layout_marginTop="10dp"
-    android:textSize="14sp"
+    android:textSize="12sp"
     tools:text="Roadmap" />
 
 </LinearLayout>


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1781 

<!-- PR description. -->
Fill the width and equally space the items in portrait mode. 
In landscape mode, use a hardcoded spacing to left-align the items.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

[map_type_selector_adaptive_spacing.webm](https://github.com/google/ground-android/assets/8918023/7a640367-fed7-4282-a558-3fc784142ddc)


<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->


@gino-m  PTAL?
