### PR TITLE
ADD Troubleshooting SHA1 matching issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,3 +199,12 @@ $ gcloud builds submit --config=cloudbuild.yaml --substitutions=_ANDROID_VERSION
 
   Open to SDK Manager in Android Studio and download and install the required version of the Android
   SDK, accepting relevant licenses agreements when prompted.
+
+* When logging in with Google, if you encounter the following exception in the stack trace:
+
+    ```
+    Sign in failed  
+    com.google.android.gms.common.api.ApiException: 10:
+    ```
+
+  Solution: Run `./gradlew :ground:signingReport` in the terminal, and check if the 'SHA1' value of the current 'Build variants' type matches with your Firebase Project.


### PR DESCRIPTION
<!-- PR description. -->

It seems like the issue of SHA1 mismatch during Google login could be encountered by everyone who runs the project for the first time. It would be a good idea to add this to a separate troubleshooting tab.

@gino-m PTAL