### PR TITLE
Fix crash on startup

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -117,6 +117,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?,
   ): View {
+    super.onCreateView(inflater, container, savedInstanceState)
     binding = BasemapLayoutBinding.inflate(inflater, container, false)
     binding.fragment = this
     binding.viewModel = mapContainerViewModel

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -129,7 +129,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
     super.onViewCreated(view, savedInstanceState)
     setupMenuFab()
     setupBottomLoiCards()
-    lifecycleScope.launch { showDataCollectionHint() }
+    viewLifecycleOwner.lifecycleScope.launch { showDataCollectionHint() }
   }
 
   /**

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 /** Main app view, displaying the map and related controls (center cross-hairs, add button, etc). */
 @AndroidEntryPoint
@@ -139,9 +140,13 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
    * This method should only be called after view creation.
    */
   private suspend fun showDataCollectionHint() {
-    check(this::mapContainerViewModel.isInitialized) { "mapContainerViewModel not initialized" }
-    check(this::binding.isInitialized) { "binding not initialized" }
+    if (!this::mapContainerViewModel.isInitialized) {
+      return Timber.w("showDataCollectionHint() called before mapContainerViewModel initialized")
+    }
     mapContainerViewModel.surveyUpdateFlow.collect {
+      if (!this::binding.isInitialized) {
+        return@collect Timber.w("showDataCollectionHint() called before binding initialized")
+      }
       val messageId =
         when {
           it.addLoiPermitted -> R.string.suggest_data_collection_hint

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -139,12 +139,8 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
    * This method should only be called after view creation.
    */
   private suspend fun showDataCollectionHint() {
-    check(this::mapContainerViewModel.isInitialized) {
-      "showDataCollectionHint called before mapContainerViewModel was initialized"
-    }
-    check(this::binding.isInitialized) {
-      "showDataCollectionHint called before binding was initialized"
-    }
+    check(this::mapContainerViewModel.isInitialized) { "mapContainerViewModel not initialized" }
+    check(this::binding.isInitialized) { "binding not initialized" }
     mapContainerViewModel.surveyUpdateFlow.collect {
       val messageId =
         when {


### PR DESCRIPTION
Fixes #2283.

Launches snackbar hint introduced in #2132 in `viewLifecycleOwner.lifecycleScope` instead of `lifecycleScope` to ensure coroutine is bound to lifecycle of view. Also, fails gracefully in the rare case there could be a race condition with view destruction.



