### PR TITLE
SubmissionStore: Handle exceptions in the allSurveyMutationsFlow

### DIFF
--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
@@ -346,7 +346,7 @@ fun SubmissionMutation.toLocalDataStoreObject(created: AuditInfo): SubmissionEnt
 fun SubmissionMutationEntity.toModelObject(survey: Survey): SubmissionMutation {
   val job =
     survey.getJob(jobId)
-      ?: throw LocalDataConsistencyException("Unknown jobId in submission mutation $id")
+      ?: throw LocalDataConsistencyException("Unknown jobId $jobId in submission mutation $id")
 
   return SubmissionMutation(
     job = job,

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomSubmissionStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomSubmissionStore.kt
@@ -49,6 +49,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 
@@ -217,9 +218,12 @@ class RoomSubmissionStore @Inject internal constructor() : LocalSubmissionStore 
   }
 
   override fun getAllSurveyMutationsFlow(survey: Survey): Flow<List<SubmissionMutation>> =
-    submissionMutationDao.getAllMutationsFlow().map { mutations ->
-      mutations.filter { it.surveyId == survey.id }.map { it.toModelObject(survey) }
-    }
+    submissionMutationDao
+      .getAllMutationsFlow()
+      .map { mutations ->
+        mutations.filter { it.surveyId == survey.id }.map { it.toModelObject(survey) }
+      }
+      .catch { Timber.e("ignoring invalid submission mutation:\n\t${it.message}") }
 
   override suspend fun findByLocationOfInterestId(
     loidId: String,


### PR DESCRIPTION
Adds a `catch` call to handle exceptions thrown during db -> model object conversion for submissions, preventing these from reaching downstream collectors. As a result, these values will be ignored in any downstream flow or collector of the flow.

Towards #2314