### PR TITLE
Specify protoc java plugin dep explicitly

### DIFF
--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -346,7 +346,7 @@ dependencies {
     implementation "com.google.guava:guava:31.1-android"
 
     api("com.google.protobuf:protobuf-kotlin-lite:4.26.1")
-    api("com.google.protobuf:protobuf-java:4.26.1")
+    api("com.google.protobuf:protobuf-javalite:4.26.1")
 
     // Pulls protodefs from the specified commit in the ground-platform repo.
     groundProtoJar "com.github.google:ground-platform:3e9162a@jar"

--- a/ground/build.gradle
+++ b/ground/build.gradle
@@ -345,8 +345,8 @@ dependencies {
 
     implementation "com.google.guava:guava:31.1-android"
 
-    // TODO(#1748): Move protos into shared module and set correct path here.
     api("com.google.protobuf:protobuf-kotlin-lite:4.26.1")
+    api("com.google.protobuf:protobuf-java:4.26.1")
 
     // Pulls protodefs from the specified commit in the ground-platform repo.
     groundProtoJar "com.github.google:ground-platform:3e9162a@jar"


### PR DESCRIPTION
Fixes failure running tests in CI in #2609. @scolsen PTAL?

Tested by syncing Gradle and running `gradle generateDevDebugUnitTestProto` locally.