### PR TITLE
Move back to map after offline area download.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorViewModel.kt
@@ -109,7 +109,7 @@ internal constructor(
         downloadProgress.postValue(bytesDownloaded)
       }
       isDownloadProgressVisible.postValue(false)
-      navigator.navigateUp()
+      navigator.navigate(OfflineAreaSelectorFragmentDirections.offlineAreaBackToHomescreen())
     }
   }
 

--- a/ground/src/main/res/navigation/nav_graph.xml
+++ b/ground/src/main/res/navigation/nav_graph.xml
@@ -183,8 +183,8 @@
     android:label="@string/offline_area_selector"
     tools:layout="@layout/offline_area_selector_frag">
     <action
-      android:id="@+id/backToOfflineAreas"
-      app:destination="@id/offline_areas_fragment" />
+      android:id="@+id/offline_area_back_to_homescreen"
+      app:destination="@id/home_screen_fragment" />
   </fragment>
   <fragment
     android:id="@+id/offline_area_viewer_fragment"


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2301

<!-- PR description. -->
Moves back to the map after completing a download.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Replaces unused `nav_graph` direction, `backToOfflineAreas`, with `offline_area_back_to_homescreen`
- [x] Instead of navigating up the back stack, navigate to the home screen instead. 

<!-- Add steps to verify bug/feature. -->
- [x] Downloaded an offline area and saw that the map view was returned to, conveniently exactly where the download occurred!

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
<img width="552" alt="Screenshot 2024-03-12 at 6 18 23 PM" src="https://github.com/google/ground-android/assets/12646706/a05ac73f-5f02-481e-95c7-904eb9402126">

![Screenshot 2024-03-12 at 6 26 24 PM](https://github.com/google/ground-android/assets/12646706/a76f3432-ce1a-4bf7-868e-a4d2d3556329)


@gino-m 
