### PR TITLE
Fix crash on app load due to race condition between initialization of bottom cards adapter

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/common/AbstractFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/AbstractFragment.kt
@@ -24,13 +24,18 @@ import android.view.ViewGroup
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.ground.AbstractActivity
 import com.google.android.ground.R
 import com.google.android.ground.ui.common.ProgressDialogs.modalSpinner
 import com.google.android.ground.ui.util.ViewUtil
 import com.google.android.ground.util.Debug
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
 abstract class AbstractFragment : Fragment() {
 
@@ -129,5 +134,13 @@ abstract class AbstractFragment : Fragment() {
       progressDialog?.dismiss()
       progressDialog = null
     }
+  }
+
+  protected fun launchWhenStarted(fn: suspend () -> Unit) {
+    lifecycleScope.launch { repeatOnLifecycle(Lifecycle.State.STARTED) { fn() } }
+  }
+
+  protected fun <T> Flow<T>.launchWhenStartedAndCollect(collector: (T) -> Unit) {
+    launchWhenStarted { this.collect { collector(it) } }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
@@ -18,9 +18,6 @@ package com.google.android.ground.ui.common
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.ground.R
 import com.google.android.ground.coroutines.DefaultDispatcher
 import com.google.android.ground.system.GeocodingManager
@@ -32,7 +29,6 @@ import com.google.android.ground.ui.map.MapFragment
 import javax.inject.Inject
 import kotlin.math.max
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /** Injects a [MapFragment] in the container with id "map" and provides shared map functionality. */
@@ -46,10 +42,6 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     map.attachToParent(this, R.id.map) { onMapAttached(it) }
-  }
-
-  private fun launchWhenStarted(fn: suspend () -> Unit) {
-    lifecycleScope.launch { repeatOnLifecycle(Lifecycle.State.STARTED) { fn.invoke() } }
   }
 
   private fun onMapAttached(map: MapFragment) {
@@ -118,7 +110,7 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
           map.enableCurrentLocationIndicator()
         }
       },
