### PR TITLE
Save `planned:false` for ad-hoc LOIs.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/Config.kt
+++ b/ground/src/main/java/com/google/android/ground/Config.kt
@@ -26,7 +26,7 @@ object Config {
 
   // Local db settings.
   // TODO(#128): Reset version to 1 before releasing.
-  const val DB_VERSION = 114
+  const val DB_VERSION = 115
   const val DB_NAME = "ground.db"
 
   // Firebase Cloud Firestore settings.

--- a/ground/src/main/java/com/google/android/ground/model/locationofinterest/LocationOfInterest.kt
+++ b/ground/src/main/java/com/google/android/ground/model/locationofinterest/LocationOfInterest.kt
@@ -48,15 +48,10 @@ data class LocationOfInterest(
    * the user.
    */
   val ownerEmail: String? = null,
-  /**
-   * Whether this LOI was created opportunistically by the user through the Suggest LOI flow, or
-   * false if the LOI was created by the survey organizer.
-   */
-  val isOpportunistic: Boolean = false,
   /** Custom map of properties for this LOI. Corresponds to the properties field in GeoJSON */
   val properties: LoiProperties = mapOf(),
   /** Whether the LOI was predefined in the survey or not (i.e. added ad hoc). */
-  val planned: Boolean? = null,
+  val isPlanned: Boolean? = null,
 ) {
 
   /**
@@ -76,8 +71,8 @@ data class LocationOfInterest(
       geometry = geometry,
       submissionCount = submissionCount,
       ownerEmail = ownerEmail,
-      isOpportunistic = isOpportunistic,
       properties = properties,
+      isPlanned = isPlanned,
     )
 
   fun getProperty(key: String): String = properties[key]?.toString() ?: ""

--- a/ground/src/main/java/com/google/android/ground/model/locationofinterest/LocationOfInterest.kt
+++ b/ground/src/main/java/com/google/android/ground/model/locationofinterest/LocationOfInterest.kt
@@ -55,6 +55,8 @@ data class LocationOfInterest(
   val isOpportunistic: Boolean = false,
   /** Custom map of properties for this LOI. Corresponds to the properties field in GeoJSON */
   val properties: LoiProperties = mapOf(),
+  /** Whether the LOI was predefined in the survey or not (i.e. added ad hoc). */
+  val planned: Boolean? = null,
 ) {
 
   /**

--- a/ground/src/main/java/com/google/android/ground/model/mutation/LocationOfInterestMutation.kt
+++ b/ground/src/main/java/com/google/android/ground/model/mutation/LocationOfInterestMutation.kt
@@ -34,6 +34,6 @@ data class LocationOfInterestMutation(
   val geometry: Geometry? = null,
   val submissionCount: Int = 0,
   val ownerEmail: String? = null,
-  val isOpportunistic: Boolean = false,
   val properties: LoiProperties = mapOf(),
+  val isPlanned: Boolean? = null,
 ) : Mutation()

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
@@ -41,11 +41,11 @@ import com.google.android.ground.persistence.local.room.relations.TaskEntityAndR
 import com.google.android.ground.ui.map.Bounds
 import com.google.common.reflect.TypeToken
 import com.google.gson.Gson
-import java.util.*
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import org.json.JSONObject
 import timber.log.Timber
+import java.util.*
 
 fun AuditInfo.toLocalDataStoreObject(): AuditInfoEntity =
   AuditInfoEntity(
@@ -147,6 +147,7 @@ fun LocationOfInterest.toLocalDataStoreObject() =
     ownerEmail = ownerEmail,
     isOpportunistic = isOpportunistic,
     properties = properties,
+    // TODO(#2300): Add `planned` field for local storage.
   )
 
 fun LocationOfInterestEntity.toModelObject(survey: Survey): LocationOfInterest =
@@ -167,6 +168,7 @@ fun LocationOfInterestEntity.toModelObject(survey: Survey): LocationOfInterest =
           ?: throw LocalDataConsistencyException(
             "Unknown jobId ${this.jobId} in location of interest ${this.id}"
           )
+      // TODO(#2300): Add `planned` field for rendering use.
     )
   }
 
@@ -211,7 +213,7 @@ fun LocationOfInterestMutation.toLocalDataStoreObject() =
     clientTimestamp = clientTimestamp.time,
     lastError = lastError,
     retryCount = retryCount,
-    newProperties = properties
+    newProperties = properties,
   )
 
 fun LocationOfInterestMutationEntity.toModelObject() =

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
@@ -45,11 +45,11 @@ import com.google.android.ground.persistence.local.room.relations.TaskEntityAndR
 import com.google.android.ground.ui.map.Bounds
 import com.google.common.reflect.TypeToken
 import com.google.gson.Gson
+import java.util.*
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import org.json.JSONObject
 import timber.log.Timber
-import java.util.*
 
 fun AuditInfo.toLocalDataStoreObject(): AuditInfoEntity =
   AuditInfoEntity(

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
@@ -149,9 +149,8 @@ fun LocationOfInterest.toLocalDataStoreObject() =
     customId = customId,
     submissionCount = submissionCount,
     ownerEmail = ownerEmail,
-    isOpportunistic = isOpportunistic,
     properties = properties,
-    // TODO(#2300): Add `planned` field for local storage.
+    isPlanned = isPlanned,
   )
 
 fun LocationOfInterestEntity.toModelObject(survey: Survey): LocationOfInterest =
@@ -167,12 +166,12 @@ fun LocationOfInterestEntity.toModelObject(survey: Survey): LocationOfInterest =
       geometry = geometry.getGeometry(),
       submissionCount = submissionCount,
       properties = properties,
+      isPlanned = isPlanned,
       job =
         survey.getJob(jobId = jobId)
           ?: throw LocalDataConsistencyException(
             "Unknown jobId ${this.jobId} in location of interest ${this.id}"
           )
-      // TODO(#2300): Add `planned` field for rendering use.
     )
   }
 
@@ -198,8 +197,8 @@ fun LocationOfInterestMutation.toLocalDataStoreObject(user: User): LocationOfInt
     customId = customId,
     submissionCount = submissionCount,
     ownerEmail = ownerEmail,
-    isOpportunistic = isOpportunistic,
-    properties = properties
+    properties = properties,
+    isPlanned = isPlanned,
   )
 }
 
@@ -218,6 +217,7 @@ fun LocationOfInterestMutation.toLocalDataStoreObject() =
     lastError = lastError,
     retryCount = retryCount,
     newProperties = properties,
+    isPlanned = isPlanned,
   )
 
 fun LocationOfInterestMutationEntity.toModelObject() =
@@ -234,7 +234,8 @@ fun LocationOfInterestMutationEntity.toModelObject() =
     clientTimestamp = Date(clientTimestamp),
     lastError = lastError,
     retryCount = retryCount,
-    properties = newProperties
+    properties = newProperties,
+    isPlanned = isPlanned,
   )
 
 fun MultipleChoiceEntity.toModelObject(optionEntities: List<OptionEntity>): MultipleChoice {

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestEntity.kt
@@ -39,7 +39,6 @@ data class LocationOfInterestEntity(
   val customId: String,
   val submissionCount: Int,
   val ownerEmail: String?,
-  val isOpportunistic: Boolean,
   val properties: LoiProperties,
-  // TODO(#2300): Add `planned` field for local storage.
+  val isPlanned: Boolean?,
 )

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestEntity.kt
@@ -15,7 +15,11 @@
  */
 package com.google.android.ground.persistence.local.room.entity
 
-import androidx.room.*
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import com.google.android.ground.model.locationofinterest.LoiProperties
 import com.google.android.ground.persistence.local.room.fields.EntityState
 
@@ -37,4 +41,5 @@ data class LocationOfInterestEntity(
   val ownerEmail: String?,
   val isOpportunistic: Boolean,
   val properties: LoiProperties,
+  // TODO(#2300): Add `planned` field for local storage.
 )

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestMutationEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestMutationEntity.kt
@@ -53,8 +53,9 @@ data class LocationOfInterestMutationEntity(
   @ColumnInfo(name = "client_timestamp") val clientTimestamp: Long,
   @ColumnInfo(name = "location_of_interest_id") val locationOfInterestId: String,
   @ColumnInfo(name = "job_id") val jobId: String,
+  @ColumnInfo(name = "is_planned") val isPlanned: Boolean?,
   /** Non-null if the LOI's geometry was updated, null if unchanged. */
   val newGeometry: GeometryWrapper?,
   val newProperties: LoiProperties,
-  val newCustomId: String
+  val newCustomId: String,
 )

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestMutationEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/LocationOfInterestMutationEntity.kt
@@ -15,7 +15,11 @@
  */
 package com.google.android.ground.persistence.local.room.entity
 
-import androidx.room.*
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import com.google.android.ground.model.locationofinterest.LoiProperties
 import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
 import com.google.android.ground.persistence.local.room.fields.MutationEntityType

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiConverter.kt
@@ -33,6 +33,7 @@ object LoiConverter {
   const val GEOMETRY_COORDINATES = "coordinates"
   const val GEOMETRY = "geometry"
   const val SUBMISSION_COUNT = "submissionCount"
+  const val PLANNED = "planned"
 
   fun toLoi(survey: Survey, doc: DocumentSnapshot): Result<LocationOfInterest> = runCatching {
     toLoiUnchecked(survey, doc)
@@ -71,7 +72,8 @@ object LoiConverter {
       // TODO(#929): Set geometry once LOI has been updated to use our own model.
       geometry = geometry,
       submissionCount = submissionCount,
-      properties = loiDoc.properties ?: mapOf()
+      properties = loiDoc.properties ?: mapOf(),
+      planned = loiDoc.planned,
     )
   }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiConverter.kt
@@ -33,7 +33,7 @@ object LoiConverter {
   const val GEOMETRY_COORDINATES = "coordinates"
   const val GEOMETRY = "geometry"
   const val SUBMISSION_COUNT = "submissionCount"
-  const val PLANNED = "planned"
+  const val IS_PLANNED = "planned"
 
   fun toLoi(survey: Survey, doc: DocumentSnapshot): Result<LocationOfInterest> = runCatching {
     toLoiUnchecked(survey, doc)
@@ -73,7 +73,7 @@ object LoiConverter {
       geometry = geometry,
       submissionCount = submissionCount,
       properties = loiDoc.properties ?: mapOf(),
-      planned = loiDoc.planned,
+      isPlanned = loiDoc.planned,
     )
   }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiDocument.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiDocument.kt
@@ -32,4 +32,5 @@ data class LoiDocument(
   val lastModified: AuditInfoNestedObject? = null,
   val submissionCount: Int? = null,
   val properties: LoiProperties? = null,
+  val planned: Boolean? = null,
 )

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverter.kt
@@ -55,6 +55,7 @@ internal object LoiMutationConverter {
       Mutation.Type.CREATE -> {
         map[LoiConverter.CREATED] = auditInfo
         map[LoiConverter.LAST_MODIFIED] = auditInfo
+        map[LoiConverter.PLANNED] = false
       }
       Mutation.Type.UPDATE -> {
         map[LoiConverter.LAST_MODIFIED] = auditInfo

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverter.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverter.kt
@@ -55,7 +55,7 @@ internal object LoiMutationConverter {
       Mutation.Type.CREATE -> {
         map[LoiConverter.CREATED] = auditInfo
         map[LoiConverter.LAST_MODIFIED] = auditInfo
-        map[LoiConverter.PLANNED] = false
+        map[LoiConverter.IS_PLANNED] = mutation.isPlanned ?: false
       }
       Mutation.Type.UPDATE -> {
         map[LoiConverter.LAST_MODIFIED] = auditInfo

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -87,7 +87,7 @@ constructor(
       created = auditInfo,
       lastModified = auditInfo,
       ownerEmail = user.email,
-      isOpportunistic = true
+      isPlanned = false
     )
   }
 

--- a/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTests.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTests.kt
@@ -48,6 +48,9 @@ import com.google.android.ground.ui.map.gms.GmsExt.getShellCoordinates
 import com.google.common.truth.Truth.assertThat
 import com.sharedtest.FakeData
 import dagger.hilt.android.testing.HiltAndroidTest
+import java.util.*
+import javax.inject.Inject
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -56,9 +59,6 @@ import org.hamcrest.Matchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.*
-import javax.inject.Inject
-import kotlin.test.assertFailsWith
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
@@ -415,7 +415,7 @@ class LocalDataStoreTests : BaseHiltTest() {
         job = TEST_JOB,
         submissionId = "submission id",
         deltas =
-        listOf(ValueDelta("task id", Task.Type.TEXT, TextResponse.fromString("updated value"))),
+          listOf(ValueDelta("task id", Task.Type.TEXT, TextResponse.fromString("updated value"))),
         id = 1L,
         type = Mutation.Type.CREATE,
         syncStatus = SyncStatus.PENDING,

--- a/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTests.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/local/LocalDataStoreTests.kt
@@ -27,7 +27,6 @@ import com.google.android.ground.model.imagery.OfflineArea
 import com.google.android.ground.model.imagery.TileSource
 import com.google.android.ground.model.job.Job
 import com.google.android.ground.model.job.Style
-import com.google.android.ground.model.mutation.LocationOfInterestMutation
 import com.google.android.ground.model.mutation.Mutation
 import com.google.android.ground.model.mutation.Mutation.SyncStatus
 import com.google.android.ground.model.mutation.SubmissionMutation
@@ -47,10 +46,8 @@ import com.google.android.ground.persistence.local.stores.*
 import com.google.android.ground.ui.map.Bounds
 import com.google.android.ground.ui.map.gms.GmsExt.getShellCoordinates
 import com.google.common.truth.Truth.assertThat
+import com.sharedtest.FakeData
 import dagger.hilt.android.testing.HiltAndroidTest
-import java.util.*
-import javax.inject.Inject
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -59,6 +56,9 @@ import org.hamcrest.Matchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.*
+import javax.inject.Inject
+import kotlin.test.assertFailsWith
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
@@ -408,14 +408,14 @@ class LocalDataStoreTests : BaseHiltTest() {
         Coordinates(49.863051, 8.647306),
         Coordinates(49.865374, 8.646920)
       )
-    private val TEST_LOI_MUTATION = createTestLoiMutation(TEST_POINT)
-    private val TEST_POLYGON_LOI_MUTATION = createTestAoiMutation(TEST_POLYGON_1)
+    private val TEST_LOI_MUTATION = FakeData.newLoiMutation(TEST_POINT)
+    private val TEST_POLYGON_LOI_MUTATION = FakeData.newAoiMutation(TEST_POLYGON_1)
     private val TEST_SUBMISSION_MUTATION =
       SubmissionMutation(
         job = TEST_JOB,
         submissionId = "submission id",
         deltas =
-          listOf(ValueDelta("task id", Task.Type.TEXT, TextResponse.fromString("updated value"))),
+        listOf(ValueDelta("task id", Task.Type.TEXT, TextResponse.fromString("updated value"))),
         id = 1L,
         type = Mutation.Type.CREATE,
         syncStatus = SyncStatus.PENDING,
@@ -425,34 +425,6 @@ class LocalDataStoreTests : BaseHiltTest() {
       )
     private val TEST_OFFLINE_AREA =
       OfflineArea("id_1", OfflineArea.State.PENDING, Bounds(0.0, 0.0, 0.0, 0.0), "Test Area", 0..14)
-
-    private fun createTestLoiMutation(point: Point): LocationOfInterestMutation =
-      LocationOfInterestMutation(
-        jobId = "job id",
-        geometry = point,
-        id = 1L,
-        locationOfInterestId = "loi id",
-        type = Mutation.Type.CREATE,
-        syncStatus = SyncStatus.PENDING,
-        userId = "user id",
-        surveyId = "survey id",
-        clientTimestamp = Date()
-      )
-
-    private fun createTestAoiMutation(
-      polygonVertices: List<Coordinates>
-    ): LocationOfInterestMutation =
-      LocationOfInterestMutation(
-        jobId = "job id",
-        geometry = Polygon(LinearRing(polygonVertices)),
-        id = 1L,
-        locationOfInterestId = "loi id",
-        type = Mutation.Type.CREATE,
-        syncStatus = SyncStatus.PENDING,
-        userId = "user id",
-        surveyId = "survey id",
-        clientTimestamp = Date()
-      )
 
     private fun assertEquivalent(mutation: SubmissionMutation, submission: Submission) {
       assertThat(mutation.submissionId).isEqualTo(submission.id)

--- a/ground/src/test/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverterTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverterTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.android.ground.persistence.remote.firebase.schema
 
 import com.google.android.ground.model.geometry.Coordinates

--- a/ground/src/test/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverterTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverterTest.kt
@@ -1,0 +1,101 @@
+package com.google.android.ground.persistence.remote.firebase.schema
+
+import com.google.android.ground.model.geometry.Coordinates
+import com.google.android.ground.model.geometry.Point
+import com.google.android.ground.model.mutation.Mutation
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.firestore.GeoPoint
+import com.sharedtest.FakeData
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import kotlin.test.fail
+
+class LoiMutationConverterTest {
+  @Test
+  fun `toMap() retains job ID and submission count`() {
+    with(LoiConverter) {
+      val mutation = FakeData.newLoiMutation(TEST_POINT)
+      val map = LoiMutationConverter.toMap(mutation, TEST_USER)
+      assertThat(map[JOB_ID]).isEqualTo(mutation.jobId)
+      assertThat(map[SUBMISSION_COUNT]).isEqualTo(mutation.submissionCount)
+    }
+  }
+
+  @Test
+  fun `toMap() retains point geometry data`() {
+    with(LoiConverter) {
+      val mutation = FakeData.newLoiMutation(TEST_POINT)
+      val map = LoiMutationConverter.toMap(mutation, TEST_USER)
+      val geometry = map[GEOMETRY]
+      if (geometry is MutableMap<*, *>) {
+        assertThat(geometry[GEOMETRY_TYPE]).isEqualTo(POINT_TYPE)
+        assertThat(geometry[GEOMETRY_COORDINATES]).isEqualTo(GeoPoint(88.0, -23.1))
+      } else {
+        fail("GEOMETRY field, $geometry, is not a map.")
+      }
+    }
+  }
+
+  @Test
+  fun `toMap() retains polygon geometry data`() {
+    with(LoiConverter) {
+      val mutation = FakeData.newAoiMutation(TEST_POLYGON)
+      val map = LoiMutationConverter.toMap(mutation, TEST_USER)
+      val geometry = map[GEOMETRY]
+      if (geometry is MutableMap<*, *>) {
+        assertThat(geometry[GEOMETRY_TYPE]).isEqualTo(POLYGON_TYPE)
+        assertThat((geometry[GEOMETRY_COORDINATES] as MutableMap<*, *>).values.size).isEqualTo(1)
+        val coordinates =
+          ((geometry[GEOMETRY_COORDINATES] as MutableMap<*, *>)["0"] as MutableMap<*, *>).toList()
+        assertThat(coordinates.size).isEqualTo(3)
+        assertThat(coordinates[0]).isEqualTo("0" to GeoPoint(0.0, 1.0))
+        assertThat(coordinates[1]).isEqualTo("1" to GeoPoint(1.0, 1.0))
+        assertThat(coordinates[2]).isEqualTo("2" to GeoPoint(0.0, 1.0))
+      } else {
+        fail("GEOMETRY field, $geometry, is not a map.")
+      }
+    }
+  }
+
+  @Test
+  fun `toMap() converts CREATE mutation to map`() {
+    with(LoiConverter) {
+      val mutation = FakeData.newLoiMutation(TEST_POINT, mutationType = Mutation.Type.CREATE)
+      val map = LoiMutationConverter.toMap(mutation, TEST_USER)
+      assertThat(map[CREATED]).isEqualTo(map[LAST_MODIFIED])
+      assertThat(map[CREATED])
+        .isEqualTo(AuditInfoConverter.fromMutationAndUser(mutation, TEST_USER))
+      assertThat(map[PLANNED]).isEqualTo(false)
+    }
+  }
+
+  @Test
+  fun `toMap() converts UPDATE mutation to map`() {
+    with(LoiConverter) {
+      val mutation = FakeData.newLoiMutation(TEST_POINT, mutationType = Mutation.Type.UPDATE)
+      val map = LoiMutationConverter.toMap(mutation, TEST_USER)
+      assertThat(map[CREATED]).isNotEqualTo(map[LAST_MODIFIED])
+      assertThat(map[LAST_MODIFIED])
+        .isEqualTo(AuditInfoConverter.fromMutationAndUser(mutation, TEST_USER))
+    }
+  }
+
+  @Test
+  fun `toMap() throws an error for DELETE and UNKOWN mutation`() {
+    val deleteMutation = FakeData.newLoiMutation(TEST_POINT, mutationType = Mutation.Type.DELETE)
+    assertThrows(UnsupportedOperationException::class.java) {
+      LoiMutationConverter.toMap(deleteMutation, TEST_USER)
+    }
+    val unknownMutation = FakeData.newLoiMutation(TEST_POINT, mutationType = Mutation.Type.UNKNOWN)
+    assertThrows(UnsupportedOperationException::class.java) {
+      LoiMutationConverter.toMap(unknownMutation, TEST_USER)
+    }
+  }
+
+  companion object {
+    private val TEST_USER = FakeData.USER
+    private val TEST_POINT = Point(Coordinates(88.0, -23.1))
+    private val TEST_POLYGON =
+      listOf(Coordinates(0.0, 1.0), Coordinates(1.0, 1.0), Coordinates(0.0, 1.0))
+  }
+}

--- a/ground/src/test/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverterTest.kt
+++ b/ground/src/test/java/com/google/android/ground/persistence/remote/firebase/schema/LoiMutationConverterTest.kt
@@ -6,9 +6,9 @@ import com.google.android.ground.model.mutation.Mutation
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.firestore.GeoPoint
 import com.sharedtest.FakeData
+import kotlin.test.fail
 import org.junit.Assert.assertThrows
 import org.junit.Test
-import kotlin.test.fail
 
 class LoiMutationConverterTest {
   @Test
@@ -65,7 +65,7 @@ class LoiMutationConverterTest {
       assertThat(map[CREATED]).isEqualTo(map[LAST_MODIFIED])
       assertThat(map[CREATED])
         .isEqualTo(AuditInfoConverter.fromMutationAndUser(mutation, TEST_USER))
-      assertThat(map[PLANNED]).isEqualTo(false)
+      assertThat(map[IS_PLANNED]).isEqualTo(false)
     }
   }
 

--- a/sharedTest/src/main/kotlin/com/sharedtest/FakeData.kt
+++ b/sharedTest/src/main/kotlin/com/sharedtest/FakeData.kt
@@ -44,6 +44,10 @@ object FakeData {
   // TODO: Replace constants with calls to newFoo() methods.
   val TERMS_OF_SERVICE: TermsOfService =
     TermsOfService("TERMS_OF_SERVICE", "Fake Terms of Service text")
+  const val JOB_ID = "job id"
+  const val LOI_ID = "loi id"
+  const val USER_ID = "user id"
+  const val SURVEY_ID = "survey id"
 
   val JOB =
     Job(
@@ -67,7 +71,7 @@ object FakeData {
 
   val LOCATION_OF_INTEREST =
     LocationOfInterest(
-      "loi id",
+      LOI_ID,
       SURVEY.id,
       JOB,
       customId = "",
@@ -99,7 +103,7 @@ object FakeData {
 
   val AREA_OF_INTEREST: LocationOfInterest =
     LocationOfInterest(
-      "loi id",
+      LOI_ID,
       SURVEY.id,
       JOB,
       "",
@@ -142,14 +146,14 @@ object FakeData {
     syncStatus: Mutation.SyncStatus = Mutation.SyncStatus.PENDING,
   ): LocationOfInterestMutation =
     LocationOfInterestMutation(
-      jobId = "job id",
+      jobId = JOB_ID,
       geometry = point,
       id = 1L,
-      locationOfInterestId = "loi id",
+      locationOfInterestId = LOI_ID,
       type = mutationType,
       syncStatus = syncStatus,
-      userId = "user id",
-      surveyId = "survey id",
+      userId = USER_ID,
+      surveyId = SURVEY_ID,
       clientTimestamp = Date()
     )
 
@@ -159,14 +163,14 @@ object FakeData {
     syncStatus: Mutation.SyncStatus = Mutation.SyncStatus.PENDING,
   ): LocationOfInterestMutation =
     LocationOfInterestMutation(
-      jobId = "job id",
+      jobId = JOB_ID,
       geometry = Polygon(LinearRing(polygonVertices)),
       id = 1L,
-      locationOfInterestId = "loi id",
+      locationOfInterestId = LOI_ID,
       type = mutationType,
       syncStatus = syncStatus,
-      userId = "user id",
-      surveyId = "survey id",
+      userId = USER_ID,
+      surveyId = SURVEY_ID,
       clientTimestamp = Date()
     )
 }

--- a/sharedTest/src/main/kotlin/com/sharedtest/FakeData.kt
+++ b/sharedTest/src/main/kotlin/com/sharedtest/FakeData.kt
@@ -19,16 +19,22 @@ import com.google.android.ground.model.AuditInfo
 import com.google.android.ground.model.Survey
 import com.google.android.ground.model.TermsOfService
 import com.google.android.ground.model.User
-import com.google.android.ground.model.geometry.*
+import com.google.android.ground.model.geometry.Coordinates
+import com.google.android.ground.model.geometry.LinearRing
+import com.google.android.ground.model.geometry.Point
+import com.google.android.ground.model.geometry.Polygon
 import com.google.android.ground.model.job.Job
 import com.google.android.ground.model.job.Style
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
+import com.google.android.ground.model.mutation.LocationOfInterestMutation
+import com.google.android.ground.model.mutation.Mutation
 import com.google.android.ground.model.submission.Submission
 import com.google.android.ground.model.task.MultipleChoice
 import com.google.android.ground.model.task.Task
 import com.google.android.ground.ui.map.Feature
 import com.google.android.ground.ui.map.FeatureType
 import com.google.android.ground.ui.map.gms.features.FeatureClusterItem
+import java.util.Date
 
 /**
  * Shared test data constants. Tests are expected to override existing or set missing values when
@@ -129,4 +135,38 @@ object FakeData {
     type: Task.Type = Task.Type.TEXT,
     multipleChoice: MultipleChoice? = null
   ): Task = Task(id, 0, type, "", false, multipleChoice)
+
+  fun newLoiMutation(
+    point: Point,
+    mutationType: Mutation.Type = Mutation.Type.CREATE,
+    syncStatus: Mutation.SyncStatus = Mutation.SyncStatus.PENDING,
+  ): LocationOfInterestMutation =
+    LocationOfInterestMutation(
+      jobId = "job id",
+      geometry = point,
+      id = 1L,
+      locationOfInterestId = "loi id",
+      type = mutationType,
+      syncStatus = syncStatus,
+      userId = "user id",
+      surveyId = "survey id",
+      clientTimestamp = Date()
+    )
+
+  fun newAoiMutation(
+    polygonVertices: List<Coordinates>,
+    mutationType: Mutation.Type = Mutation.Type.CREATE,
+    syncStatus: Mutation.SyncStatus = Mutation.SyncStatus.PENDING,
+  ): LocationOfInterestMutation =
+    LocationOfInterestMutation(
+      jobId = "job id",
+      geometry = Polygon(LinearRing(polygonVertices)),
+      id = 1L,
+      locationOfInterestId = "loi id",
+      type = mutationType,
+      syncStatus = syncStatus,
+      userId = "user id",
+      surveyId = "survey id",
+      clientTimestamp = Date()
+    )
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2300.

<!-- PR description. -->
Send `planned: false` for LOIs that are created ad-hoc from the app. Maps to `isPlanned` on the client.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

- [x] Adds the `planned` field to the `LoiDocument` for Firsetore storage, sets to false when an ad-hoc request is made.
- [x] Maps the field to `isPlanned` in the `LocationOfInterest` and `LocationOfInterestMutation`
- [x] Refactored usage of `isOpportunistic` and to `isPlanned`.
- [x] Added support for the local datastore schema.
- [x] Unit tests.

<!-- Add steps to verify bug/feature. -->
- Breakpoints at document load time verified that the Firestore was storing "planned:false" for newly created entries and reserialized back on the client.
- Firestore stores the field (see image).

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
<img width="196" alt="Screenshot 2024-03-06 at 1 24 17 AM" src="https://github.com/google/ground-android/assets/12646706/33892497-a6ba-4b14-bccc-f699f9e3d739">

@gino-m PTAL!
