### PR TITLE
Re-center the viewport when reverting the polygon's last vertex

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
@@ -20,10 +20,12 @@ import android.view.View
 import android.widget.Toast
 import com.google.android.ground.R
 import com.google.android.ground.coroutines.DefaultDispatcher
+import com.google.android.ground.model.geometry.Coordinates
 import com.google.android.ground.system.GeocodingManager
 import com.google.android.ground.system.PermissionDeniedException
 import com.google.android.ground.system.SettingsChangeRequestCanceled
 import com.google.android.ground.ui.home.mapcontainer.MapTypeDialogFragmentDirections
+import com.google.android.ground.ui.map.CameraPosition
 import com.google.android.ground.ui.map.CameraUpdateRequest
 import com.google.android.ground.ui.map.MapFragment
 import javax.inject.Inject
@@ -126,6 +128,18 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
         else -> R.string.location_updates_unknown_error
       }
     Toast.makeText(context, messageId, Toast.LENGTH_LONG).show()
+  }
+
+  /** Moves the camera to a given position. */
+  fun moveToPosition(
+    coordinates: Coordinates,
+    shouldAnimate: Boolean = true,
+    isAllowZoomOut: Boolean = false,
+  ) {
+    onCameraUpdateRequest(
+      CameraUpdateRequest(CameraPosition(coordinates), shouldAnimate, isAllowZoomOut),
+      map,
+    )
   }
 
   private fun onCameraUpdateRequest(cameraUpdateRequest: CameraUpdateRequest, map: MapFragment) {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -192,9 +192,11 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
     }
   }
 
-  fun addUndoButton() =
+  fun addUndoButton() = addUndoButton { viewModel.clearResponse() }
+
+  fun addUndoButton(clickHandler: () -> Unit) =
     addButton(ButtonAction.UNDO)
-      .setOnClickListener { viewModel.clearResponse() }
+      .setOnClickListener { clickHandler() }
       .setOnValueChanged { button, value -> button.showIfTrue(value.isNotNullOrEmpty()) }
       .hide()
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -69,7 +69,7 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
 
   override fun onCreateActionButtons() {
     addSkipButton()
-    addUndoButton()
+    addUndoButton { removeLastVertex() }
     nextButton = addNextButton()
     addPointButton =
       addButton(ButtonAction.ADD_POINT).setOnClickListener { viewModel.addLastVertex() }
@@ -77,6 +77,15 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
       addButton(ButtonAction.COMPLETE).setOnClickListener {
         viewModel.onCompletePolygonButtonClick()
       }
+  }
+
+  /** Removes the last vertex from the polygon. */
+  private fun removeLastVertex() {
+    viewModel.removeLastVertex()
+
+    // Move the camera to the last vertex, if any.
+    val lastVertex = viewModel.getLastVertex() ?: return
+    drawAreaTaskMapFragment.moveToPosition(lastVertex)
   }
 
   override fun onTaskViewAttached() {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
@@ -76,6 +76,8 @@ internal constructor(
 
   fun isMarkedComplete(): Boolean = isMarkedComplete
 
+  fun getLastVertex() = vertices.lastOrNull()
+
   /**
    * If the distance between the last added vertex and the given [target] is more than the
    * configured threshold, then updates the last vertex with the given [target]. Otherwise, snaps to
@@ -97,10 +99,6 @@ internal constructor(
     }
 
     addVertex(updatedTarget, true)
-  }
-
-  override fun clearResponse() {
-    removeLastVertex()
   }
 
   /** Attempts to remove the last vertex of drawn polygon, if any. */


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2145

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
[center-prev-vertex.webm](https://github.com/google/ground-android/assets/8918023/4397a45f-1c36-4e8d-8c97-d43e51c655f6)


<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m @sufyanAbbasi  PTAL?
