### PR TITLE
Save LOI name dialog state on the view model to prevent re-triggering the LOI name dialog.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -15,6 +15,8 @@
  */
 package com.google.android.ground.ui.datacollection
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.google.android.ground.coroutines.ApplicationScope
@@ -120,6 +122,8 @@ internal constructor(
           emit(label)
         })
       .stateIn(viewModelScope, SharingStarted.Lazily, "")
+
+  val loiNameDialogOpen: MutableState<Boolean> = mutableStateOf(false)
 
   private val taskViewModels: MutableStateFlow<MutableList<AbstractTaskViewModel>> =
     MutableStateFlow(mutableListOf())


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2331

<!-- PR description. -->
Prevent re-triggering the LOI name dialog when clicking Previous (which recomposes the Composable) by saving the dialog open state on the view model. Also performs some refactoring to adhere to Jetpack State Hoisting architecture.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Add new mutable state to the view model to keep track of whether to open the dialog on each compose.
- [x] Refactor to use `rememberSaveable` for better save state management.
- [x] Broke up the `Pair<String, Boolean>` into two different `rememberSaveables`.

<!-- Add steps to verify bug/feature. -->
- [x] Followed repro case from the bug. Breakpoint on the recompose  step to verify that the boolean state is preserved.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

PTAL @gino-m!
