### PR TITLE
Update gradle/kotlin versions to be more compatible with Java 21.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
 buildscript {
     ext {
         // As of Gradle 8.5, Kotlin plugin only tested up to 1.9.20.
-        kotlinVersion = "1.9.20"
+        kotlinVersion = "1.9.23"
         hiltVersion = "2.51"
         navigationVersion = "2.7.7"
         roomVersion = "2.6.1"
@@ -36,7 +36,7 @@ buildscript {
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$navigationVersion"
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.3.2'
         classpath 'com.google.gms:google-services:4.4.1'
         classpath "com.pascalwelsch.gitversioner:gitversioner:0.5.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -160,7 +160,7 @@ android {
         viewBinding true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "1.5.5"
+        kotlinCompilerExtensionVersion "1.5.13"
     }
     testOptions {
         unitTests {


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2486 

<!-- PR description. -->
Update gradle and kotlin versions to be more compatible, but not set, Java 21.

See compatibility tables: 
https://docs.gradle.org/current/userguide/compatibility.html
https://developer.android.com/jetpack/androidx/releases/compose-kotlin

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
- [x] Upgrade `kotlinVersion` to 1.9.23
- [x] Upgrade `com.android.tools.build:gradle` to 8.3.2`
- [x] Upgrade gradle-distribution to 8.7
- [x] Upgrade `kotlinCompilerExtensionVersion` "1.5.13" 

<!-- Add steps to verify bug/feature. -->
- [x] Fixes local compiler issues

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m PTAL!
