### PR TITLE
Show draw area instructions only when the task fragment is visible to the user

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -32,7 +32,7 @@ import com.google.android.ground.ui.datacollection.components.ButtonAction
 import com.google.android.ground.ui.datacollection.components.TaskButton
 import com.google.android.ground.ui.datacollection.components.TaskButtonFactory
 import com.google.android.ground.ui.datacollection.components.TaskView
-import java.util.*
+import java.util.EnumMap
 import kotlin.properties.Delegates
 import kotlinx.coroutines.launch
 import org.jetbrains.annotations.TestOnly
@@ -91,6 +91,13 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
     }
   }
 
+  override fun setMenuVisibility(menuVisible: Boolean) {
+    super.setMenuVisibility(menuVisible)
+    if (menuVisible) {
+      onTaskVisibleToUser()
+    }
+  }
+
   /** Creates the view for common task template with/without header. */
   abstract fun onCreateTaskView(inflater: LayoutInflater): TaskView
 
@@ -99,6 +106,9 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
 
   /** Invoked after the task view gets attached to the fragment. */
   open fun onTaskViewAttached() {}
+
+  /** Invoked when the task fragment is visible to the user. */
+  open fun onTaskVisibleToUser() {}
 
   /** Invoked when the fragment is ready to add buttons to the current [TaskView]. */
   open fun onCreateActionButtons() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -96,7 +96,9 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
     viewLifecycleOwner.lifecycleScope.launch {
       viewModel.draftArea.collectLatest { onFeatureUpdated(it) }
     }
+  }
 
+  override fun onTaskVisibleToUser() {
     if (!viewModel.instructionsDialogShown) {
       showInstructionsDialog()
     }

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
@@ -110,6 +110,7 @@ class DrawAreaTaskFragmentTest :
   @Test
   fun testDrawArea_incompleteWhenTaskIsOptional() = runWithTestDispatcher {
     setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
+    fragment.onTaskVisibleToUser()
 
     // Dismiss the instructions dialog
     ShadowDialog.getLatestDialog().dismiss()
@@ -142,6 +143,7 @@ class DrawAreaTaskFragmentTest :
   @Test
   fun testDrawArea() = runWithTestDispatcher {
     setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
+    fragment.onTaskVisibleToUser()
 
     // Dismiss the instructions dialog
     ShadowDialog.getLatestDialog().dismiss()
@@ -178,6 +180,7 @@ class DrawAreaTaskFragmentTest :
   @Test
   fun `Instructions dialog is shown`() = runWithTestDispatcher {
     setupTaskFragment<DrawAreaTaskFragment>(job, task)
+    fragment.onTaskVisibleToUser()
 
     assertThat(ShadowDialog.getLatestDialog()).isNotNull()
   }


### PR DESCRIPTION

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2258

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m @scolsen  PTAL?
