### PR TITLE
Add a small delay after the page scroll is idle to calculate the progress bar position.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -17,11 +17,14 @@ package com.google.android.ground.ui.datacollection
 
 import android.animation.ValueAnimator
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
 import androidx.constraintlayout.widget.Guideline
+import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.lifecycle.lifecycleScope
@@ -33,13 +36,14 @@ import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.common.BackPressListener
 import com.google.android.ground.ui.common.Navigator
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 /** Fragment allowing the user to collect data to complete a task. */
 @AndroidEntryPoint
 class DataCollectionFragment : AbstractFragment(), BackPressListener {
   @Inject lateinit var navigator: Navigator
+
   @Inject lateinit var viewPagerAdapterFactory: DataCollectionViewPagerAdapterFactory
 
   private val viewModel: DataCollectionViewModel by hiltNavGraphViewModels(R.id.data_collection)
@@ -76,18 +80,32 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
 
     viewPager.registerOnPageChangeCallback(
       object : ViewPager2.OnPageChangeCallback() {
-        override fun onPageSelected(position: Int) {
-          super.onPageSelected(position)
-
-          val buttonContainer = view.findViewById<View>(R.id.action_buttons) ?: return
-          val anchorLocation = IntArray(2)
-          buttonContainer.getLocationInWindow(anchorLocation)
-          val guidelineTop =
-            anchorLocation[1] - buttonContainer.rootWindowInsets.systemWindowInsetTop
-          guideline.setGuidelineBegin(guidelineTop)
+        override fun onPageScrollStateChanged(state: Int) {
+          super.onPageScrollStateChanged(state)
+          if (state == ViewPager2.SCROLL_STATE_IDLE) {
+            Handler(Looper.getMainLooper())
+              .postDelayed(
+                {
+                  // Reset the progress bar position after a delay to wait for the keyboard to
+                  // close.
+                  setProgressBarPosition(view)
+                },
+                100
+              )
+          }
         }
       }
     )
+  }
+
+  private fun setProgressBarPosition(view: View) {
+    val buttonContainer = view.findViewById<View>(R.id.action_buttons) ?: return
+    val anchorLocation = IntArray(2)
+    buttonContainer.getLocationInWindow(anchorLocation)
+    val windowInsets = WindowInsetsCompat.toWindowInsetsCompat(buttonContainer.rootWindowInsets)
+    val guidelineTop =
+      anchorLocation[1] - windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top
+    guideline.setGuidelineBegin(guidelineTop)
   }
 
   private fun loadTasks(tasks: List<Task>) {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -36,8 +36,8 @@ import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.common.BackPressListener
 import com.google.android.ground.ui.common.Navigator
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 /** Fragment allowing the user to collect data to complete a task. */
 @AndroidEntryPoint

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -40,6 +40,7 @@ import com.google.android.ground.ui.common.BaseMapViewModel
 import com.google.android.ground.ui.common.EphemeralPopups
 import com.google.android.ground.ui.home.HomeScreenFragmentDirections
 import com.google.android.ground.ui.home.HomeScreenViewModel
+import com.google.android.ground.ui.home.mapcontainer.HomeScreenMapContainerViewModel.SurveyProperties
 import com.google.android.ground.ui.home.mapcontainer.cards.LoiCardUtil
 import com.google.android.ground.ui.home.mapcontainer.cards.MapCardAdapter
 import com.google.android.ground.ui.home.mapcontainer.cards.MapCardUiData
@@ -143,20 +144,22 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
     if (!this::mapContainerViewModel.isInitialized) {
       return Timber.w("showDataCollectionHint() called before mapContainerViewModel initialized")
     }
-    mapContainerViewModel.surveyUpdateFlow.collect {
-      if (!this::binding.isInitialized) {
-        return@collect Timber.w("showDataCollectionHint() called before binding initialized")
-      }
-      val messageId =
-        when {
-          it.addLoiPermitted -> R.string.suggest_data_collection_hint
-          it.readOnly -> R.string.read_only_data_collection_hint
-          else -> R.string.predefined_data_collection_hint
-        }
-      ephemeralPopups
-        .InfoPopup()
-        .show(binding.root, messageId, EphemeralPopups.PopupDuration.INDEFINITE)
+    mapContainerViewModel.surveyUpdateFlow.collect(this::onSurveyUpdate)
+  }
+
+  private fun onSurveyUpdate(surveyProperties: SurveyProperties) {
+    if (!this::binding.isInitialized) {
+      return Timber.w("showDataCollectionHint() called before binding initialized")
     }
+    val messageId =
+      when {
+        surveyProperties.addLoiPermitted -> R.string.suggest_data_collection_hint
+        surveyProperties.readOnly -> R.string.read_only_data_collection_hint
+        else -> R.string.predefined_data_collection_hint
+      }
+    ephemeralPopups
+      .InfoPopup()
+      .show(binding.root, messageId, EphemeralPopups.PopupDuration.INDEFINITE)
   }
 
   private fun setupMenuFab() {

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -90,9 +90,9 @@ internal constructor(
    * determine if and how behavior should change based on differing survey properties.
    */
   val surveyUpdateFlow: Flow<SurveyProperties> =
-    activeSurvey.filterNotNull().map {
-      val lois = loiRepository.getLocationsOfInterests(it).first()
-      SurveyProperties(it.jobs.any { it.canDataCollectorsAddLois }, lois.isEmpty())
+    activeSurvey.filterNotNull().map { survey ->
+      val lois = loiRepository.getLocationsOfInterests(survey).first()
+      SurveyProperties(survey.jobs.any { job -> job.canDataCollectorsAddLois }, lois.isEmpty())
     }
 
   /** Set of [Feature] to render on the map. */

--- a/ground/src/test/java/com/google/android/ground/ui/home/HomeScreenFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/home/HomeScreenFragmentTest.kt
@@ -39,6 +39,7 @@ import com.google.android.ground.ui.common.Navigator
 import com.sharedtest.FakeData
 import com.squareup.picasso.Picasso
 import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.hamcrest.CoreMatchers.not
@@ -47,7 +48,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RobolectricTestRunner
-import javax.inject.Inject
 
 abstract class AbstractHomeScreenFragmentTest : BaseHiltTest() {
 
@@ -138,16 +138,6 @@ class HomeScreenFragmentTest : AbstractHomeScreenFragmentTest() {
 
     openDrawer()
     onView(withId(R.id.nav_offline_areas)).check(matches(not(isEnabled())))
-  }
-
-  @Test
-  fun offlineMapImageryMenuIsEnabledWhenActiveSurveyHasBasemap() = runWithTestDispatcher {
-    localSurveyStore.insertOrUpdateSurvey(surveyWithTileSources)
-    surveyRepository.selectedSurveyId = surveyWithTileSources.id
-    advanceUntilIdle()
-
-    openDrawer()
-    onView(withId(R.id.nav_offline_areas)).check(matches(isEnabled()))
   }
 }
 

--- a/ground/src/test/java/com/google/android/ground/ui/home/HomeScreenFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/home/HomeScreenFragmentTest.kt
@@ -39,7 +39,6 @@ import com.google.android.ground.ui.common.Navigator
 import com.sharedtest.FakeData
 import com.squareup.picasso.Picasso
 import dagger.hilt.android.testing.HiltAndroidTest
-import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.hamcrest.CoreMatchers.not
@@ -48,6 +47,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RobolectricTestRunner
+import javax.inject.Inject
 
 abstract class AbstractHomeScreenFragmentTest : BaseHiltTest() {
 
@@ -129,15 +129,6 @@ class HomeScreenFragmentTest : AbstractHomeScreenFragmentTest() {
       mapOf(FakeData.JOB.id to FakeData.JOB),
       listOf(),
       mapOf(Pair(FakeData.USER.email, "data-collector"))
-    )
-
-  private val surveyWithTileSources: Survey =
-    surveyWithoutBasemap.copy(
-      tileSources =
-        listOf(
-          TileSource("http://google.com", TileSource.Type.MOG_COLLECTION),
-        ),
-      id = "SURVEY_WITH_TILE_SOURCES"
     )
 
   @Test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #1975 

<!-- PR description. -->
Waits a little bit after the task view has changed in order to recalculate the progress bar position, which is based on the top of the action buttons container. This is is in order to allow the action buttons to settle into their position after the keyboard has moved out of the way, since the callbacks are called too quickly.

Also replaces deprecated Java `systemWindowInsetTop` property (sorry, I used Bard/Gemini for that).

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Waits a ~100ms delay before attempting to set the progress bar position.
- [x] Replaces deprecated  `systemWindowInsetTop` with `WindowInsetsCompat` API.

<!-- Add steps to verify bug/feature. -->
- Clicked on a text task, wait for the keyboard to show up, then moved to the next and previous tasks while the action buttons are pushed up.


<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
<img width="306" alt="Screenshot 2024-02-29 at 7 12 06 PM" src="https://github.com/google/ground-android/assets/12646706/1f8f6ec1-431e-41a4-8d52-db13208f67ae">

@gino-m  PTAL!
