### PR TITLE
Lock orientation to portrait mode to prevent reflow issues.

### DIFF
--- a/ground/src/main/AndroidManifest.xml
+++ b/ground/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
     <activity
       android:name=".MainActivity"
       android:exported="true"
-      android:screenOrientation="fullUser"
+      android:screenOrientation="portrait"
       android:windowSoftInputMode="stateHidden|adjustResize">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Addresses #2299

<!-- PR description. -->
To address crashing due to reflow issues when turning, we can temporarily lock the app in portrait mode. This is unfortunately a band-aid on a bigger issue with reconstructing map task fragments, but it does prevent a common cause for this. Furthermore, the app was not designed for landscape, nor larger screens.

We will want to revert this later when we have a better fix.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Locks app in portrait mode.

<!-- Add steps to verify bug/feature. -->
- [x] Spun the emulator around while auto-rotate was on, saw that the orientation was locked.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
![Screenshot 2024-03-12 at 4 47 42 PM](https://github.com/google/ground-android/assets/12646706/89e4c178-6620-41cd-8600-be68c13dac34)

@gino-m 
