### PR TITLE
Add unit tests for saving and loading drafts in data collection fragment

### DIFF
--- a/ground/src/main/res/navigation/nav_graph.xml
+++ b/ground/src/main/res/navigation/nav_graph.xml
@@ -109,6 +109,13 @@
       <argument
         android:name="jobId"
         type="string" />
+      <argument
+        android:name="shouldLoadFromDraft"
+        app:argType="boolean" />
+      <argument
+        android:name="draftValues"
+        type="string"
+        app:nullable="true" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #708

<!-- PR description. -->
Adds unit tests for following behaviors:
 * Draft is saved when clicking next or previous button
 * Tasks are pre-loaded when data collection fragment is opened with draft submission

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
