### PR TITLE
Prevent view ID conflict/crash by multiplying each generated view ID by a prime number

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
@@ -40,7 +40,7 @@ class CaptureLocationTaskFragment : AbstractTaskFragment<CaptureLocationTaskView
   override fun onCreateTaskBody(inflater: LayoutInflater): View {
     // NOTE(#2493): Multiplying by a random prime to allow for some mathematical uniqueness.
     // Otherwise, the sequentially generated ID might conflict with an ID produced by Google Maps.
-    val rowLayout = LinearLayout(requireContext()).apply { id = View.generateViewId() * 11149}
+    val rowLayout = LinearLayout(requireContext()).apply { id = View.generateViewId() * 11149 }
     parentFragmentManager
       .beginTransaction()
       .add(

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
@@ -38,7 +38,9 @@ class CaptureLocationTaskFragment : AbstractTaskFragment<CaptureLocationTaskView
     TaskViewFactory.createWithCombinedHeader(inflater, R.drawable.outline_pin_drop)
 
   override fun onCreateTaskBody(inflater: LayoutInflater): View {
-    val rowLayout = LinearLayout(requireContext()).apply { id = View.generateViewId() }
+    // NOTE(#2493): Multiplying by a random prime to allow for some mathematical uniqueness.
+    // Otherwise, the sequentially generated ID might conflict with an ID produced by Google Maps.
+    val rowLayout = LinearLayout(requireContext()).apply { id = View.generateViewId() * 11149}
     parentFragmentManager
       .beginTransaction()
       .add(

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskFragment.kt
@@ -44,7 +44,9 @@ class DropPinTaskFragment : AbstractTaskFragment<DropPinTaskViewModel>() {
     TaskViewFactory.createWithCombinedHeader(inflater, R.drawable.outline_pin_drop)
 
   override fun onCreateTaskBody(inflater: LayoutInflater): View {
-    val rowLayout = LinearLayout(requireContext()).apply { id = View.generateViewId() }
+    // NOTE(#2493): Multiplying by a random prime to allow for some mathematical "uniqueness".
+    // Otherwise, the sequentially generated ID might conflict with an ID produced by Google Maps.
+    val rowLayout = LinearLayout(requireContext()).apply { id = View.generateViewId() * 11617 }
     parentFragmentManager
       .beginTransaction()
       .add(rowLayout.id, DropPinTaskMapFragment.newInstance(viewModel, map), "Drop a pin fragment")

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -56,7 +56,9 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
     TaskViewFactory.createWithCombinedHeader(inflater, R.drawable.outline_draw)
 
   override fun onCreateTaskBody(inflater: LayoutInflater): View {
-    val rowLayout = LinearLayout(requireContext()).apply { id = View.generateViewId() }
+    // NOTE(#2493): Multiplying by a random prime to allow for some mathematical "uniqueness".
+    // Otherwise, the sequentially generated ID might conflict with an ID produced by Google Maps.
+    val rowLayout = LinearLayout(requireContext()).apply { id = View.generateViewId() * 11411 }
     drawAreaTaskMapFragment = DrawAreaTaskMapFragment.newInstance(viewModel, map)
     parentFragmentManager
       .beginTransaction()


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2493

<!-- PR description. -->
- [x] Increase the chances of uniqueness for generated View IDs by multiplying by a randomly chosen, 5-digit prime number in order to prevent crashes due to `generateViewId()` producing an ID number that is the same as an ID number assigned to a View in the GoogleMapsFragment.
  -  I think this occurs because `generateViewId()` is not thread safe when `GoogleMapsFragment` views are also being produced at the same time.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
- [x] Created a survey via `npm run test:e2e:create` in `ground-platform` to create a survey to repro breakage.
- [x] Run local server via `npm run start:local` by modifying package.json to use `test/data-create`
- [x] Opened survey, verified that crash was avoided. 

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
<img width="288" alt="Screenshot 2024-07-29 at 5 13 12 PM" src="https://github.com/user-attachments/assets/cfc0b20b-7219-4fa9-ad4d-59ca746e99cc">

@gino-m, @shobhitagarwal1612  PTAL!
