### PR TITLE
Use `taskId` instead of `position` for initializing task view models

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -321,13 +321,9 @@ internal constructor(
     saveDraft()
   }
 
-  /** Returns true if the given task index is last if set, or the current active task. */
-  fun isLastPosition(taskIndex: Int? = null): Boolean =
-    if (taskIndex == null) {
-      currentTaskId.value
-    } else {
-      tasks[taskIndex].id
-    } == getTaskSequence().last().id
+  /** Returns true if the given [taskId] is last if set, or the current active task. */
+  fun isLastPosition(taskId: String? = null): Boolean =
+    (taskId ?: currentTaskId.value) == getTaskSequence().last().id
 
   /** Evaluates the task condition against the current inputs. */
   private fun evaluateCondition(condition: Condition): Boolean =

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -321,6 +321,9 @@ internal constructor(
     saveDraft()
   }
 
+  /** Returns true if the given [taskId] is first in the sequence of displayed tasks. */
+  fun isFirstPosition(taskId: String): Boolean = taskId == getTaskSequence().first().id
+
   /** Returns true if the given [taskId] is last if set, or the current active task. */
   fun isLastPosition(taskId: String? = null): Boolean =
     (taskId ?: currentTaskId.value) == getTaskSequence().last().id

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewPagerAdapter.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewPagerAdapter.kt
@@ -57,8 +57,6 @@ constructor(@Assisted fragment: Fragment, @Assisted val tasks: List<Task>) :
           throw UnsupportedOperationException("Unsupported task type: ${task.type}")
       }
 
-    return taskFragment.also {
-      it.taskId = task.id
-    }
+    return taskFragment.also { it.taskId = task.id }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewPagerAdapter.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewPagerAdapter.kt
@@ -58,7 +58,6 @@ constructor(@Assisted fragment: Fragment, @Assisted val tasks: List<Task>) :
       }
 
     return taskFragment.also {
-      it.position = position
       it.taskId = task.id
     }
   }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewPagerAdapter.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewPagerAdapter.kt
@@ -35,10 +35,8 @@ import dagger.assisted.AssistedInject
  */
 class DataCollectionViewPagerAdapter
 @AssistedInject
-constructor(
-  @Assisted fragment: Fragment,
-  @Assisted val tasks: List<Task>,
-) : FragmentStateAdapter(fragment) {
+constructor(@Assisted fragment: Fragment, @Assisted val tasks: List<Task>) :
+  FragmentStateAdapter(fragment) {
   override fun getItemCount(): Int = tasks.size
 
   override fun createFragment(position: Int): Fragment {
@@ -59,6 +57,9 @@ constructor(
           throw UnsupportedOperationException("Unsupported task type: ${task.type}")
       }
 
-    return taskFragment.also { it.position = position }
+    return taskFragment.also {
+      it.position = position
+      it.taskId = task.id
+    }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -140,7 +140,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
   private fun addPreviousButton() =
     addButton(ButtonAction.PREVIOUS)
       .setOnClickListener { moveToPrevious() }
-      .showIfTrue(position != 0)
+      .showIfTrue(!dataCollectionViewModel.isFirstPosition(taskId))
 
   protected fun addNextButton() =
     addButton(ButtonAction.NEXT)

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -212,7 +212,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
 
   /** Returns true if the given [ButtonAction] should be replace with "Done" button. */
   private fun ButtonAction.shouldReplaceWithDoneButton() =
-    this == ButtonAction.NEXT && dataCollectionViewModel.isLastPosition(position)
+    this == ButtonAction.NEXT && dataCollectionViewModel.isLastPosition(taskId)
 
   fun getTask(): Task = viewModel.task
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -55,21 +55,18 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
   private lateinit var taskView: TaskView
   protected lateinit var viewModel: T
 
-  /** Position of the task in the Job's sorted task list. Used for instantiating the [viewModel]. */
-  var position by Delegates.notNull<Int>()
+  /** ID of the associated task in the Job. Used for instantiating the [viewModel]. */
   var taskId by Delegates.notNull<String>()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     if (savedInstanceState != null) {
-      position = savedInstanceState.getInt(POSITION)
       taskId = requireNotNull(savedInstanceState.getString(TASK_ID))
     }
   }
 
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
-    outState.putInt(POSITION, position)
     outState.putString(TASK_ID, taskId)
   }
 
@@ -259,8 +256,6 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
   }
 
   companion object {
-    /** Key used to store the position of the task in the Job's sorted tasklist. */
-    const val POSITION = "position"
     const val TASK_ID = "taskId"
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -57,23 +57,26 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
 
   /** Position of the task in the Job's sorted task list. Used for instantiating the [viewModel]. */
   var position by Delegates.notNull<Int>()
+  var taskId by Delegates.notNull<String>()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     if (savedInstanceState != null) {
       position = savedInstanceState.getInt(POSITION)
+      taskId = requireNotNull(savedInstanceState.getString(TASK_ID))
     }
   }
 
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
     outState.putInt(POSITION, position)
