### PR TITLE
Disable gradle daemon for remote builds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -85,7 +85,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex assembleDevStaging assembleDevStagingUnitTest -PtestBuildType=staging
+        ./gradlew -PdisablePreDex assembleDevStaging assembleDevStagingUnitTest -PtestBuildType=staging --no-daemon
 
   # TODO(#1547): Re-enable once instrumentation tests are fixed.
   #        if [[ "${_PUSH_TO_MASTER}" ]]; then
@@ -100,11 +100,11 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex checkCode 2> check-logs.txt || echo "fail" > build-status.txt
+        ./gradlew -PdisablePreDex checkCode --no-daemon 2> check-logs.txt || echo "fail" > build-status.txt
         cat check-logs.txt
 
         if [[ "${_PUSH_TO_MASTER}" ]]; then
-          ./gradlew -PdisablePreDex dependencyUpdates
+          ./gradlew -PdisablePreDex dependencyUpdates --no-daemon
         fi
 
   - name: 'gcr.io/$PROJECT_ID/android:34'
@@ -114,11 +114,11 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex testDevStagingUnitTest 2> unit-test-logs.txt || echo "fail" > build-status.txt
+        ./gradlew -PdisablePreDex testDevStagingUnitTest --no-daemon 2> unit-test-logs.txt || echo "fail" > build-status.txt
         cat unit-test-logs.txt
 
         # TODO: Add a check for _PUSH_TO_MASTER
-        ./gradlew jacocoTestStagingUnitTestReport
+        ./gradlew jacocoTestStagingUnitTestReport --no-daemon
 
   - name: 'gcr.io/$PROJECT_ID/android:34'
     id: &authenticate_gcloud 'Authorize gcloud'


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2269

<!-- PR description. -->
Gradle daemons are background processes which are spawned to speed up subsequent builds. It is generally recommended to disable these for CI builds.

https://docs.gradle.org/8.5/userguide/gradle_daemon.html#disable_for_a_build

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@sufyanAbbasi PTAL?
