### PR TITLE
Add custom keys to firebase crashlytics

### DIFF
--- a/ground/src/main/java/com/google/android/ground/Config.kt
+++ b/ground/src/main/java/com/google/android/ground/Config.kt
@@ -67,13 +67,12 @@ object Config {
 
   fun getMogSources(path: String) =
     listOf(
-      MogSource(
-        0 ..< DEFAULT_MOG_MIN_ZOOM,
-        "$path/$DEFAULT_MOG_MIN_ZOOM/overview.tif",
-      ),
+      MogSource(0 ..< DEFAULT_MOG_MIN_ZOOM, "$path/$DEFAULT_MOG_MIN_ZOOM/overview.tif"),
       MogSource(
         DEFAULT_MOG_MIN_ZOOM..DEFAULT_MOG_MAX_ZOOM,
         "$path/$DEFAULT_MOG_MIN_ZOOM/{x}/{y}.tif",
-      )
+      ),
     )
+
+  fun isReleaseBuild(): Boolean = BuildConfig.BUILD_TYPE.contentEquals("release")
 }

--- a/ground/src/main/java/com/google/android/ground/FirebaseCrashLogger.kt
+++ b/ground/src/main/java/com/google/android/ground/FirebaseCrashLogger.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class FirebaseCrashLogging @Inject constructor() {
+class FirebaseCrashLogger @Inject constructor() {
 
   fun recordException(priority: Int, message: String, t: Throwable?) {
     val crashlytics = FirebaseCrashlytics.getInstance()

--- a/ground/src/main/java/com/google/android/ground/FirebaseCrashLogger.kt
+++ b/ground/src/main/java/com/google/android/ground/FirebaseCrashLogger.kt
@@ -37,8 +37,8 @@ class FirebaseCrashLogger @Inject constructor() {
     setCustomKeys { key("selectedSurveyId", surveyId ?: "") }
   }
 
-  fun setScreenName(name: String) {
-    setCustomKeys { key("screenName", name) }
+  fun setScreenName(viewClass: String) {
+    setCustomKeys { key("screenName", viewClass) }
   }
 
   private fun setCustomKeys(init: KeyValueBuilder.() -> Unit) {

--- a/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
+++ b/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.android.ground
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics

--- a/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
+++ b/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
@@ -32,7 +32,8 @@ class FirebaseCrashLogging @Inject constructor() {
   }
 
   private fun setCustomKeys(init: KeyValueBuilder.() -> Unit) {
-    val builder = KeyValueBuilder(FirebaseCrashlytics.getInstance())
-    builder.init()
+    if (BuildConfig.BUILD_TYPE.contentEquals("release")) {
+      KeyValueBuilder(FirebaseCrashlytics.getInstance()).init()
+    }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
+++ b/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
@@ -15,6 +15,7 @@
  */
 package com.google.android.ground
 
+import com.google.android.ground.Config.isReleaseBuild
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.crashlytics.KeyValueBuilder
 import javax.inject.Inject
@@ -32,7 +33,7 @@ class FirebaseCrashLogging @Inject constructor() {
   }
 
   private fun setCustomKeys(init: KeyValueBuilder.() -> Unit) {
-    if (BuildConfig.BUILD_TYPE.contentEquals("release")) {
+    if (isReleaseBuild()) {
       KeyValueBuilder(FirebaseCrashlytics.getInstance()).init()
     }
   }

--- a/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
+++ b/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
@@ -1,0 +1,19 @@
+package com.google.android.ground
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.KeyValueBuilder
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FirebaseCrashLogging @Inject constructor() {
+
+  fun setSelectedSurveyId(surveyId: String?) {
+    setCustomKeys { key("selectedSurveyId", surveyId ?: "") }
+  }
+
+  private fun setCustomKeys(init: KeyValueBuilder.() -> Unit) {
+    val builder = KeyValueBuilder(FirebaseCrashlytics.getInstance())
+    builder.init()
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
+++ b/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
@@ -15,6 +15,7 @@
  */
 package com.google.android.ground
 
+import android.util.Log
 import com.google.android.ground.Config.isReleaseBuild
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.crashlytics.KeyValueBuilder
@@ -23,6 +24,14 @@ import javax.inject.Singleton
 
 @Singleton
 class FirebaseCrashLogging @Inject constructor() {
+
+  fun recordException(priority: Int, message: String, t: Throwable?) {
+    val crashlytics = FirebaseCrashlytics.getInstance()
+    crashlytics.log(message)
+    if (t != null && priority == Log.ERROR) {
+      crashlytics.recordException(t)
+    }
+  }
 
   fun setSelectedSurveyId(surveyId: String?) {
     setCustomKeys { key("selectedSurveyId", surveyId ?: "") }

--- a/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
+++ b/ground/src/main/java/com/google/android/ground/FirebaseCrashLogging.kt
@@ -12,6 +12,10 @@ class FirebaseCrashLogging @Inject constructor() {
     setCustomKeys { key("selectedSurveyId", surveyId ?: "") }
   }
 
+  fun setScreenName(name: String) {
+    setCustomKeys { key("screenName", name) }
+  }
+
   private fun setCustomKeys(init: KeyValueBuilder.() -> Unit) {
     val builder = KeyValueBuilder(FirebaseCrashlytics.getInstance())
     builder.init()

--- a/ground/src/main/java/com/google/android/ground/GroundApplication.kt
+++ b/ground/src/main/java/com/google/android/ground/GroundApplication.kt
@@ -21,6 +21,7 @@ import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.multidex.MultiDexApplication
 import androidx.work.Configuration
+import com.google.android.ground.Config.isReleaseBuild
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -33,8 +34,6 @@ class GroundApplication : MultiDexApplication(), Configuration.Provider {
 
   override val workManagerConfiguration: Configuration
     get() = Configuration.Builder().setWorkerFactory(workerFactory).build()
-
-  private fun isReleaseBuild(): Boolean = BuildConfig.BUILD_TYPE.contentEquals("release")
 
   override fun onCreate() {
     super.onCreate()

--- a/ground/src/main/java/com/google/android/ground/GroundApplication.kt
+++ b/ground/src/main/java/com/google/android/ground/GroundApplication.kt
@@ -57,11 +57,11 @@ class GroundApplication : MultiDexApplication(), Configuration.Provider {
   /** Reports any error with priority more than "info" to Crashlytics. */
   class CrashReportingTree
   @Inject
-  constructor(private val firebaseCrashLogging: FirebaseCrashLogging) : Timber.Tree() {
+  constructor(private val firebaseCrashLogger: FirebaseCrashLogger) : Timber.Tree() {
 
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
       if (priority > Log.INFO) {
-        firebaseCrashLogging.recordException(priority, message, t)
+        firebaseCrashLogger.recordException(priority, message, t)
       }
     }
   }

--- a/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
@@ -15,7 +15,7 @@
  */
 package com.google.android.ground.repository
 
-import com.google.android.ground.FirebaseCrashLogging
+import com.google.android.ground.FirebaseCrashLogger
 import com.google.android.ground.coroutines.ApplicationScope
 import com.google.android.ground.model.Survey
 import com.google.android.ground.model.SurveyListItem
@@ -57,7 +57,7 @@ private const val LOAD_REMOTE_SURVEY_TIMEOUT_MILLS: Long = 15 * 1000
 class SurveyRepository
 @Inject
 constructor(
-  private val firebaseCrashLogging: FirebaseCrashLogging,
+  private val firebaseCrashLogger: FirebaseCrashLogger,
   private val localSurveyStore: LocalSurveyStore,
   private val remoteDataStore: RemoteDataStore,
   private val localValueStore: LocalValueStore,
@@ -69,7 +69,7 @@ constructor(
     get() = _selectedSurveyIdFlow.value
     set(value) {
       _selectedSurveyIdFlow.value = value
-      firebaseCrashLogging.setSelectedSurveyId(value)
+      firebaseCrashLogger.setSelectedSurveyId(value)
     }
 
   val activeSurveyFlow: StateFlow<Survey?> =

--- a/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
@@ -15,6 +15,7 @@
  */
 package com.google.android.ground.repository
 
+import com.google.android.ground.FirebaseCrashLogging
 import com.google.android.ground.coroutines.ApplicationScope
 import com.google.android.ground.model.Survey
 import com.google.android.ground.model.SurveyListItem
@@ -56,6 +57,7 @@ private const val LOAD_REMOTE_SURVEY_TIMEOUT_MILLS: Long = 15 * 1000
 class SurveyRepository
 @Inject
 constructor(
+  private val firebaseCrashLogging: FirebaseCrashLogging,
   private val localSurveyStore: LocalSurveyStore,
   private val remoteDataStore: RemoteDataStore,
   private val localValueStore: LocalValueStore,
@@ -67,6 +69,7 @@ constructor(
     get() = _selectedSurveyIdFlow.value
     set(value) {
       _selectedSurveyIdFlow.value = value
+      firebaseCrashLogging.setSelectedSurveyId(value)
     }
 
   val activeSurveyFlow: StateFlow<Survey?> =

--- a/ground/src/main/java/com/google/android/ground/util/Debug.kt
+++ b/ground/src/main/java/com/google/android/ground/util/Debug.kt
@@ -15,7 +15,7 @@
  */
 package com.google.android.ground.util
 
-import com.google.android.ground.FirebaseCrashLogging
+import com.google.android.ground.FirebaseCrashLogger
 import timber.log.Timber
 
 object Debug {
@@ -26,7 +26,7 @@ object Debug {
     Timber.tag(className).v("Lifecycle event: $callingMethod")
 
     if (callingMethod == "onResume()") {
-      FirebaseCrashLogging().setScreenName(className)
+      FirebaseCrashLogger().setScreenName(className)
     }
   }
 

--- a/ground/src/main/java/com/google/android/ground/util/Debug.kt
+++ b/ground/src/main/java/com/google/android/ground/util/Debug.kt
@@ -15,13 +15,19 @@
  */
 package com.google.android.ground.util
 
+import com.google.android.ground.FirebaseCrashLogging
 import timber.log.Timber
 
 object Debug {
   fun logLifecycleEvent(instance: Any) {
     val stackTrace = Thread.currentThread().stackTrace
     val callingMethod = stackTrace[3].methodName + "()"
-    Timber.tag(instance.javaClass.simpleName).v("Lifecycle event: $callingMethod")
+    val className = instance.javaClass.simpleName
+    Timber.tag(className).v("Lifecycle event: $callingMethod")
+
+    if (callingMethod == "onResume()") {
+      FirebaseCrashLogging().setScreenName(className)
+    }
   }
 
   fun <T> logOnFailure(fn: () -> T): T? =

--- a/ground/src/main/java/com/google/android/ground/util/Debug.kt
+++ b/ground/src/main/java/com/google/android/ground/util/Debug.kt
@@ -15,6 +15,8 @@
  */
 package com.google.android.ground.util
 
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.google.android.ground.FirebaseCrashLogger
 import timber.log.Timber
 
@@ -25,7 +27,7 @@ object Debug {
     val className = instance.javaClass.simpleName
     Timber.tag(className).v("Lifecycle event: $callingMethod")
 
-    if (callingMethod == "onResume()") {
+    if ((instance is Fragment || instance is FragmentActivity) && callingMethod == "onResume()") {
       FirebaseCrashLogger().setScreenName(className)
     }
   }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2421

<!-- PR description. -->
Currently, we were only logging survey id when the error is logged. But if the app crashes, then the app closes directly and the custom key isn't loaded. 

To fix that, update the selected survey id and screen name to firebase crashlytics proactively.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