-      onFailure = { exception -> onLocationLockStateError(exception) }
+      onFailure = { exception -> onLocationLockStateError(exception) },
     )
   }
 

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -155,14 +155,13 @@ internal constructor(
    * Returns a flow of [MapCardUiData] associated with the active survey's LOIs and adhoc jobs for
    * displaying the cards.
    */
-  fun getMapCardUiData(): Flow<Pair<List<MapCardUiData>, Int>> {
-    return loisInViewport.combine(adHocLoiJobs) { lois, jobs ->
+  fun getMapCardUiData(): Flow<Pair<List<MapCardUiData>, Int>> =
+    loisInViewport.combine(adHocLoiJobs) { lois, jobs ->
       val loiCards = lois.map { MapCardUiData.LoiCardUiData(it) }
       val jobCards = jobs.map { MapCardUiData.AddLoiCardUiData(it) }
 
       Pair(loiCards + jobCards, lois.size)
     }
-  }
 
   private fun updatedLoiSelectedStates(
     features: Set<Feature>,

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -32,6 +32,7 @@ import com.google.android.ground.system.PermissionsManager
 import com.google.android.ground.system.SettingsManager
 import com.google.android.ground.ui.common.BaseMapViewModel
 import com.google.android.ground.ui.common.SharedViewModel
+import com.google.android.ground.ui.home.mapcontainer.cards.MapCardUiData
 import com.google.android.ground.ui.map.CameraPosition
 import com.google.android.ground.ui.map.Feature
 import com.google.android.ground.ui.map.FeatureType
@@ -148,6 +149,19 @@ internal constructor(
         if (survey == null || !isZoomedIn) listOf()
         else survey.jobs.filter { it.canDataCollectorsAddLois && it.getAddLoiTask() != null }
       }
+  }
+
+  /**
+   * Returns a flow of [MapCardUiData] associated with the active survey's LOIs and adhoc jobs for
+   * displaying the cards.
+   */
+  fun getMapCardUiData(): Flow<Pair<List<MapCardUiData>, Int>> {
+    return loisInViewport.combine(adHocLoiJobs) { lois, jobs ->
+      val loiCards = lois.map { MapCardUiData.LoiCardUiData(it) }
+      val jobCards = jobs.map { MapCardUiData.AddLoiCardUiData(it) }
+
+      Pair(loiCards + jobCards, lois.size)
+    }
   }
 
   private fun updatedLoiSelectedStates(

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/cards/MapCardAdapter.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/cards/MapCardAdapter.kt
@@ -33,10 +33,10 @@ import com.google.android.ground.ui.common.LocationOfInterestHelper
  * [ViewHolder] views.
  */
 class MapCardAdapter(
-  private val canUserSubmitData: Boolean,
-  private val updateSubmissionCount: (loi: LocationOfInterest, view: TextView) -> Unit,
+  private val updateSubmissionCount: (loi: LocationOfInterest, view: TextView) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
+  private var canUserSubmitData: Boolean = false
   private var focusedIndex: Int = 0
   private var indexOfLastLoi: Int = -1
   private val itemsList: MutableList<MapCardUiData> = mutableListOf()
@@ -50,14 +50,10 @@ class MapCardAdapter(
     return if (viewType == R.layout.loi_card_item) {
       LoiViewHolder(
         LoiCardItemBinding.inflate(layoutInflater, parent, false),
-        canUserSubmitData,
         updateSubmissionCount,
       )
     } else {
-      AddLoiCardViewHolder(
-        AddLoiCardItemBinding.inflate(layoutInflater, parent, false),
-        canUserSubmitData,
-      )
+      AddLoiCardViewHolder(AddLoiCardItemBinding.inflate(layoutInflater, parent, false))
     }
   }
 
@@ -90,7 +86,12 @@ class MapCardAdapter(
   }
 
   /** Overwrites existing cards. */
-  fun updateData(newItemsList: List<MapCardUiData>, indexOfLastLoi: Int) {
+  fun updateData(
+    canUserSubmitData: Boolean,
+    newItemsList: List<MapCardUiData>,
+    indexOfLastLoi: Int,
+  ) {
+    this.canUserSubmitData = canUserSubmitData
     this.indexOfLastLoi = indexOfLastLoi
     itemsList.clear()
     itemsList.addAll(newItemsList)
@@ -112,10 +113,10 @@ class MapCardAdapter(
   ): CardViewHolder =
     when (uiData) {
       is MapCardUiData.LoiCardUiData -> {
-        (holder as LoiViewHolder).apply { bind(uiData.loi) }
+        (holder as LoiViewHolder).apply { bind(canUserSubmitData, uiData.loi) }
       }
       is MapCardUiData.AddLoiCardUiData -> {
-        (holder as AddLoiCardViewHolder).apply { bind(uiData.job) }
+        (holder as AddLoiCardViewHolder).apply { bind(canUserSubmitData, uiData.job) }
       }
     }
 
@@ -136,12 +137,11 @@ class MapCardAdapter(
   /** View item representing the [LocationOfInterest] data in the list. */
   class LoiViewHolder(
     internal val binding: LoiCardItemBinding,
-    private val canUserSubmitData: Boolean,
     private val updateSubmissionCount: (loi: LocationOfInterest, view: TextView) -> Unit,
   ) : CardViewHolder(binding.root) {
     private val loiHelper = LocationOfInterestHelper(itemView.resources)
 
-    fun bind(loi: LocationOfInterest) {
+    fun bind(canUserSubmitData: Boolean, loi: LocationOfInterest) {
       with(binding) {
         loiName.text = loiHelper.getDisplayLoiName(loi)
         jobName.text = loiHelper.getJobName(loi)
@@ -157,12 +157,10 @@ class MapCardAdapter(
   }
 
   /** View item representing the Add Loi Job data in the list. */
-  class AddLoiCardViewHolder(
-    internal val binding: AddLoiCardItemBinding,
-    private val canUserSubmitData: Boolean,
-  ) : CardViewHolder(binding.root) {
+  class AddLoiCardViewHolder(internal val binding: AddLoiCardItemBinding) :
+    CardViewHolder(binding.root) {
 
-    fun bind(job: Job) {
+    fun bind(canUserSubmitData: Boolean, job: Job) {
       with(binding) {
         jobName.text = job.name
         collectData.visibility =


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2298

<!-- PR description. -->
The root cause is that we are initializing the adapter in a coroutine scope and later when the view is generated,  binding the recycler view to the adapter. Sometimes, the adapter takes longer to load and the binding throws an exception.

In order to solve this, move the adapter creation out of the coroutine and do the necessary refactors.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
