### PR TITLE
Merge multiple ui state flows into a single flow in SurveySelectorFragment

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
@@ -23,7 +23,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
 import android.widget.Toast
-import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
 import com.google.android.ground.databinding.SurveySelectorFragBinding
 import com.google.android.ground.model.SurveyListItem
@@ -32,7 +31,6 @@ import com.google.android.ground.ui.common.BackPressListener
 import com.google.android.ground.util.visibleIf
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.launch
 
 /** User interface implementation of survey selector screen. */
 @AndroidEntryPoint
@@ -70,8 +68,10 @@ class SurveySelectorFragment : AbstractFragment(), BackPressListener {
   }
 
   private fun handleSurveyListUpdated(surveys: List<SurveyListItem>) {
-    binding.container.visibleIf(surveys.isNotEmpty())
-    binding.emptyContainer.visibleIf(surveys.isEmpty())
+    with(binding) {
+      container.visibleIf(surveys.isNotEmpty())
+      emptyContainer.visibleIf(surveys.isEmpty())
+    }
     adapter.updateData(surveys)
   }
 

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
@@ -30,7 +30,6 @@ import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.common.BackPressListener
 import com.google.android.ground.util.visibleIf
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.filterNotNull
 
 /** User interface implementation of survey selector screen. */
 @AndroidEntryPoint
