### PR TITLE
[Auth] Wait for user to be initialized before checking if null

### DIFF
--- a/ground/src/main/java/com/google/android/ground/system/auth/GoogleAuthenticationManager.kt
+++ b/ground/src/main/java/com/google/android/ground/system/auth/GoogleAuthenticationManager.kt
@@ -71,8 +71,10 @@ constructor(
   override val signInState: Flow<SignInState> = _signInStateFlow.asStateFlow().filterNotNull()
 
   override fun init() {
-    val user = firebaseAuth.currentUser?.toUser()
-    setState(if (user == null) SignInState.signedOut() else SignInState.signedIn(user))
+    firebaseAuth.addAuthStateListener { auth ->
+      val user = auth.currentUser?.toUser()
+      setState(if (user == null) SignInState.signedOut() else SignInState.signedIn(user))
+    }
   }
 
   private fun setState(nextState: SignInState) {


### PR DESCRIPTION
`FirebaseAuth` doesn't block the main thread, so checking its state directly at startup may be producing a race condition on init of the current user. Waiting for auth events before checking should solve this issue.

Fixes #2390