### PR TITLE
Only trigger permission dialog for capture location when user arrives on the task.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/system/PermissionsManager.kt
+++ b/ground/src/main/java/com/google/android/ground/system/PermissionsManager.kt
@@ -61,7 +61,7 @@ constructor(
     }
 
   /** Returns `true` iff the app has been granted the specified permission. */
-  private fun isGranted(permission: String): Boolean =
+  fun isGranted(permission: String): Boolean =
     checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
 
   /** Throws an error [PermissionDeniedException] if the request permission was denied. */

--- a/ground/src/main/java/com/google/android/ground/ui/common/BaseMapViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/BaseMapViewModel.kt
@@ -126,6 +126,10 @@ constructor(
         .asLiveData()
   }
 
+  /** Returns whether the user has granted fine location permission. */
+  fun hasLocationPermission() =
+    permissionsManager.isGranted(Manifest.permission.ACCESS_FINE_LOCATION)
+
   private suspend fun toggleLocationLock() {
     if (locationLock.value.getOrDefault(false)) {
       disableLocationLock()

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
@@ -18,6 +18,7 @@ package com.google.android.ground.ui.datacollection.tasks.location
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.LinearLayout
+import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
 import com.google.android.ground.model.submission.isNotNullOrEmpty
 import com.google.android.ground.model.submission.isNullOrEmpty
@@ -28,6 +29,7 @@ import com.google.android.ground.ui.datacollection.tasks.AbstractTaskFragment
 import com.google.android.ground.ui.map.MapFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class CaptureLocationTaskFragment : AbstractTaskFragment<CaptureLocationTaskViewModel>() {
@@ -48,6 +50,13 @@ class CaptureLocationTaskFragment : AbstractTaskFragment<CaptureLocationTaskView
       )
       .commit()
     return rowLayout
+  }
+
+  override fun onTaskResume() {
+    // Ensure that the location lock is enabled, if it hasn't been..
+    if (viewModel.enableLocationLockFlow.value == false) {
+      viewLifecycleOwner.lifecycleScope.launch { viewModel.enableLocationLockFlow.emit(true) }
+    }
   }
 
   override fun onCreateActionButtons() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskMapFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskMapFragment.kt
@@ -53,7 +53,23 @@ class CaptureLocationTaskMapFragment(private val viewModel: CaptureLocationTaskV
 
   override fun onMapReady(map: MapFragment) {
     binding.basemap.locationLockBtn.isClickable = false
-    viewLifecycleOwner.lifecycleScope.launch { mapViewModel.enableLocationLockAndGetUpdates() }
+    viewLifecycleOwner.lifecycleScope.launch {
+      val locationLockEnabled: Boolean? =
+        if (mapViewModel.hasLocationPermission()) {
+          mapViewModel.enableLocationLockAndGetUpdates()
+          null
+        } else {
+          false
+        }
+      viewModel.enableLocationLockFlow.value = locationLockEnabled
+      viewModel.enableLocationLockFlow.collect {
+        if (it == true) {
+          // No-op if permission already granted.
+          mapViewModel.enableLocationLockAndGetUpdates()
+          viewModel.enableLocationLockFlow.value = null
+        }
+      }
+    }
   }
 
   companion object {


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2388

<!-- PR description. -->
Prevents the location permission dialog from being shown too early (see issue for explanation), by only triggering early when the user has already given permission, and otherwise waiting to trigger the dialog until the user has arrived at the capture location task.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Adds a new flow property, `enableLocationLockFlow`, that keeps track of three states: 
1.   whether the location lock has already been enabled (`null`)
2.  whether the location lock needs to be enabled (`false`)
3.  whether to actually enable the location lock  (`true`)
- [x] If permission was already given, the existing behavior of starting the location lock early is preserved.
- [x] If permission was not given, then the request to turn on location lock is deferred to when the task is resumed or the user hits "Capture" if they declined the permission.

<!-- Add steps to verify bug/feature. -->
- [x] Created survey with a text task before a capture location task. Verified that turning off permission does not trigger the permission early, and triggers when the user arrives on the task.
- [x] Verified that already having the permission replicates the existing behavior.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

PTAL @gino-m @shobhitagarwal1612 !
