### PR TITLE
Update draw area info dialog text and use `onResume()` event to show the dialog.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -92,11 +92,9 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
     }
   }
 
-  override fun setMenuVisibility(menuVisible: Boolean) {
-    super.setMenuVisibility(menuVisible)
-    if (menuVisible) {
-      onTaskVisibleToUser()
-    }
+  override fun onResume() {
+    super.onResume()
+    onTaskResume()
   }
 
   /** Creates the view for common task template with/without header. */
@@ -109,7 +107,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
   open fun onTaskViewAttached() {}
 
   /** Invoked when the task fragment is visible to the user. */
-  open fun onTaskVisibleToUser() {}
+  open fun onTaskResume() {}
 
   /** Invoked when the fragment is ready to add buttons to the current [TaskView]. */
   open fun onCreateActionButtons() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -98,7 +98,7 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
   }
 
   override fun onTaskResume() {
-    if (!viewModel.instructionsDialogShown) {
+    if (isVisible && !viewModel.instructionsDialogShown) {
       showInstructionsDialog()
     }
   }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -19,7 +19,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
@@ -35,7 +34,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
 import com.google.android.ground.model.geometry.LineString
@@ -98,7 +97,7 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
     }
   }
 
-  override fun onTaskVisibleToUser() {
+  override fun onTaskResume() {
     if (!viewModel.instructionsDialogShown) {
       showInstructionsDialog()
     }
@@ -114,16 +113,14 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
   }
 
   private fun showInstructionsDialog() {
+    viewModel.instructionsDialogShown = true
     (view as ViewGroup).addView(
       ComposeView(requireContext()).apply {
         setContent {
           val openAlertDialog = remember { mutableStateOf(true) }
           when {
             openAlertDialog.value -> {
-              CreateInstructionsDialog {
-                openAlertDialog.value = false
-                viewModel.instructionsDialogShown = true
-              }
+              CreateInstructionsDialog { openAlertDialog.value = false }
             }
           }
         }
@@ -141,30 +138,22 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
           modifier = Modifier.width(48.dp).height(48.dp),
         )
       },
-      title = { StyledText(getText(R.string.draw_area_task_instruction)) },
+      title = { Text(text = getString(R.string.draw_area_task_instruction), fontSize = 18.sp) },
       onDismissRequest = {}, // Prevent dismissing the dialog by clicking outside
       confirmButton = {}, // Hide confirm button
       dismissButton = {
         OutlinedButton(onClick = { onDismissRequest() }) {
           Text(
             text = getString(R.string.close),
-            color = Color(MaterialColors.getColor(context, R.attr.colorPrimary, "")),
+            color = getMaterialColor(R.attr.colorPrimary),
           )
         }
       },
+      containerColor = getMaterialColor(R.attr.colorBackgroundFloating),
+      textContentColor = getMaterialColor(R.attr.colorOnBackground),
     )
   }
 
-  /** Supports annotated texts e.g. <b>Hello world</b> */
-  @Composable
-  private fun StyledText(text: CharSequence, modifier: Modifier = Modifier) {
-    AndroidView(
-      modifier = modifier,
-      factory = { context -> TextView(context) },
-      update = {
-        it.text = text
-        it.textSize = 18.toFloat()
-      },
-    )
-  }
+  private fun getMaterialColor(id: Int): Color =
+    Color(MaterialColors.getColor(requireContext(), id, ""))
 }

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
   <string name="error_message">Something went wrong</string>
   <string name="incomplete_area">Incomplete area</string>
   <string name="initializing">Initializing…</string>
-  <string name="draw_area_task_instruction">Move the map and tap <b>Add point</b> to mark this location.</string>
+  <string name="draw_area_task_instruction">Move the map and tap "Add point" to add points around the desired area.</string>
   <string name="close">Close</string>
   <string name="map_location">Map location</string>
   <string name="sign_out_dialog_title">Unsynced data</string>

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
   <string name="error_message">Something went wrong</string>
   <string name="incomplete_area">Incomplete area</string>
   <string name="initializing">Initializing…</string>
-  <string name="draw_area_task_instruction">Move the map and tap "Add point" to add points around the desired area.</string>
+  <string name="draw_area_task_instruction">Move the map and tap “Add point” to add points around the desired area.</string>
   <string name="close">Close</string>
   <string name="map_location">Map location</string>
   <string name="sign_out_dialog_title">Unsynced data</string>

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
@@ -110,8 +110,6 @@ class DrawAreaTaskFragmentTest :
   @Test
   fun testDrawArea_incompleteWhenTaskIsOptional() = runWithTestDispatcher {
     setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
-    fragment.onTaskVisibleToUser()
-
     // Dismiss the instructions dialog
     ShadowDialog.getLatestDialog().dismiss()
 
@@ -143,8 +141,6 @@ class DrawAreaTaskFragmentTest :
   @Test
   fun testDrawArea() = runWithTestDispatcher {
     setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
-    fragment.onTaskVisibleToUser()
-
     // Dismiss the instructions dialog
     ShadowDialog.getLatestDialog().dismiss()
 
@@ -180,8 +176,6 @@ class DrawAreaTaskFragmentTest :
   @Test
   fun `Instructions dialog is shown`() = runWithTestDispatcher {
     setupTaskFragment<DrawAreaTaskFragment>(job, task)
-    fragment.onTaskVisibleToUser()
-
     assertThat(ShadowDialog.getLatestDialog()).isNotNull()
   }
 


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2311

<!-- PR description. -->
Updates text for draw area info. Uses `onResume()` event to trigger the info dialog, since the `setMenuVisibility()` is deprecated in newer versions of Android and was not reliable for determining the task's visibility state overall.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.
Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Updates text to match the mocks.
- [x] Use `onResume()` event + `isVisible` to definitively determine the trigger to show the info dialog.
- [x] [Verified the performance of `SharedPreference`](https://stackoverflow.com/questions/19148282/read-speed-of-sharedpreferences) to be acceptable for multiple rapid-fire calls to `onResume()`.
- [x] Standardized the dialog color.
- [x] Removed unnecessary `StylizedText`, since fontSize already existed.

<!-- Add steps to verify bug/feature. -->
- [x] Existing unit tests pass.
- [x] Locally by removing the setter to always trigger the dialog and determinine that the 

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
<img width="330" alt="Screenshot 2024-03-09 at 5 09 14 PM" src="https://github.com/google/ground-android/assets/12646706/ef5f4302-e0a2-430c-a75b-6c8e60a01c2b">

@gino-m @shobhitagarwal1612 ?
