### PR TITLE
Disable fallbackToDestructiveMigration()

### DIFF
--- a/ground/src/main/java/com/google/android/ground/Config.kt
+++ b/ground/src/main/java/com/google/android/ground/Config.kt
@@ -25,7 +25,6 @@ object Config {
   const val SHARED_PREFS_MODE = Context.MODE_PRIVATE
 
   // Local db settings.
-  // TODO(#128): Reset version to 1 before releasing.
   const val DB_VERSION = 117
   const val DB_NAME = "ground.db"
 

--- a/ground/src/main/java/com/google/android/ground/LocalDatabaseModule.kt
+++ b/ground/src/main/java/com/google/android/ground/LocalDatabaseModule.kt
@@ -35,10 +35,9 @@ object LocalDatabaseModule {
   @Singleton
   fun localDatabase(
     @ApplicationContext context: Context,
-    @IoDispatcher ioDispatcher: CoroutineDispatcher
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
   ): LocalDatabase =
     Room.databaseBuilder(context, LocalDatabase::class.java, Config.DB_NAME)
-      .fallbackToDestructiveMigration() // TODO(#128): Disable before official release.
       // Run queries and transactions on background I/O thread.
       .setQueryExecutor(ioDispatcher.asExecutor())
       .build()


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #932

<!-- PR description. -->
We can't reset DB version to 1 since it is already launched to play store. With this change, the app will always require migration instead of clearing the db when upgrading the db version

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
