### PR TITLE
Use UiState in DataCollectionFragment

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -34,7 +34,6 @@ import com.google.android.ground.databinding.DataCollectionFragBinding
 import com.google.android.ground.model.task.Task
 import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.common.BackPressListener
-import com.google.android.ground.ui.common.EphemeralPopups
 import com.google.android.ground.ui.common.Navigator
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -45,7 +44,6 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class DataCollectionFragment : AbstractFragment(), BackPressListener {
   @Inject lateinit var navigator: Navigator
-  @Inject lateinit var popups: EphemeralPopups
   @Inject lateinit var viewPagerAdapterFactory: DataCollectionViewPagerAdapterFactory
 
   private val viewModel: DataCollectionViewModel by hiltNavGraphViewModels(R.id.data_collection)
@@ -109,7 +107,6 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
     when (uiState) {
       is UiState.TaskListAvailable -> loadTasks(uiState.tasks, uiState.taskPosition)
       is UiState.TaskUpdated -> onTaskChanged(uiState.taskPosition)
-      is UiState.Error -> popups.ErrorPopup().show(uiState.message)
     }
   }
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -34,6 +34,7 @@ import com.google.android.ground.repository.LocationOfInterestRepository
 import com.google.android.ground.repository.SubmissionRepository
 import com.google.android.ground.repository.SurveyRepository
 import com.google.android.ground.ui.common.AbstractViewModel
+import com.google.android.ground.ui.common.EphemeralPopups
 import com.google.android.ground.ui.common.LocationOfInterestHelper
 import com.google.android.ground.ui.common.Navigator
 import com.google.android.ground.ui.common.ViewModelFactory
@@ -50,6 +51,7 @@ import com.google.android.ground.ui.datacollection.tasks.time.TimeTaskViewModel
 import com.google.android.ground.ui.home.HomeScreenFragmentDirections
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
@@ -73,6 +75,7 @@ class DataCollectionViewModel
 internal constructor(
   private val viewModelFactory: ViewModelFactory,
   private val locationOfInterestHelper: LocationOfInterestHelper,
+  private val popups: Provider<EphemeralPopups>,
   private val navigator: Navigator,
   private val submitDataUseCase: SubmitDataUseCase,
   @ApplicationScope private val externalScope: CoroutineScope,
@@ -216,7 +219,7 @@ internal constructor(
 
     val validationError = taskViewModel.validate()
     if (validationError != null) {
-      _uiState.emit(UiState.Error(validationError))
+      popups.get().ErrorPopup().show(validationError)
       return
     }
 
@@ -231,7 +234,7 @@ internal constructor(
   suspend fun onNextClicked(taskViewModel: AbstractTaskViewModel) {
     val validationError = taskViewModel.validate()
     if (validationError != null) {
-      _uiState.emit(UiState.Error(validationError))
+      popups.get().ErrorPopup().show(validationError)
       return
     }
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskPosition.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskPosition.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.datacollection
+
+data class TaskPosition(
+  /** Represents the actual index of the task from the initial list. */
+  val absoluteIndex: Int,
+  /** Represents the index of the task from the computed task sequence. */
+  val relativeIndex: Int,
+  /** Represents the size of the computed task sequence. */
+  val sequenceSize: Int,
+)

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/UiState.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/UiState.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.ui.datacollection
+
+import com.google.android.ground.model.task.Task
+
+sealed class UiState {
+
+  data class TaskListAvailable(val tasks: List<Task>, val taskPosition: TaskPosition) : UiState()
+
+  data class TaskUpdated(val taskPosition: TaskPosition) : UiState()
+
+  data class Error(val message: String) : UiState()
+}

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/UiState.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/UiState.kt
@@ -22,6 +22,4 @@ sealed class UiState {
   data class TaskListAvailable(val tasks: List<Task>, val taskPosition: TaskPosition) : UiState()
 
   data class TaskUpdated(val taskPosition: TaskPosition) : UiState()
-
-  data class Error(val message: String) : UiState()
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
This is similar to https://github.com/google/ground-android/pull/2476. This allows hiding internals of the view model to fragment and exposing it via UiState. This makes the class more robust and manageable.

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
