### PR TITLE
[End-to-End Tests] Allow configuration for LOI task to be at any index in task list

### DIFF
--- a/e2eTest/src/main/java/com/google/android/ground/e2etest/SurveyRunnerTest.kt
+++ b/e2eTest/src/main/java/com/google/android/ground/e2etest/SurveyRunnerTest.kt
@@ -35,6 +35,7 @@ import com.google.android.ground.e2etest.TestConfig.GROUND_PACKAGE
 import com.google.android.ground.e2etest.TestConfig.LONG_TIMEOUT
 import com.google.android.ground.e2etest.TestConfig.SHORT_TIMEOUT
 import com.google.android.ground.e2etest.TestConfig.TEST_SURVEY_IDENTIFIER
+import com.google.android.ground.e2etest.TestConfig.TEST_SURVEY_LOI_TASK_INDEX
 import com.google.android.ground.e2etest.TestConfig.TEST_SURVEY_TASKS_ADHOC
 import com.google.android.ground.model.task.Task
 import java.io.IOException
@@ -61,7 +62,7 @@ class SurveyRunnerTest : AutomatorRunner {
     fillOutTaskData(isAdHoc = true, TEST_SURVEY_TASKS_ADHOC)
     clickSubmissionConfirmationDone()
     startPredefinedLoiTask()
-    fillOutTaskData(isAdHoc = false, TEST_SURVEY_TASKS_ADHOC.drop(1))
+    fillOutTaskData(isAdHoc = false, TEST_SURVEY_TASKS_ADHOC)
     clickSubmissionConfirmationDone()
   }
 
@@ -154,6 +155,9 @@ class SurveyRunnerTest : AutomatorRunner {
   private fun fillOutTaskData(isAdHoc: Boolean, taskList: List<Task.Type>) {
     taskList.forEachIndexed { i, it ->
       device.waitForIdle()
+      if (!isAdHoc && i == TEST_SURVEY_LOI_TASK_INDEX) {
+        return@forEachIndexed
+      }
       when (it) {
         Task.Type.DROP_PIN -> completeDropPinTask()
         Task.Type.DRAW_AREA -> completeDrawArea()
@@ -168,7 +172,7 @@ class SurveyRunnerTest : AutomatorRunner {
       }
       if (i < taskList.size - 1) {
         clickNext()
-        if (isAdHoc && i == 0) {
+        if (isAdHoc && i == TEST_SURVEY_LOI_TASK_INDEX) {
           setLoiName()
         }
       } else {

--- a/e2eTest/src/main/java/com/google/android/ground/e2etest/TestConfig.kt
+++ b/e2eTest/src/main/java/com/google/android/ground/e2etest/TestConfig.kt
@@ -23,6 +23,7 @@ object TestConfig {
   const val GROUND_PACKAGE = "com.google.android.ground"
   val TEST_SURVEY_TASKS_ADHOC =
     listOf(
+      Task.Type.CAPTURE_LOCATION,
       Task.Type.DROP_PIN,
       Task.Type.TEXT,
       Task.Type.MULTIPLE_CHOICE,
@@ -33,5 +34,6 @@ object TestConfig {
       Task.Type.PHOTO,
       Task.Type.CAPTURE_LOCATION,
     )
+  val TEST_SURVEY_LOI_TASK_INDEX = 1
   const val TEST_SURVEY_IDENTIFIER = "test"
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards https://github.com/google/ground-platform/issues/1927

<!-- PR description. -->
Allows for LOI task to be at an arbitrary index rather than hardcoded to the first entry.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.
- [x] Added a new config param, `TEST_SURVEY_LOI_TASK_INDEX`, to set the index at which to find the LOI task.
- [x] Skip LOI task when starting a predefined task.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
- Ran `npm run test:e2e:create` in ground-platform.
- Ran `firebase emulators:exec "./gradlew :e2eTest:connectedLocalDebugAndroidTest --stacktrace --info" --project local --ui  --config ../ground-platform/firebase.local.json --import ../ground-platform/data/test-create --export-on-exit ../ground-platform/data/test-submit`

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m PTAL!