@@ -44,7 +43,7 @@ class SurveySelectorFragment : AbstractFragment(), BackPressListener {
     super.onCreate(savedInstanceState)
     viewModel = getViewModel(SurveySelectorViewModel::class.java)
     adapter = SurveyListAdapter(viewModel, this)
-    viewModel.uiState.filterNotNull().launchWhenStartedAndCollect { updateUI(it) }
+    viewModel.uiState.launchWhenStartedAndCollect { updateUI(it) }
   }
 
   private fun updateUI(uiState: UiState) {

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
@@ -43,10 +43,10 @@ class SurveySelectorFragment : AbstractFragment(), BackPressListener {
     super.onCreate(savedInstanceState)
     viewModel = getViewModel(SurveySelectorViewModel::class.java)
     adapter = SurveyListAdapter(viewModel, this)
-    viewModel.uiState.launchWhenStartedAndCollect { updateUI(it) }
+    viewModel.uiState.launchWhenStartedAndCollect { updateUi(it) }
   }
 
-  private fun updateUI(uiState: UiState) {
+  private fun updateUi(uiState: UiState) {
     when (uiState) {
       UiState.ActivatingSurvey,
       UiState.FetchingSurveys -> {

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
@@ -26,9 +26,12 @@ import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
 import com.google.android.ground.databinding.SurveySelectorFragBinding
+import com.google.android.ground.model.SurveyListItem
 import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.common.BackPressListener
+import com.google.android.ground.util.visibleIf
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 
 /** User interface implementation of survey selector screen. */
@@ -43,16 +46,33 @@ class SurveySelectorFragment : AbstractFragment(), BackPressListener {
     super.onCreate(savedInstanceState)
     viewModel = getViewModel(SurveySelectorViewModel::class.java)
     adapter = SurveyListAdapter(viewModel, this)
-    // TODO(#2081): Merge the survey list flow and survey list state flow into a single stream.
-    lifecycleScope.launch { viewModel.getSurveyList().collect { adapter.updateData(it) } }
-    lifecycleScope.launch {
-      viewModel.surveyListState.collect { state -> state?.let { handleSurveyListState(it) } }
-    }
-    lifecycleScope.launch {
-      viewModel.errorFlow.collect {
-        Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+    lifecycleScope.launch { viewModel.uiState.filterNotNull().collect { updateUI(it) } }
+  }
+
+  private fun updateUI(uiState: UiState) {
+    when (uiState) {
+      UiState.ActivatingSurvey,
+      UiState.FetchingSurveys -> {
+        showProgressDialog()
+      }
+      UiState.SurveyActivated -> {
+        dismissProgressDialog()
+      }
+      is UiState.SurveyListAvailable -> {
+        handleSurveyListUpdated(uiState.surveys)
+        dismissProgressDialog()
+      }
+      is UiState.Error -> {
+        dismissProgressDialog()
+        Toast.makeText(requireContext(), uiState.errorResId, Toast.LENGTH_SHORT).show()
       }
     }
+  }
+
+  private fun handleSurveyListUpdated(surveys: List<SurveyListItem>) {
+    binding.container.visibleIf(surveys.isNotEmpty())
+    binding.emptyContainer.visibleIf(surveys.isEmpty())
+    adapter.updateData(surveys)
   }
 
   override fun onCreateView(
@@ -92,13 +112,6 @@ class SurveySelectorFragment : AbstractFragment(), BackPressListener {
       show()
     }
   }
-
-  private fun handleSurveyListState(state: SurveySelectorViewModel.State) =
-    when (state) {
-      SurveySelectorViewModel.State.LOADING -> showProgressDialog()
-      SurveySelectorViewModel.State.LOADED,
-      SurveySelectorViewModel.State.NOT_FOUND -> dismissProgressDialog()
-    }
 
   private fun shouldExitApp(): Boolean =
     arguments?.let { SurveySelectorFragmentArgs.fromBundle(it).shouldExitApp } ?: false

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragment.kt
@@ -46,7 +46,7 @@ class SurveySelectorFragment : AbstractFragment(), BackPressListener {
     super.onCreate(savedInstanceState)
     viewModel = getViewModel(SurveySelectorViewModel::class.java)
     adapter = SurveyListAdapter(viewModel, this)
-    lifecycleScope.launch { viewModel.uiState.filterNotNull().collect { updateUI(it) } }
+    viewModel.uiState.filterNotNull().launchWhenStartedAndCollect { updateUI(it) }
   }
 
   private fun updateUI(uiState: UiState) {

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -53,15 +52,14 @@ internal constructor(
   private val userRepository: UserRepository,
 ) : AbstractViewModel() {
 
-  private val _uiState: MutableStateFlow<UiState?> = MutableStateFlow(null)
-  val uiState: StateFlow<UiState?> = _uiState.asStateFlow()
+  private val _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState.FetchingSurveys)
+  val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
   init {
     viewModelScope.launch {
-      getSurveyList()
-        .distinctUntilChanged()
-        .onStart { _uiState.emit(UiState.FetchingSurveys) }
-        .collect { _uiState.emit(UiState.SurveyListAvailable(it)) }
+      getSurveyList().distinctUntilChanged().collect {
+        _uiState.emit(UiState.SurveyListAvailable(it))
+      }
     }
   }
 

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
@@ -31,13 +31,11 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -55,38 +53,41 @@ internal constructor(
   private val userRepository: UserRepository,
 ) : AbstractViewModel() {
 
-  // TODO(#2081): Expose non-mutable state flow.
-  val surveyListState: MutableStateFlow<State?> = MutableStateFlow(null)
-  private val _errorFlow: MutableSharedFlow<Int?> = MutableSharedFlow()
-  val errorFlow: Flow<Int> = _errorFlow.asSharedFlow().filterNotNull()
+  private val _uiState: MutableStateFlow<UiState?> = MutableStateFlow(null)
+  val uiState: StateFlow<UiState?> = _uiState.asStateFlow()
+
+  init {
+    viewModelScope.launch {
+      getSurveyList()
+        .distinctUntilChanged()
+        .onStart { _uiState.emit(UiState.FetchingSurveys) }
+        .collect { _uiState.emit(UiState.SurveyListAvailable(it)) }
+    }
+  }
 
   /** Returns a flow of [SurveyListItem] to be displayed to the user. */
-  suspend fun getSurveyList(): Flow<List<SurveyListItem>> =
-    surveyRepository
-      .getSurveyList(authManager.getAuthenticatedUser())
-      .distinctUntilChanged()
-      .onStart { setLoading() }
-      .map { surveys -> surveys.sortedWith(compareBy({ !it.availableOffline }, { it.title })) }
-      .onEach {
-        if (it.isEmpty()) {
-          setNotFound()
-        } else {
-          setLoaded()
-        }
-      }
+  private suspend fun getSurveyList(): Flow<List<SurveyListItem>> =
+    surveyRepository.getSurveyList(authManager.getAuthenticatedUser()).map { surveys ->
+      surveys.sortedWith(compareBy({ !it.availableOffline }, { it.title }))
+    }
 
   /** Triggers the specified survey to be loaded and activated. */
   fun activateSurvey(surveyId: String) =
     viewModelScope.launch {
-      setLoading()
-      val result = runCatching { activateSurveyUseCase(surveyId) }
-      setLoaded()
-      if (result.isSuccess) {
-        navigateToHomeScreen()
-      } else {
-        Timber.e(result.exceptionOrNull())
-        _errorFlow.emit(R.string.error_message)
-      }
+      runCatching {
+          _uiState.emit(UiState.ActivatingSurvey)
+          activateSurveyUseCase(surveyId)
+        }
+        .fold(
+          onSuccess = {
+            _uiState.emit(UiState.SurveyActivated)
+            navigateToHomeScreen()
+          },
+          onFailure = { exception ->
+            Timber.e(exception)
+            _uiState.emit(UiState.Error(R.string.error_message))
+          },
+        )
     }
 
   private fun navigateToHomeScreen() {
@@ -99,23 +100,5 @@ internal constructor(
 
   fun signOut() {
     userRepository.signOut()
-  }
-
-  private fun setNotFound() {
-    surveyListState.value = State.NOT_FOUND
-  }
-
-  private fun setLoading() {
-    surveyListState.value = State.LOADING
-  }
-
-  private fun setLoaded() {
-    surveyListState.value = State.LOADED
-  }
-
-  enum class State {
-    NOT_FOUND,
-    LOADING,
-    LOADED,
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/UiState.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/UiState.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.surveyselector
+
+import com.google.android.ground.model.SurveyListItem
+
+sealed class UiState {
+
+  data object FetchingSurveys : UiState()
+
+  data class SurveyListAvailable(val surveys: List<SurveyListItem>) : UiState()
+
+  data object ActivatingSurvey : UiState()
+
+  data object SurveyActivated : UiState()
+
+  data class Error(val errorResId: Int) : UiState()
+}

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/UiState.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/UiState.kt
@@ -19,13 +19,24 @@ import com.google.android.ground.model.SurveyListItem
 
 sealed class UiState {
 
+  /** Represents that surveys are being fetched from the remote server. */
   data object FetchingSurveys : UiState()
 
+  /**
+   * Represents that surveys have been successfully fetched and are available to be shown to the
+   * user.
+   */
   data class SurveyListAvailable(val surveys: List<SurveyListItem>) : UiState()
 
+  /** Represents that the selected survey and its associated LOIs are being persisted locally. */
   data object ActivatingSurvey : UiState()
 
+  /**
+   * Represents that the selected survey and its associated LOIs have been successfully saved
+   * locally and is ready to be loaded.
+   */
   data object SurveyActivated : UiState()
 
+  /** Represents that there was an error while activating surveys. */
   data class Error(val errorResId: Int) : UiState()
 }

--- a/ground/src/main/java/com/google/android/ground/util/ViewExt.kt
+++ b/ground/src/main/java/com/google/android/ground/util/ViewExt.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.util
+
+import android.view.View
+
+fun View.visibleIf(condition: Boolean) {
+  visibility = if (condition) View.VISIBLE else View.GONE
+}

--- a/ground/src/main/res/layout/survey_selector_frag.xml
+++ b/ground/src/main/res/layout/survey_selector_frag.xml
@@ -21,7 +21,6 @@
   xmlns:tools="http://schemas.android.com/tools">
 
   <data>
-    <import type="com.google.android.ground.ui.surveyselector.SurveySelectorViewModel.State" />
     <import type="android.view.View" />
     <variable
       name="viewModel"
@@ -46,7 +45,6 @@
 
     <LinearLayout
       android:id="@+id/container"
-      visible="@{viewModel.surveyListState != State.NOT_FOUND}"
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:orientation="vertical"
@@ -87,11 +85,11 @@
 
     <LinearLayout
       android:id="@+id/emptyContainer"
-      visible="@{viewModel.surveyListState == State.NOT_FOUND}"
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:gravity="center"
       android:orientation="vertical"
+      android:visibility="gone"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2081

<!-- PR description. -->
This PR aims at simplifying the way we are updating the UI in survey selector fragment. Currently, we have 3 separate flows for toggling progress dialog, survey list and errors. In this PR, we have merged all three flows into a single flow `UiState`  

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
