### PR TITLE
[DRAFT] MediaMutations: Implement initial model and persistent types.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/media/Media.kt
+++ b/ground/src/main/java/com/google/android/ground/model/media/Media.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.model.media
+
+/** Represents a single piece of user-provided media, such as a photo. */
+interface Media {
+  // A unique identifier for this piece of media
+  val id: String
+}

--- a/ground/src/main/java/com/google/android/ground/model/media/Photo.kt
+++ b/ground/src/main/java/com/google/android/ground/model/media/Photo.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.model.media
+
+import java.net.URI
+
+/**
+ * Represents a user-provided photo.
+ *
+ * This class consists of a unique identifier and URI. The URI corresponds to an on-device location
+ * that contains data associated with a given Photo.
+ */
+data class Photo(override val id: String, val uri: URI) : Media

--- a/ground/src/main/java/com/google/android/ground/model/mutation/MediaMutation.kt
+++ b/ground/src/main/java/com/google/android/ground/model/mutation/MediaMutation.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.model.mutation
+
+import java.util.Date
+
+/**
+ * Represents a local change to media associated with a submission.
+ *
+ * These mutations are directly dependent upon another mutation type: SubmissionMutation. At
+ * present, any MediaMutation will only have relevance in the context of a submission. To this end,
+ * several properties are derived from the mutation's associated submission mutation.
+ */
+data class MediaMutation(
+  override val type: Type,
+  val mediaId: String,
+  val submissionMutation: SubmissionMutation,
+  override val id: Long? = null,
+  override val syncStatus: SyncStatus = SyncStatus.PENDING,
+  override val retryCount: Long = 0,
+  override val lastError: String = "",
+) : Mutation() {
+  override val surveyId: String = submissionMutation.surveyId
+  override val locationOfInterestId: String = submissionMutation.locationOfInterestId
+  override val clientTimestamp: Date = submissionMutation.clientTimestamp
+  override val userId: String = submissionMutation.userId
+}

--- a/ground/src/main/java/com/google/android/ground/persistence/local/LocalDataStoreModule.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/LocalDataStoreModule.kt
@@ -121,5 +121,10 @@ abstract class LocalDataStoreModule {
     fun expressionDao(localDatabase: LocalDatabase): ExpressionDao {
       return localDatabase.expressionDao()
     }
+
+    @Provides
+    fun mediaMutationDao(localDatabase: LocalDatabase): MediaMutationDao {
+      return localDatabase.mediaMutationDao()
+    }
   }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/LocalDatabase.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/LocalDatabase.kt
@@ -30,6 +30,7 @@ import com.google.android.ground.persistence.local.room.dao.ExpressionDao
 import com.google.android.ground.persistence.local.room.dao.JobDao
 import com.google.android.ground.persistence.local.room.dao.LocationOfInterestDao
 import com.google.android.ground.persistence.local.room.dao.LocationOfInterestMutationDao
+import com.google.android.ground.persistence.local.room.dao.MediaMutationDao
 import com.google.android.ground.persistence.local.room.dao.MultipleChoiceDao
 import com.google.android.ground.persistence.local.room.dao.OfflineAreaDao
 import com.google.android.ground.persistence.local.room.dao.OptionDao
@@ -45,6 +46,7 @@ import com.google.android.ground.persistence.local.room.entity.ExpressionEntity
 import com.google.android.ground.persistence.local.room.entity.JobEntity
 import com.google.android.ground.persistence.local.room.entity.LocationOfInterestEntity
 import com.google.android.ground.persistence.local.room.entity.LocationOfInterestMutationEntity
+import com.google.android.ground.persistence.local.room.entity.MediaMutationEntity
 import com.google.android.ground.persistence.local.room.entity.MultipleChoiceEntity
 import com.google.android.ground.persistence.local.room.entity.OfflineAreaEntity
 import com.google.android.ground.persistence.local.room.entity.OptionEntity
@@ -89,9 +91,10 @@ import com.google.android.ground.persistence.local.room.fields.TileSetEntityStat
       UserEntity::class,
       ConditionEntity::class,
       ExpressionEntity::class,
+      MediaMutationEntity::class,
     ],
   version = Config.DB_VERSION,
