### PR TITLE
[ACLs] Prevent data collectors from seeing each other's LOIs

### DIFF
--- a/ground/src/main/java/com/google/android/ground/persistence/remote/RemoteDataStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/RemoteDataStore.kt
@@ -44,7 +44,7 @@ interface RemoteDataStore {
   suspend fun loadTermsOfService(): TermsOfService?
 
   /** Returns all LOIs in the specified survey. Main-safe. */
-  suspend fun loadLocationsOfInterest(survey: Survey): List<LocationOfInterest>
+  suspend fun loadPredefinedLois(survey: Survey): List<LocationOfInterest>
 
   /**
    * Returns a list of all submissions associated with the specified LOI, or an empty list if none
@@ -67,4 +67,6 @@ interface RemoteDataStore {
 
   /** Refreshes the current user's profile info in the remote database. */
   suspend fun refreshUserProfile()
+
+  suspend fun loadUserDefinedLois(survey: Survey, creatorEmail: String): List<LocationOfInterest>
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/RemoteDataStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/RemoteDataStore.kt
@@ -43,8 +43,11 @@ interface RemoteDataStore {
    */
   suspend fun loadTermsOfService(): TermsOfService?
 
-  /** Returns all LOIs in the specified survey. Main-safe. */
+  /** Returns predefined LOIs in the specified survey. Main-safe. */
   suspend fun loadPredefinedLois(survey: Survey): List<LocationOfInterest>
+
+  /** Returns LOIs created by the specified email in the specified survey. Main-safe. */
+  suspend fun loadUserDefinedLois(survey: Survey, creatorEmail: String): List<LocationOfInterest>
 
   /**
    * Returns a list of all submissions associated with the specified LOI, or an empty list if none
@@ -67,6 +70,4 @@ interface RemoteDataStore {
 
   /** Refreshes the current user's profile info in the remote database. */
   suspend fun refreshUserProfile()
-
-  suspend fun loadUserDefinedLois(survey: Survey, creatorEmail: String): List<LocationOfInterest>
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/FirestoreDataStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/FirestoreDataStore.kt
@@ -79,8 +79,11 @@ internal constructor(
     )
   }
 
-  override suspend fun loadLocationsOfInterest(survey: Survey) =
-    db().surveys().survey(survey.id).lois().locationsOfInterest(survey)
+  override suspend fun loadPredefinedLois(survey: Survey) =
+    db().surveys().survey(survey.id).lois().fetchPredefined(survey)
+
+  override suspend fun loadUserDefinedLois(survey: Survey, creatorEmail: String) =
+    db().surveys().survey(survey.id).lois().fetchUserDefined(survey, creatorEmail)
 
   override suspend fun subscribeToSurveyUpdates(surveyId: String) {
     Timber.d("Subscribing to FCM topic $surveyId")

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiCollectionReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiCollectionReference.kt
@@ -21,19 +21,44 @@ import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.persistence.remote.firebase.base.FluentCollectionReference
 import com.google.android.ground.persistence.remote.firebase.schema.LoiConverter.toLoi
 import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.QuerySnapshot
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+
+/**
+ * Path of field on LOI documents used to differentiate LOIs defined by the organizer vs by data
+ * collectors.
+ */
+const val PREDEFINED_FIELD = "predefined"
+/** Path of field on LOI documents representing the creator of the LOI. */
+val CREATOR_EMAIL_FIELD = FieldPath.of("created", "user", "email")
 
 class LoiCollectionReference internal constructor(ref: CollectionReference) :
   FluentCollectionReference(ref) {
 
   fun loi(id: String) = LoiDocumentReference(reference().document(id))
 
-  /** Retrieves all LOIs in the specified survey. Main-safe. */
-  suspend fun locationsOfInterest(survey: Survey): List<LocationOfInterest> =
-    withContext(ioDispatcher) { toLois(survey, reference().get().await()) }
+  /** Retrieves all "predefined" LOIs in the specified survey. Main-safe. */
+  suspend fun fetchPredefined(survey: Survey): List<LocationOfInterest> =
+    withContext(ioDispatcher) {
+      // Use !=false rather than ==true to not break legacy dev surveys.
+      // TODO(#2375): Switch to whereEqualTo(true) once legacy dev surveys deleted or migrated.
+      val query = reference().whereNotEqualTo(PREDEFINED_FIELD, false)
+      toLois(survey, query.get().await())
+    }
+
+  /** Retrieves LOIs created by the specified email in the specified survey. Main-safe. */
+  suspend fun fetchUserDefined(survey: Survey, creatorEmail: String): List<LocationOfInterest> =
+    withContext(ioDispatcher) {
+      Timber.e(creatorEmail)
+      val query =
+        reference()
+          .whereEqualTo(PREDEFINED_FIELD, false)
+          .whereEqualTo(CREATOR_EMAIL_FIELD, creatorEmail)
+      toLois(survey, query.get().await())
+    }
 
   private suspend fun toLois(survey: Survey, snapshot: QuerySnapshot): List<LocationOfInterest> =
     withContext(defaultDispatcher) {

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -29,6 +29,7 @@ import com.google.android.ground.persistence.remote.NotFoundException
 import com.google.android.ground.persistence.remote.RemoteDataStore
 import com.google.android.ground.persistence.sync.MutationSyncWorkManager
 import com.google.android.ground.persistence.uuid.OfflineUuidGenerator
+import com.google.android.ground.system.auth.AuthenticationManager
 import com.google.android.ground.ui.map.Bounds
 import com.google.android.ground.ui.map.gms.GmsExt.contains
 import javax.inject.Inject
@@ -52,10 +53,15 @@ constructor(
   private val remoteDataStore: RemoteDataStore,
   private val mutationSyncWorkManager: MutationSyncWorkManager,
   private val uuidGenerator: OfflineUuidGenerator,
+  private val authenticationManager: AuthenticationManager
 ) {
   /** Mirrors locations of interest in the specified survey from the remote db into the local db. */
   suspend fun syncLocationsOfInterest(survey: Survey) {
-    val lois = remoteDataStore.loadLocationsOfInterest(survey)
+    val creatorEmail = authenticationManager.getAuthenticatedUser().email
+    val lois =
+      with(remoteDataStore) {
+        loadPredefinedLois(survey) + loadUserDefinedLois(survey, creatorEmail)
+      }
     mergeAll(survey.id, lois)
   }
 

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -57,6 +57,7 @@ constructor(
 ) {
   /** Mirrors locations of interest in the specified survey from the remote db into the local db. */
   suspend fun syncLocationsOfInterest(survey: Survey) {
+    // TODO(#2384): Allow survey organizers to make ad hoc LOIs visible to all data collectors.
     val creatorEmail = authenticationManager.getAuthenticatedUser().email
     val lois =
       with(remoteDataStore) {

--- a/ground/src/test/java/com/google/android/ground/repository/LocationOfInterestRepositoryTest.kt
+++ b/ground/src/test/java/com/google/android/ground/repository/LocationOfInterestRepositoryTest.kt
@@ -70,7 +70,7 @@ class LocationOfInterestRepositoryTest : BaseHiltTest() {
 
       // Setup survey and LOIs
       fakeRemoteDataStore.surveys = listOf(TEST_SURVEY)
-      fakeRemoteDataStore.lois = TEST_LOCATIONS_OF_INTEREST
+      fakeRemoteDataStore.predefinedLois = TEST_LOCATIONS_OF_INTEREST
       activateSurvey(TEST_SURVEY.id)
       advanceUntilIdle()
     }

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -233,7 +233,7 @@ class DataCollectionFragmentTest : BaseHiltTest() {
       .thenReturn(SUBMISSION)
 
     fakeRemoteDataStore.surveys = listOf(SURVEY)
-    fakeRemoteDataStore.lois = listOf(LOCATION_OF_INTEREST)
+    fakeRemoteDataStore.predefinedLois = listOf(LOCATION_OF_INTEREST)
     activateSurvey(SURVEY.id)
     advanceUntilIdle()
   }

--- a/sharedTest/src/main/kotlin/com/sharedtest/persistence/remote/FakeRemoteDataStore.kt
+++ b/sharedTest/src/main/kotlin/com/sharedtest/persistence/remote/FakeRemoteDataStore.kt
@@ -31,7 +31,8 @@ import kotlinx.coroutines.flow.flowOf
 
 @Singleton
 class FakeRemoteDataStore @Inject internal constructor() : RemoteDataStore {
-  var lois = emptyList<LocationOfInterest>()
+  var predefinedLois = emptyList<LocationOfInterest>()
+  var userDefinedLois = emptyList<LocationOfInterest>()
   var surveys = emptyList<Survey>()
   var onLoadSurvey = { surveyId: String -> surveys.firstOrNull { it.id == surveyId } }
   var userProfileRefreshCount = 0
@@ -49,7 +50,7 @@ class FakeRemoteDataStore @Inject internal constructor() : RemoteDataStore {
 
   override suspend fun loadTermsOfService(): TermsOfService? = termsOfService?.getOrThrow()
 
-  override suspend fun loadLocationsOfInterest(survey: Survey) = lois
+  override suspend fun loadPredefinedLois(survey: Survey) = predefinedLois
 
   override suspend fun loadSubmissions(locationOfInterest: LocationOfInterest): List<Submission> {
     TODO("Missing implementation")
@@ -68,6 +69,11 @@ class FakeRemoteDataStore @Inject internal constructor() : RemoteDataStore {
   override suspend fun refreshUserProfile() {
     userProfileRefreshCount++
   }
+
+  override suspend fun loadUserDefinedLois(
+    survey: Survey,
+    creatorEmail: String
+  ): List<LocationOfInterest> = userDefinedLois
 
   /** Returns true iff [subscribeToSurveyUpdates] has been called with the specified id. */
   fun isSubscribedToSurveyUpdates(surveyId: String): Boolean =


### PR DESCRIPTION
This PR hard codes this behavior for surveys by default. As follow-ups, we'll want to 1) add restriction server side and 2) allow survey organizers to control whether data collectors can see each other's data.

Tested manually on Pixel 7, Android 14, API 34.

Towards #2374

@lecrabe @rfontanarosa @jcqli  FYI