### PR TITLE
Home: Adjust location lock position for snackbar.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/common/EphemeralPopups.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/EphemeralPopups.kt
@@ -64,7 +64,7 @@ class EphemeralPopups @Inject constructor(private val context: Application) {
   inner class InfoPopup(view: View, @StringRes messageId: Int, duration: PopupDuration) {
     private var snackbar: Snackbar =
       Snackbar.make(view, context.resources.getString(messageId), durationToSnackDuration(duration))
-        .setAction("Dismiss") { this.dismiss() }
+        .setAction(context.getString(R.string.dismiss_info_popup)) { this.dismiss() }
     val isShown: Boolean
       get() = this.snackbar.isShown
 

--- a/ground/src/main/java/com/google/android/ground/ui/common/EphemeralPopups.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/EphemeralPopups.kt
@@ -61,24 +61,29 @@ class EphemeralPopups @Inject constructor(private val context: Application) {
   }
 
   /** Defines functions to render a popup that displays an informational message to the user. */
-  inner class InfoPopup {
-    fun show(
-      view: View,
-      @StringRes messageId: Int,
-      duration: PopupDuration = PopupDuration.INDEFINITE,
-    ) {
-      val msg = context.resources.getString(messageId)
-      showSnackbar(view, msg, duration)
+  inner class InfoPopup(view: View, @StringRes messageId: Int, duration: PopupDuration) {
+    private var snackbar: Snackbar =
+      Snackbar.make(view, context.resources.getString(messageId), durationToSnackDuration(duration))
+        .setAction("Dismiss") { this.dismiss() }
+    val isShown: Boolean
+      get() = this.snackbar.isShown
+
+    val view: View
+      get() = this.snackbar.view
+
+    fun show() = snackbar.show()
+
+    fun setAnchor(view: View) = snackbar.setAnchorView(view)
+
+    private fun dismiss() {
+      this.snackbar.dismiss()
     }
 
-    private fun showSnackbar(view: View, msg: String, duration: PopupDuration) {
-      val dur =
-        when (duration) {
-          PopupDuration.SHORT -> Snackbar.LENGTH_SHORT
-          PopupDuration.LONG -> Snackbar.LENGTH_LONG
-          PopupDuration.INDEFINITE -> Snackbar.LENGTH_INDEFINITE
-        }
-      Snackbar.make(view, msg, dur).show()
-    }
+    private fun durationToSnackDuration(duration: PopupDuration) =
+      when (duration) {
+        PopupDuration.SHORT -> Snackbar.LENGTH_SHORT
+        PopupDuration.LONG -> Snackbar.LENGTH_LONG
+        PopupDuration.INDEFINITE -> Snackbar.LENGTH_INDEFINITE
+      }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -163,7 +163,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
       ephemeralPopups.InfoPopup(
         binding.bottomContainer,
         messageId,
-        EphemeralPopups.PopupDuration.SHORT,
+        EphemeralPopups.PopupDuration.LONG,
       )
     infoPopup.show()
   }

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -68,6 +68,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
   private lateinit var homeScreenViewModel: HomeScreenViewModel
   private lateinit var binding: BasemapLayoutBinding
   private lateinit var adapter: MapCardAdapter
+  private lateinit var infoPopup: EphemeralPopups.InfoPopup
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -158,7 +159,13 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
         surveyProperties.readOnly -> R.string.read_only_data_collection_hint
         else -> R.string.predefined_data_collection_hint
       }
-    ephemeralPopups.InfoPopup().show(binding.root, messageId, EphemeralPopups.PopupDuration.SHORT)
+    infoPopup =
+      ephemeralPopups.InfoPopup(
+        binding.bottomContainer,
+        messageId,
+        EphemeralPopups.PopupDuration.SHORT,
+      )
+    infoPopup.show()
   }
 
   private fun setupMenuFab() {

--- a/ground/src/main/res/layout/basemap_layout.xml
+++ b/ground/src/main/res/layout/basemap_layout.xml
@@ -76,7 +76,7 @@
         app:useCompatPadding="true" />
 
       <!-- Use this container to add overlay views that are anchored to location lock button. -->
-      <FrameLayout
+      <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/bottom_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
   <string name="read_only_data_collection_hint">Survey is read-only</string>
   <string name="predefined_data_collection_hint">Zoom in to a data collection site to collect data</string>
   <string name="no_submissions">No submissions</string>
+  <string name="dismiss_info_popup">Dismiss</string>
   <plurals name="submission_count">
     <item quantity="one">%d submission</item>
     <item quantity="other">%d submissions</item>


### PR DESCRIPTION
Updates our snackbar popup to support two enhancements:

1. The location lock button moves dynamically so that it is not obscured by the snackbar
2. The snackbar has a dismiss action which, on tap, dismisses the snackbar.

Towards #2285

<img width="411" alt="Screenshot 2024-03-06 at 12 49 52 PM" src="https://github.com/google/ground-android/assets/11237600/e09bcc8c-7395-4ce7-8b8e-91940f52b7ca">


