### PR TITLE
Refactor `readOnly` -> `noLois` in `SurveyProperties`

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskMapFragment.kt
@@ -52,8 +52,9 @@ class CaptureLocationTaskMapFragment(private val viewModel: CaptureLocationTaskV
   }
 
   override fun onMapReady(map: MapFragment) {
-    binding.basemap.locationLockBtn.isClickable = false
-    viewLifecycleOwner.lifecycleScope.launch { mapViewModel.enableLocationLockAndGetUpdates() }
+    //    binding.basemap.locationLockBtn.isClickable = false
+    //    viewLifecycleOwner.lifecycleScope.launch { mapViewModel.enableLocationLockAndGetUpdates()
+    // }
   }
 
   companion object {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskMapFragment.kt
@@ -52,9 +52,8 @@ class CaptureLocationTaskMapFragment(private val viewModel: CaptureLocationTaskV
   }
 
   override fun onMapReady(map: MapFragment) {
-    //    binding.basemap.locationLockBtn.isClickable = false
-    //    viewLifecycleOwner.lifecycleScope.launch { mapViewModel.enableLocationLockAndGetUpdates()
-    // }
+    binding.basemap.locationLockBtn.isClickable = false
+    viewLifecycleOwner.lifecycleScope.launch { mapViewModel.enableLocationLockAndGetUpdates() }
   }
 
   companion object {

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -156,7 +156,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
       .launchWhenStartedAndCollectFirst {
         val (surveyProperties, isZoomedOut) = it
         when {
-          surveyProperties.readOnly -> R.string.read_only_data_collection_hint
+          surveyProperties.noLois && !surveyProperties.addLoiPermitted-> R.string.read_only_data_collection_hint
           isZoomedOut && surveyProperties.addLoiPermitted -> R.string.suggest_data_collection_hint
           isZoomedOut -> R.string.predefined_data_collection_hint
           else -> null

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -156,7 +156,8 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
       .launchWhenStartedAndCollectFirst {
         val (surveyProperties, isZoomedOut) = it
         when {
-          surveyProperties.noLois && !surveyProperties.addLoiPermitted-> R.string.read_only_data_collection_hint
+          surveyProperties.noLois && !surveyProperties.addLoiPermitted ->
+            R.string.read_only_data_collection_hint
           isZoomedOut && surveyProperties.addLoiPermitted -> R.string.suggest_data_collection_hint
           isZoomedOut -> R.string.predefined_data_collection_hint
           else -> null

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -94,7 +94,7 @@ internal constructor(
     activeSurvey.filterNotNull().map { survey ->
       val lois = loiRepository.getLocationsOfInterests(survey).first()
       val addLoiPermitted = survey.jobs.any { job -> job.canDataCollectorsAddLois }
-      SurveyProperties(addLoiPermitted=addLoiPermitted, noLois = lois.isEmpty())
+      SurveyProperties(addLoiPermitted = addLoiPermitted, noLois = lois.isEmpty())
     }
 
   /** Set of [Feature] to render on the map. */

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -84,7 +84,7 @@ internal constructor(
   val activeSurvey: StateFlow<Survey?> = surveyRepository.activeSurveyFlow
 
   /** Captures essential, high-level derived properties for a given survey. */
-  data class SurveyProperties(val addLoiPermitted: Boolean, val readOnly: Boolean)
+  data class SurveyProperties(val addLoiPermitted: Boolean, val noLois: Boolean)
 
   /**
    * This flow emits [SurveyProperties] when the active survey changes. Callers can use this data to
@@ -93,7 +93,8 @@ internal constructor(
   val surveyUpdateFlow: Flow<SurveyProperties> =
     activeSurvey.filterNotNull().map { survey ->
       val lois = loiRepository.getLocationsOfInterests(survey).first()
-      SurveyProperties(survey.jobs.any { job -> job.canDataCollectorsAddLois }, lois.isEmpty())
+      val addLoiPermitted = survey.jobs.any { job -> job.canDataCollectorsAddLois }
+      SurveyProperties(addLoiPermitted=addLoiPermitted, noLois = lois.isEmpty())
     }
 
   /** Set of [Feature] to render on the map. */


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2376

<!-- PR description. -->
Make `SurveyProperties` contain the data needed to compute a read only state instead. I mistakenly assumed 

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Refactor `readOnly` -> `noLois` in `SurveyProperties`
- [x] Compute the `readOnly` state downstream instead. 

<!-- Add steps to verify bug/feature. -->
- [x] Created a survey with empty LOIs with no ad-hoc LOIs, saw the read-only card was shown.
- [x] Toggled the ad-hoc switch and  saw that the card was replaced with the zoom-in one (needed a fragment refresh)

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
<img width="380" alt="Screenshot 2024-03-18 at 8 34 07 PM" src="https://github.com/google/ground-android/assets/12646706/88c7ef1b-b0a5-4b01-89a3-4a385b1433cb">
<img width="363" alt="Screenshot 2024-03-18 at 8 36 26 PM" src="https://github.com/google/ground-android/assets/12646706/de5b0ef9-4eda-4c32-8dc6-350a68ceca4b">


PTAL @gino-m @shobhitagarwal1612 