-  exportSchema = false
+  exportSchema = false,
 )
 @TypeConverters(
   TaskEntityType::class,
@@ -139,4 +142,6 @@ abstract class LocalDatabase : RoomDatabase() {
   abstract fun conditionDao(): ConditionDao
 
   abstract fun expressionDao(): ExpressionDao
+
+  abstract fun mediaMutationDao(): MediaMutationDao
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/MediaMutationDao.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/dao/MediaMutationDao.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.persistence.local.room.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import com.google.android.ground.persistence.local.room.entity.MediaMutationEntity
+import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
+import kotlinx.coroutines.flow.Flow
+
+/** Defines access and write operations for media mutations stored in the local database. */
+@Dao
+interface MediaMutationDao : BaseDao<MediaMutationEntity> {
+  @Query("SELECT * FROM media_mutation")
+  fun getAllMediaMutationsFlow(): Flow<List<MediaMutationEntity>>
+
+  @Query(
+    "SELECT * FROM media_mutation WHERE submission_mutation_id = :submissionMutationId AND state IN (:states)"
+  )
+  suspend fun getMediaMutationsForSubmissionMutation(
+    submissionMutationId: Long,
+    vararg states: MutationEntitySyncStatus,
+  ): List<MediaMutationEntity>?
+}

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/MediaMutationEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/MediaMutationEntity.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.persistence.local.room.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.google.android.ground.model.mutation.MediaMutation
+import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
+import com.google.android.ground.persistence.local.room.fields.MutationEntityType
+
+/** Persistent representation of mutations applied to user-provided media during data collection. */
+@Entity(
+  tableName = "media_mutation",
+  foreignKeys =
+    [
+      ForeignKey(
+        entity = SubmissionMutationEntity::class,
+        parentColumns = ["id"],
+        childColumns = ["submission_mutation_id"],
+        onDelete = ForeignKey.CASCADE,
+      )
+    ],
+  indices = [Index("submission_mutation_id")],
+)
+data class MediaMutationEntity(
+  @ColumnInfo(name = "id") @PrimaryKey(autoGenerate = true) val id: Long? = 0,
+  @ColumnInfo(name = "type") val type: MutationEntityType,
+  @ColumnInfo(name = "media_id") val mediaId: String,
+  @ColumnInfo(name = "submission_mutation_id") val submissionMutationId: Long,
+  @ColumnInfo(name = "state") val syncStatus: MutationEntitySyncStatus,
+  @ColumnInfo(name = "retry_count") val retryCount: Long,
+  @ColumnInfo(name = "last_error") val lastError: String,
+) {
+  companion object {
+    fun fromMediaMutation(mutation: MediaMutation): MediaMutationEntity {
+      requireNotNull(mutation.submissionMutation.id) {
+        "associated submission mutation must have a non-null ID"
+      }
+      return MediaMutationEntity(
+        id = mutation.id,
+        type = MutationEntityType.fromMutationType(mutation.type),
+        mediaId = mutation.mediaId,
+        submissionMutationId = mutation.submissionMutation.id,
+        syncStatus = MutationEntitySyncStatus.fromMutationSyncStatus(mutation.syncStatus),
+        retryCount = mutation.retryCount,
+        lastError = mutation.lastError,
+      )
+    }
+  }
+}

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/PhotoEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/PhotoEntity.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.persistence.local.room.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+
+/**
+ * Persisted representation of an on-device photo that has been associated with the application,
+ * usually through data submission. We do not store associations between photos and the submissions,
+ * this table is merely a record of the on-device data itself. Uploads and submission history are
+ * modelled through the use of media mutations and are processed at submission time.
+ */
+@Entity(tableName = "photo")
+data class PhotoEntity(
+  @ColumnInfo(name = "id") val id: String,
+  @ColumnInfo(name = "uri") val uri: String,
+)

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/FirestoreDataStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/FirestoreDataStore.kt
@@ -22,6 +22,7 @@ import com.google.android.ground.model.TermsOfService
 import com.google.android.ground.model.User
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.model.mutation.LocationOfInterestMutation
+import com.google.android.ground.model.mutation.MediaMutation
 import com.google.android.ground.model.mutation.Mutation
 import com.google.android.ground.model.mutation.SubmissionMutation
 import com.google.android.ground.model.submission.Submission
@@ -103,6 +104,7 @@ internal constructor(
     val batch = db().batch()
     for (mutation in mutations) {
       when (mutation) {
+        is MediaMutation -> {} // no-op at present
         is LocationOfInterestMutation -> addLocationOfInterestMutationToBatch(mutation, user, batch)
         is SubmissionMutation -> addSubmissionMutationToBatch(mutation, user, batch)
       }


### PR DESCRIPTION
Adds basic types for representing media and media mutations separately from other mutations. Media mutations are dependent on submission mutations, but using a more fine-grained representation allows us to both operate on these mutations in a more granular manner and allows us to give more specific information to users.

Note that we do not use these types yet, they are only introduced here.

@gino-m, @sufyanAbbasi - FYI.
