### PR TITLE
Fix alignment of button for the first task

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -143,7 +143,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
   private fun addPreviousButton() =
     addButton(ButtonAction.PREVIOUS)
       .setOnClickListener { moveToPrevious() }
-      .showIfTrue(!dataCollectionViewModel.isFirstPosition(taskId))
+      .enableIfTrue(!dataCollectionViewModel.isFirstPosition(taskId))
 
   protected fun addNextButton() =
     addButton(ButtonAction.NEXT)

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
@@ -266,7 +266,7 @@ class MultipleChoiceTaskFragmentTest :
     setupTaskFragment<MultipleChoiceTaskFragment>(job, task.copy(isRequired = false))
 
     runner()
-      .assertButtonIsHidden("Previous")
+      .assertButtonIsDisabled("Previous")
       .assertButtonIsDisabled("Next")
       .assertButtonIsEnabled("Skip")
   }
@@ -297,7 +297,7 @@ class MultipleChoiceTaskFragmentTest :
     setupTaskFragment<MultipleChoiceTaskFragment>(job, task.copy(isRequired = true))
 
     runner()
-      .assertButtonIsHidden("Previous")
+      .assertButtonIsDisabled("Previous")
       .assertButtonIsDisabled("Next")
       .assertButtonIsHidden("Skip")
   }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2417

<!-- PR description. -->
This PR fixes the position of "skip" button for the first task. Currently this button appears at the beginning of the row. This is because "previous" button is hidden for the first task. 

To resolve it, make the "previous" button as disabled instead of hiding it.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
