### PR TITLE
[Bug] Ensure firebase auth is always initialized before accessing it

### DIFF
--- a/ground/src/main/java/com/google/android/ground/repository/UserRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/UserRepository.kt
@@ -40,11 +40,21 @@ constructor(
   private val networkManager: NetworkManager,
   private val surveyRepository: SurveyRepository,
   private val remoteDataStore: RemoteDataStore,
-) : AuthenticationManager by authenticationManager {
+) {
+
+  fun getSignInState() = authenticationManager.signInState
+
+  fun init() = authenticationManager.init()
+
+  fun signIn() = authenticationManager.signIn()
+
+  fun signOut() = authenticationManager.signOut()
+
+  suspend fun getAuthenticatedUser() = authenticationManager.getAuthenticatedUser()
 
   /** Stores the current user's profile details into the local and remote dbs. */
   suspend fun saveUserDetails() {
-    localUserStore.insertOrUpdateUser(authenticationManager.getAuthenticatedUser())
+    localUserStore.insertOrUpdateUser(getAuthenticatedUser())
     updateRemoteUserInfo()
   }
 
@@ -54,7 +64,7 @@ constructor(
       Timber.d("Skipped refreshing user profile as device is offline.")
       return
     }
-    if (!authenticationManager.getAuthenticatedUser().isAnonymous) {
+    if (!getAuthenticatedUser().isAnonymous) {
       remoteDataStore.refreshUserProfile()
     }
   }

--- a/ground/src/main/java/com/google/android/ground/system/auth/AnonymousAuthenticationManager.kt
+++ b/ground/src/main/java/com/google/android/ground/system/auth/AnonymousAuthenticationManager.kt
@@ -36,12 +36,12 @@ class AnonymousAuthenticationManager
 @Inject
 constructor(
   private val firebaseAuth: FirebaseAuth,
-  @ApplicationScope private val externalScope: CoroutineScope
-) : AuthenticationManager {
+  @ApplicationScope private val externalScope: CoroutineScope,
+) : BaseAuthenticationManager() {
   private val _signInStateFlow = MutableStateFlow<SignInState?>(null)
   override val signInState: Flow<SignInState> = _signInStateFlow.asStateFlow().filterNotNull()
 
-  override fun init() {
+  override fun initInternal() {
     setState(
       if (firebaseAuth.currentUser == null) SignInState.signedOut()
       else SignInState.signedIn(anonymousUser)

--- a/ground/src/main/java/com/google/android/ground/system/auth/GoogleAuthenticationManager.kt
+++ b/ground/src/main/java/com/google/android/ground/system/auth/GoogleAuthenticationManager.kt
@@ -49,8 +49,8 @@ constructor(
   resources: Resources,
   private val activityStreams: ActivityStreams,
   private val firebaseAuth: FirebaseAuth,
-  @ApplicationScope private val externalScope: CoroutineScope
-) : AuthenticationManager {
+  @ApplicationScope private val externalScope: CoroutineScope,
+) : BaseAuthenticationManager() {
 
   private val googleSignInOptions: GoogleSignInOptions
 
@@ -70,7 +70,7 @@ constructor(
   private val _signInStateFlow = MutableStateFlow<SignInState?>(null)
   override val signInState: Flow<SignInState> = _signInStateFlow.asStateFlow().filterNotNull()
 
-  override fun init() {
+  override fun initInternal() {
     firebaseAuth.addAuthStateListener { auth ->
       val user = auth.currentUser?.toUser()
       setState(if (user == null) SignInState.signedOut() else SignInState.signedIn(user))

--- a/ground/src/main/java/com/google/android/ground/ui/signin/SignInViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/signin/SignInViewModel.kt
@@ -45,7 +45,7 @@ internal constructor(
 
   fun onSignInButtonClick() {
     viewModelScope.launch {
-      val signInState = userRepository.signInState.first()
+      val signInState = userRepository.getSignInState().first()
       when (signInState.state) {
         SignInState.State.SIGNED_OUT,
         SignInState.State.ERROR -> userRepository.signIn()

--- a/ground/src/test/java/com/google/android/ground/domain/usecase/MakeSurveyAvailableOfflineUseCaseTest.kt
+++ b/ground/src/test/java/com/google/android/ground/domain/usecase/MakeSurveyAvailableOfflineUseCaseTest.kt
@@ -41,7 +41,7 @@ class MakeSurveyAvailableOfflineUseCaseTest : BaseHiltTest() {
   @BindValue @Mock lateinit var surveyRepository: SurveyRepository
 
   @Test
-  fun `Returns null when survey doesn't exist`() = runBlocking {
+  fun `Returns null when survey doesn't exist`() = runWithTestDispatcher {
     `when`(surveyRepository.loadAndSyncSurveyWithRemote(SURVEY.id)).thenReturn(null)
 
     assertNull(makeSurveyAvailableOffline(SURVEY.id))
@@ -57,14 +57,14 @@ class MakeSurveyAvailableOfflineUseCaseTest : BaseHiltTest() {
   }
 
   @Test
-  fun `Returns survey on success`() = runBlocking {
+  fun `Returns survey on success`() = runWithTestDispatcher {
     `when`(surveyRepository.loadAndSyncSurveyWithRemote(SURVEY.id)).thenReturn(SURVEY)
 
     assertEquals(SURVEY, makeSurveyAvailableOffline(SURVEY.id))
   }
 
   @Test
-  fun `Subscribes to updates on success`() = runBlocking {
+  fun `Subscribes to updates on success`() = runWithTestDispatcher {
     `when`(surveyRepository.loadAndSyncSurveyWithRemote(SURVEY.id)).thenReturn(SURVEY)
 
     makeSurveyAvailableOffline(SURVEY.id)

--- a/ground/src/test/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragmentTest.kt
@@ -232,14 +232,18 @@ class SurveySelectorFragmentTest : BaseHiltTest() {
     verify(surveyRepository).removeOfflineSurvey(TEST_SURVEY_2.id)
   }
 
-  private fun setUpFragment(optBundle: Bundle = bundleOf(Pair("shouldExitApp", false))) {
-    launchFragmentInHiltContainer<SurveySelectorFragment>(optBundle) {
-      fragment = this as SurveySelectorFragment
+  private fun setUpFragment(optBundle: Bundle = bundleOf(Pair("shouldExitApp", false))) =
+    runWithTestDispatcher {
+      launchFragmentInHiltContainer<SurveySelectorFragment>(optBundle) {
+        fragment = this as SurveySelectorFragment
+      }
+
+      // Wait for survey cards to be populated
+      advanceUntilIdle()
     }
-  }
 
   private fun setSurveyList(surveys: List<SurveyListItem>) = runWithTestDispatcher {
-    whenever(surveyRepository.getSurveyList(FakeData.USER)).thenReturn(listOf(surveys).asFlow())
+    whenever(surveyRepository.getSurveyList(TEST_USER)).thenReturn(listOf(surveys).asFlow())
   }
 
   private fun setLocalSurveys(surveys: List<SurveyListItem>) {

--- a/sharedTest/src/main/kotlin/com/sharedtest/system/auth/FakeAuthenticationManager.kt
+++ b/sharedTest/src/main/kotlin/com/sharedtest/system/auth/FakeAuthenticationManager.kt
@@ -17,7 +17,7 @@ package com.sharedtest.system.auth
 
 import com.google.android.ground.coroutines.ApplicationScope
 import com.google.android.ground.model.User
-import com.google.android.ground.system.auth.AuthenticationManager
+import com.google.android.ground.system.auth.BaseAuthenticationManager
 import com.google.android.ground.system.auth.SignInState
 import com.google.android.ground.system.auth.SignInState.Companion.signedIn
 import com.google.android.ground.system.auth.SignInState.Companion.signedOut
@@ -34,7 +34,8 @@ import kotlinx.coroutines.launch
 @Singleton
 class FakeAuthenticationManager
 @Inject
-constructor(@ApplicationScope private val externalScope: CoroutineScope) : AuthenticationManager {
+constructor(@ApplicationScope private val externalScope: CoroutineScope) :
+  BaseAuthenticationManager() {
 
   private val _signInStateFlow = MutableStateFlow<SignInState?>(null)
   override val signInState: Flow<SignInState> = _signInStateFlow.asStateFlow().filterNotNull()
@@ -51,7 +52,7 @@ constructor(@ApplicationScope private val externalScope: CoroutineScope) : Authe
     externalScope.launch { _signInStateFlow.emit(state) }
   }
 
-  override fun init() = setState(signedIn(currentUser))
+  override fun initInternal() = setState(signedIn(currentUser))
 
   override fun signIn() = setState(signedIn(currentUser))
 

--- a/sharedTest/src/main/kotlin/com/sharedtest/system/auth/FakeAuthenticationManager.kt
+++ b/sharedTest/src/main/kotlin/com/sharedtest/system/auth/FakeAuthenticationManager.kt
@@ -57,6 +57,4 @@ constructor(@ApplicationScope private val externalScope: CoroutineScope) :
   override fun signIn() = setState(signedIn(currentUser))
 
   override fun signOut() = setState(signedOut())
-
-  override suspend fun getAuthenticatedUser(): User = currentUser
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2335

<!-- PR description. -->
When opening the app by following the repro steps as per #2335, the startup fragment is not invoked. Due to this, the user isn't logged in and the app appears to be un-initialized.

This PR fixes that by ensuring that sdk is always initialized irrespective of how the app is launched.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
Verified by following the below steps:

2. Ensure app has location permissions, click on a survey.
3. While in the survey map view, before clicking on "Collect", go into app settings and remove location permissions.
4. Then re-open the app using the "Open" button on the settings.
5. See that app is properly loaded including user details and survey list.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m @sufyanAbbasi @scolsen PTAL?
