### PR TITLE
NavDrawer: Include survey info

### DIFF
--- a/ground/src/main/res/layout/nav_drawer_header.xml
+++ b/ground/src/main/res/layout/nav_drawer_header.xml
@@ -24,11 +24,15 @@
     <variable
       name="user"
       type="com.google.android.ground.model.User" />
+    <variable
+      name="survey"
+      type="com.google.android.ground.model.Survey" />
   </data>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="22dp"
     android:background="?attr/colorSurfaceVariant"
     android:fitsSystemWindows="true"
     android:orientation="vertical">
@@ -50,6 +54,57 @@
       style="@style/NavDrawerHeader.SecondaryText"
       android:text="@{user.email}"
       tools:text="User email" />
-
+    <com.google.android.material.divider.MaterialDivider
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content" />
+    <LinearLayout
+      style="@style/NavDrawerHeader"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="16dp"
+      android:fitsSystemWindows="true"
+      android:orientation="vertical">
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/current_survey"
+        app:drawableStartCompat="@drawable/ic_content_paste"
+        tools:text="Current survey" />
+      <TextView
+        android:id="@+id/no_surveys_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/no_survey_selected"
+        android:visibility="gone"
+        />
+       <LinearLayout
+         android:id="@+id/survey_info"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:orientation="vertical">
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@{survey.title}"
+        android:textStyle="bold"
+        tools:text="Deforestation areas" />
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@{survey.description}"
+        tools:text="A survey about farms. Collect information on all the farms." />
+       </LinearLayout>
+      <TextView
+        android:id="@+id/switch_survey_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:text="@string/switch_survey"
+        android:textColor="@color/task_transparent_btn_selector" />
+    </LinearLayout>
   </LinearLayout>
 </layout>

--- a/ground/src/main/res/menu/nav_drawer_menu.xml
+++ b/ground/src/main/res/menu/nav_drawer_menu.xml
@@ -18,10 +18,6 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
   <item
-    android:id="@+id/nav_change_survey"
-    android:icon="@drawable/ic_content_paste"
-    android:title="@string/change_survey" />
-  <item
     android:id="@+id/sync_status"
     android:icon="@drawable/ic_history"
     android:title="@string/sync_status" />

--- a/ground/src/main/res/values/strings.xml
+++ b/ground/src/main/res/values/strings.xml
@@ -42,7 +42,6 @@
   <string name="google_api_install_failed">Google Play Services installation failed</string>
   <string name="sign_out">Sign out</string>
   <string name="ok">OK</string>
-  <string name="change_survey">Surveys</string>
   <string name="collect_data">Collect data</string>
 
   <!-- Untranslated strings -->
@@ -149,4 +148,7 @@
   </plurals>
   <string name="loi_name_dialog_title">Name this location</string>
   <string name="loi_name_dialog_body">A new data collection site will be created.</string>
+  <string name="current_survey">Current survey</string>
+  <string name="switch_survey">Switch survey</string>
+  <string name="no_survey_selected">No survey selected</string>
 </resources>


### PR DESCRIPTION
Updates the layout of the navigation drawer to include information about the active survey and gets us closer to the latest mocks.

Towards #2136 

<img width="453" alt="Screenshot 2024-03-15 at 12 59 00 PM" src="https://github.com/google/ground-android/assets/11237600/bd460719-3b8d-4201-85f5-d2a06bae12f4">
(the black rectangle isn't in the UI, I just redacted my email)


@sufyanAbbasi 