### PR TITLE
Allow navigating to previous task for required fields when task is empty

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -26,6 +26,7 @@ import com.google.android.ground.model.Survey
 import com.google.android.ground.model.job.Job
 import com.google.android.ground.model.submission.Value
 import com.google.android.ground.model.submission.ValueDelta
+import com.google.android.ground.model.submission.isNullOrEmpty
 import com.google.android.ground.model.task.Condition
 import com.google.android.ground.model.task.Task
 import com.google.android.ground.persistence.local.room.converter.SubmissionDeltasConverter
@@ -189,12 +190,19 @@ internal constructor(
     taskViewModels.value = taskViewModels.value
   }
 
-  /**
-   * Validates the user's input and displays an error if the user input was invalid. Moves back to
-   * the previous Data Collection screen if the user input was valid.
-   */
+  /** Moves back to the previous task in the sequence if the current value is valid or empty. */
   suspend fun onPreviousClicked(taskViewModel: AbstractTaskViewModel) {
     check(getPositionInTaskSequence().first != 0)
+
+    val task = taskViewModel.task
+    val taskValue = taskViewModel.taskValue.firstOrNull()
+
+    // Skip validation if the task is empty
+    if (taskValue.isNullOrEmpty()) {
+      data[task] = taskValue
+      step(-1)
+      return
+    }
 
     val validationError = taskViewModel.validate()
     if (validationError != null) {
@@ -202,8 +210,7 @@ internal constructor(
       return
     }
 
-    data[taskViewModel.task] = taskViewModel.taskValue.firstOrNull()
-
+    data[task] = taskValue
     step(-1)
   }
 

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -166,16 +166,16 @@ class DataCollectionFragmentTest : BaseHiltTest() {
   }
 
   @Test
-  fun `Click previous button does not show initial task if validation failed`() {
+  fun `Click previous button moves to previous task if task is empty`() {
     runner()
       .inputText(TASK_1_RESPONSE)
       .clickNextButton()
       .clickPreviousButton()
-      .validateTextIsDisplayed(TASK_2_NAME)
-      .validateTextIsNotDisplayed(TASK_1_NAME)
+      .validateTextIsDisplayed(TASK_1_NAME)
+      .validateTextIsNotDisplayed(TASK_2_NAME)
 
-    // Validation error is shown as a toast message
-    assertThat(ShadowToast.shownToastCount()).isEqualTo(1)
+    // Validation error is not shown
+    assertThat(ShadowToast.shownToastCount()).isEqualTo(0)
   }
 
   @Test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2359

<!-- PR description. -->
In the current behavior, the validation fails due to empty value and we show an error toast message instead of navigating to previous task fragment. This PR changes that by not validating the task value if it is empty for previous button only.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
