### PR TITLE
Moves creation of LOI to LoiRepository

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/locationofinterest/LocationOfInterest.kt
+++ b/ground/src/main/java/com/google/android/ground/model/locationofinterest/LocationOfInterest.kt
@@ -63,6 +63,7 @@ data class LocationOfInterest(
    * Converts this LOI to a mutation that can be used to update this LOI in the remote and local
    * database.
    */
+  // TODO: Remove this test-only method
   fun toMutation(type: Mutation.Type, userId: String): LocationOfInterestMutation =
     LocationOfInterestMutation(
       jobId = job.id,

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -32,7 +32,6 @@ import com.google.android.ground.persistence.uuid.OfflineUuidGenerator
 import com.google.android.ground.system.auth.AuthenticationManager
 import com.google.android.ground.ui.map.Bounds
 import com.google.android.ground.ui.map.gms.GmsExt.contains
-import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -94,7 +93,6 @@ constructor(
         surveyId = surveyId,
         locationOfInterestId = newId,
         userId = user.id,
-        clientTimestamp = Date(),
         geometry = geometry,
         ownerEmail = user.email,
         properties = generateProperties(loiName),

--- a/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/LocationOfInterestRepository.kt
@@ -15,14 +15,14 @@
  */
 package com.google.android.ground.repository
 
-import com.google.android.ground.model.AuditInfo
 import com.google.android.ground.model.Survey
-import com.google.android.ground.model.User
 import com.google.android.ground.model.geometry.Geometry
 import com.google.android.ground.model.job.Job
 import com.google.android.ground.model.locationofinterest.LocationOfInterest
 import com.google.android.ground.model.locationofinterest.generateProperties
 import com.google.android.ground.model.mutation.LocationOfInterestMutation
+import com.google.android.ground.model.mutation.Mutation
+import com.google.android.ground.model.mutation.Mutation.SyncStatus
 import com.google.android.ground.persistence.local.stores.LocalLocationOfInterestStore
 import com.google.android.ground.persistence.local.stores.LocalSurveyStore
 import com.google.android.ground.persistence.remote.NotFoundException
@@ -32,6 +32,7 @@ import com.google.android.ground.persistence.uuid.OfflineUuidGenerator
 import com.google.android.ground.system.auth.AuthenticationManager
 import com.google.android.ground.ui.map.Bounds
 import com.google.android.ground.ui.map.gms.GmsExt.contains
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -52,6 +53,7 @@ constructor(
   private val localLoiStore: LocalLocationOfInterestStore,
   private val remoteDataStore: RemoteDataStore,
   private val mutationSyncWorkManager: MutationSyncWorkManager,
+  private val userRepository: UserRepository,
   private val uuidGenerator: OfflineUuidGenerator,
   private val authenticationManager: AuthenticationManager,
 ) {
@@ -80,25 +82,26 @@ constructor(
       localLoiStore.getLocationOfInterest(it, locationOfInterest)
     } ?: throw NotFoundException("Location of interest not found $locationOfInterest")
 
-  fun createLocationOfInterest(
-    geometry: Geometry,
-    job: Job,
-    surveyId: String,
-    user: User,
-    loiName: String?,
-  ): LocationOfInterest {
-    val auditInfo = AuditInfo(user)
-    return LocationOfInterest(
-      id = uuidGenerator.generateUuid(),
-      surveyId = surveyId,
-      geometry = geometry,
-      job = job,
-      created = auditInfo,
-      lastModified = auditInfo,
-      ownerEmail = user.email,
-      properties = generateProperties(loiName),
-      isPredefined = false,
-    )
+  /** Saves a new LOI in the local db and enqueues a sync worker. */
+  suspend fun saveLoi(geometry: Geometry, job: Job, surveyId: String, loiName: String?): String {
+    val newId = uuidGenerator.generateUuid()
+    val user = userRepository.getAuthenticatedUser()
+    val mutation =
+      LocationOfInterestMutation(
+        jobId = job.id,
+        type = Mutation.Type.CREATE,
+        syncStatus = SyncStatus.PENDING,
+        surveyId = surveyId,
+        locationOfInterestId = newId,
+        userId = user.id,
+        clientTimestamp = Date(),
+        geometry = geometry,
+        ownerEmail = user.email,
+        properties = generateProperties(loiName),
+        isPredefined = false,
+      )
+    applyAndEnqueue(mutation)
+    return newId
   }
 
   /**


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->

<!-- PR description. -->
Moves logic for creation of LOI to LoiRepository. Also, removes the creation of intermediate state `LocationOfInterest` and directly generates the mutation.

This is similar to https://github.com/google/ground-android/pull/2495 where the goal is to simplify the save LOI flow by reducing the number of steps involved.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m @sufyanAbbasi  PTAL?
