### PR TITLE
Load drawn area from saved state

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/polygon/DrawAreaTaskFragment.kt
@@ -74,9 +74,7 @@ class DrawAreaTaskFragment : AbstractTaskFragment<DrawAreaTaskViewModel>() {
     addPointButton =
       addButton(ButtonAction.ADD_POINT).setOnClickListener { viewModel.addLastVertex() }
     completeButton =
-      addButton(ButtonAction.COMPLETE).setOnClickListener {
-        viewModel.onCompletePolygonButtonClick()
-      }
+      addButton(ButtonAction.COMPLETE).setOnClickListener { viewModel.completePolygon() }
   }
 
   /** Removes the last vertex from the polygon. */


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #2373 

<!-- PR description. -->
Ensures that draw area tasks can be loaded from saved state. Will enter "complete" mode by default and the user can  undo if they want to go back, similar to the drop pin save state logic.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

- [x] Loads drawn areas from `taskData` by setting the vertices and completing the polygon.
- [x] Handles errors if for whatever reason the saved polygon is incomplete.

<!-- Add steps to verify bug/feature. -->
- [x] Created a job with draw area LOI task and quit after the draw area task was completed by force quitting the app.
- [x] Reloaded the app and ensured that the task started with the drawn area already loaded (see screenshot)

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
![Screenshot 2024-08-01 at 6 04 32 PM](https://github.com/user-attachments/assets/0d5f9e3f-3557-4b36-8d57-1cf915de1769)

@shobhitagarwal1612 PTAL!
