### PR TITLE
Remove unused HomeScreenMapContainerViewModel from point/area task fragments

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskMapFragment.kt
@@ -19,27 +19,22 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
 import com.google.android.ground.ui.common.AbstractMapFragmentWithControls
 import com.google.android.ground.ui.common.BaseMapViewModel
 import com.google.android.ground.ui.datacollection.components.TaskHeaderPopupView
-import com.google.android.ground.ui.home.mapcontainer.HomeScreenMapContainerViewModel
 import com.google.android.ground.ui.map.CameraPosition
 import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class DropPinTaskMapFragment(private val viewModel: DropPinTaskViewModel) :
   AbstractMapFragmentWithControls() {
 
   private lateinit var mapViewModel: BaseMapViewModel
-  private lateinit var mapContainerViewModel: HomeScreenMapContainerViewModel
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    mapContainerViewModel = getViewModel(HomeScreenMapContainerViewModel::class.java)
     mapViewModel = getViewModel(BaseMapViewModel::class.java)
   }
 
@@ -60,11 +55,6 @@ class DropPinTaskMapFragment(private val viewModel: DropPinTaskViewModel) :
   override fun getMapViewModel(): BaseMapViewModel = mapViewModel
 
   override fun onMapReady(map: MapFragment) {
-    // Observe events emitted by the ViewModel.
-    viewLifecycleOwner.lifecycleScope.launch {
-      mapContainerViewModel.mapLoiFeatures.collect { map.setFeatures(it) }
-    }
-
     viewModel.features.observe(this) { map.setFeatures(it) }
   }
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskMapFragment.kt
@@ -19,7 +19,6 @@ import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.ui.common.AbstractMapFragmentWithControls
 import com.google.android.ground.ui.common.BaseMapViewModel
-import com.google.android.ground.ui.home.mapcontainer.HomeScreenMapContainerViewModel
 import com.google.android.ground.ui.map.CameraPosition
 import com.google.android.ground.ui.map.Feature
 import com.google.android.ground.ui.map.MapFragment
@@ -31,22 +30,15 @@ class DrawAreaTaskMapFragment(private val viewModel: DrawAreaTaskViewModel) :
   AbstractMapFragmentWithControls() {
 
   private lateinit var mapViewModel: BaseMapViewModel
-  private lateinit var mapContainerViewModel: HomeScreenMapContainerViewModel
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    mapContainerViewModel = getViewModel(HomeScreenMapContainerViewModel::class.java)
     mapViewModel = getViewModel(BaseMapViewModel::class.java)
   }
 
   override fun getMapViewModel(): BaseMapViewModel = mapViewModel
 
   override fun onMapReady(map: MapFragment) {
-    // Observe events emitted by the ViewModel.
-    viewLifecycleOwner.lifecycleScope.launch {
-      mapContainerViewModel.mapLoiFeatures.collect { map.setFeatures(it) }
-    }
-
     viewLifecycleOwner.lifecycleScope.launch {
       viewModel.draftArea.collect { feature: Feature? ->
         map.setFeatures(if (feature == null) setOf() else setOf(feature))


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->
Found while working on https://github.com/google/ground-android/issues/2299

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Cleanup obsolete code. The `mapViewModel` is used for updating the map features.

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