+    outState.putString(TASK_ID, taskId)
   }
 
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View? {
     super.onCreateView(inflater, container, savedInstanceState)
     taskView = onCreateTaskView(inflater)
@@ -84,7 +87,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
     super.onViewCreated(view, savedInstanceState)
     view.doOnAttach {
       @Suppress("UNCHECKED_CAST", "LabeledExpression")
-      val vm = dataCollectionViewModel.getTaskViewModel(position) as? T ?: return@doOnAttach
+      val vm = dataCollectionViewModel.getTaskViewModel(taskId) as? T ?: return@doOnAttach
 
       viewModel = vm
       taskView.bind(this, viewModel)
@@ -200,7 +203,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
           ButtonAction.Location.START -> taskView.actionButtonsContainer.startButtons
           ButtonAction.Location.END -> taskView.actionButtonsContainer.endButtons
         },
-        layoutInflater
+        layoutInflater,
       )
     buttonsIndex[buttons.size] = action
     buttons[action] = button
@@ -250,7 +253,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
           name = initialNameValue
           openAlertDialog = false
         },
-        onTextFieldChange = { name = it }
+        onTextFieldChange = { name = it },
       )
     }
   }
@@ -258,5 +261,6 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
   companion object {
     /** Key used to store the position of the task in the Job's sorted tasklist. */
     const val POSITION = "position"
+    const val TASK_ID = "taskId"
   }
 }

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/BaseTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/BaseTaskFragmentTest.kt
@@ -113,7 +113,7 @@ abstract class BaseTaskFragmentTest<F : AbstractTaskFragment<VM>, VM : AbstractT
   protected inline fun <reified T : Fragment> setupTaskFragment(job: Job, task: Task) {
     viewModel = viewModelFactory.create(DataCollectionViewModel.getViewModelClass(task.type)) as VM
     viewModel.initialize(job, task, null)
-    whenever(dataCollectionViewModel.getTaskViewModel(task.index)).thenReturn(viewModel)
+    whenever(dataCollectionViewModel.getTaskViewModel(task.id)).thenReturn(viewModel)
 
     launchFragmentWithNavController<T>(
       destId = R.id.data_collection_fragment,

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/BaseTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/BaseTaskFragmentTest.kt
@@ -119,7 +119,6 @@ abstract class BaseTaskFragmentTest<F : AbstractTaskFragment<VM>, VM : AbstractT
       destId = R.id.data_collection_fragment,
       preTransactionAction = {
         fragment = this as F
-        fragment.position = task.index
         fragment.taskId = task.id
       }
     )

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/BaseTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/BaseTaskFragmentTest.kt
@@ -120,6 +120,7 @@ abstract class BaseTaskFragmentTest<F : AbstractTaskFragment<VM>, VM : AbstractT
       preTransactionAction = {
         fragment = this as F
         fragment.position = task.index
+        fragment.taskId = task.id
       }
     )
   }

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
@@ -32,7 +32,6 @@ import com.google.android.ground.ui.common.ViewModelFactory
 import com.google.android.ground.ui.datacollection.DataCollectionViewModel
 import com.google.android.ground.ui.datacollection.components.ButtonAction
 import com.google.android.ground.ui.datacollection.tasks.BaseTaskFragmentTest
-import com.google.android.ground.ui.map.gms.mog.sec
 import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
@@ -32,6 +32,7 @@ import com.google.android.ground.ui.common.ViewModelFactory
 import com.google.android.ground.ui.datacollection.DataCollectionViewModel
 import com.google.android.ground.ui.datacollection.components.ButtonAction
 import com.google.android.ground.ui.datacollection.tasks.BaseTaskFragmentTest
+import com.google.android.ground.ui.map.gms.mog.sec
 import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -256,7 +257,8 @@ class MultipleChoiceTaskFragmentTest :
   }
 
   @Test
-  fun `renders action buttons when optional`() {
+  fun `renders action buttons when first task and optional`() {
+    whenever(dataCollectionViewModel.isFirstPosition(task.id)).thenReturn(true)
     setupTaskFragment<MultipleChoiceTaskFragment>(job, task.copy(isRequired = false))
 
     buttonIsHidden("Previous")
@@ -284,7 +286,8 @@ class MultipleChoiceTaskFragmentTest :
   }
 
   @Test
-  fun `renders action buttons when task is required`() {
+  fun `renders action buttons when task is first and required`() {
+    whenever(dataCollectionViewModel.isFirstPosition(task.id)).thenReturn(true)
     setupTaskFragment<MultipleChoiceTaskFragment>(job, task.copy(isRequired = true))
 
     buttonIsHidden("Previous")
@@ -293,8 +296,9 @@ class MultipleChoiceTaskFragmentTest :
   }
 
   @Test
-  fun `renders action buttons when task is second`() {
-    setupTaskFragment<MultipleChoiceTaskFragment>(job, task.copy(index = 1))
+  fun `renders action buttons when task is not first`() {
+    whenever(dataCollectionViewModel.isFirstPosition(task.id)).thenReturn(false)
+    setupTaskFragment<MultipleChoiceTaskFragment>(job, task)
 
     buttonIsEnabled("Previous")
     buttonIsDisabled("Next")


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2410

<!-- PR description. -->
Currently, we set a position integer to each task fragment during creation and later use it to generate/fetch view model for the task fragment. This has been working fine but is still error prone. This is because it assumes that the original order of tasks can never change which may or may not be true. 

To make it more secure, replacing `position` with `taskId` since it is guaranteed that each task id is unique.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
Verified for regressions by checking all scenarios manually
 * First task
 * Last task
 * App pause/resume
 * Draft state

@sufyanAbbasi  @gino-m  PTAL?
