### PR TITLE
[Offline area] Refactor code related to loading local/remote tile overlays

### DIFF
--- a/ground/src/main/java/com/google/android/ground/model/imagery/TileSource.kt
+++ b/ground/src/main/java/com/google/android/ground/model/imagery/TileSource.kt
@@ -22,4 +22,4 @@ sealed class TileSource
 
 data class LocalTileSource(val localFilePath: String, val clipBounds: List<Bounds>) : TileSource()
 
-data class RemoteMogTileSource(val remoteUrl: String) : TileSource()
+data class RemoteMogTileSource(val remotePath: String) : TileSource()

--- a/ground/src/main/java/com/google/android/ground/model/imagery/TileSource.kt
+++ b/ground/src/main/java/com/google/android/ground/model/imagery/TileSource.kt
@@ -18,11 +18,8 @@ package com.google.android.ground.model.imagery
 import com.google.android.ground.ui.map.Bounds
 
 /** Represents a single source of tiled map imagery. */
-data class TileSource(val url: String, val type: Type, val clipBounds: List<Bounds> = listOf()) {
-  // TODO(#1790): Consider creating specialized classes for each type of TileSource.
-  enum class Type {
-    TILED_WEB_MAP,
-    MOG_COLLECTION,
-    UNKNOWN,
-  }
-}
+sealed class TileSource
+
+data class TiledWebMapSource(val url: String, val clipBounds: List<Bounds>) : TileSource()
+
+data class MogCollectionSource(val url: String) : TileSource()

--- a/ground/src/main/java/com/google/android/ground/model/imagery/TileSource.kt
+++ b/ground/src/main/java/com/google/android/ground/model/imagery/TileSource.kt
@@ -20,6 +20,6 @@ import com.google.android.ground.ui.map.Bounds
 /** Represents a single source of tiled map imagery. */
 sealed class TileSource
 
-data class TiledWebMapSource(val url: String, val clipBounds: List<Bounds>) : TileSource()
+data class LocalTileSource(val localFilePath: String, val clipBounds: List<Bounds>) : TileSource()
 
-data class MogCollectionSource(val url: String) : TileSource()
+data class RemoteMogTileSource(val remoteUrl: String) : TileSource()

--- a/ground/src/main/java/com/google/android/ground/repository/OfflineAreaRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/OfflineAreaRepository.kt
@@ -111,9 +111,9 @@ constructor(
         TiledWebMapSource("file://${getLocalTileSourcePath()}/{z}/{x}/{y}.jpg", bounds)
       }
 
-  /** Returns the default configured tile sources. */
-  fun getDefaultTileSources(): List<TileSource> =
-    listOf(MogCollectionSource(url = Config.DEFAULT_MOG_TILE_LOCATION))
+  /** Returns the default configured tile source. */
+  fun getRemoteTileSource(): TileSource =
+    MogCollectionSource(url = Config.DEFAULT_MOG_TILE_LOCATION)
 
   suspend fun hasHiResImagery(bounds: Bounds): Boolean {
     val maxZoom = mogClient.collection.sources.maxZoom()

--- a/ground/src/main/java/com/google/android/ground/repository/OfflineAreaRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/OfflineAreaRepository.kt
@@ -32,14 +32,14 @@ import com.google.android.ground.ui.util.FileUtil
 import com.google.android.ground.util.ByteCount
 import com.google.android.ground.util.deleteIfEmpty
 import com.google.android.ground.util.rangeOf
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
-import java.io.File
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Corners of the viewport are scaled by this value when determining the name of downloaded areas.
@@ -113,7 +113,7 @@ constructor(
 
   /** Returns the default configured tile source. */
   fun getRemoteTileSource(): TileSource =
-    RemoteMogTileSource(remoteUrl = Config.DEFAULT_MOG_TILE_LOCATION)
+    RemoteMogTileSource(remotePath = Config.DEFAULT_MOG_TILE_LOCATION)
 
   suspend fun hasHiResImagery(bounds: Bounds): Boolean {
     val maxZoom = mogClient.collection.sources.maxZoom()

--- a/ground/src/main/java/com/google/android/ground/repository/OfflineAreaRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/OfflineAreaRepository.kt
@@ -16,10 +16,10 @@
 package com.google.android.ground.repository
 
 import com.google.android.ground.Config
-import com.google.android.ground.model.imagery.MogCollectionSource
+import com.google.android.ground.model.imagery.LocalTileSource
 import com.google.android.ground.model.imagery.OfflineArea
+import com.google.android.ground.model.imagery.RemoteMogTileSource
 import com.google.android.ground.model.imagery.TileSource
-import com.google.android.ground.model.imagery.TiledWebMapSource
 import com.google.android.ground.persistence.local.stores.LocalOfflineAreaStore
 import com.google.android.ground.persistence.uuid.OfflineUuidGenerator
 import com.google.android.ground.system.GeocodingManager
@@ -32,14 +32,14 @@ import com.google.android.ground.ui.util.FileUtil
 import com.google.android.ground.util.ByteCount
 import com.google.android.ground.util.deleteIfEmpty
 import com.google.android.ground.util.rangeOf
-import java.io.File
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Corners of the viewport are scaled by this value when determining the name of downloaded areas.
@@ -108,12 +108,12 @@ constructor(
       .offlineAreas()
       .map { list -> list.map { it.bounds } }
       .map { bounds ->
-        TiledWebMapSource("file://${getLocalTileSourcePath()}/{z}/{x}/{y}.jpg", bounds)
+        LocalTileSource("file://${getLocalTileSourcePath()}/{z}/{x}/{y}.jpg", bounds)
       }
 
   /** Returns the default configured tile source. */
   fun getRemoteTileSource(): TileSource =
-    MogCollectionSource(url = Config.DEFAULT_MOG_TILE_LOCATION)
+    RemoteMogTileSource(remoteUrl = Config.DEFAULT_MOG_TILE_LOCATION)
 
   suspend fun hasHiResImagery(bounds: Bounds): Boolean {
     val maxZoom = mogClient.collection.sources.maxZoom()

--- a/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/AbstractMapContainerFragment.kt
@@ -77,9 +77,9 @@ abstract class AbstractMapContainerFragment : AbstractFragment() {
 
     // Tile overlays.
     if (config.showOfflineImagery) {
-      viewModel.offlineTileSources.observe(viewLifecycleOwner) {
+      viewModel.offlineTileSources.observe(viewLifecycleOwner) { tileSource ->
         map.clearTileOverlays()
-        it.forEach(map::addTileOverlay)
+        tileSource?.let { map.addTileOverlay(it) }
       }
     }
 

--- a/ground/src/main/java/com/google/android/ground/ui/common/BaseMapViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/common/BaseMapViewModel.kt
@@ -115,11 +115,11 @@ constructor(
   var currentCameraPosition = MutableStateFlow<CameraPosition?>(null)
     private set
 
-  val offlineTileSources: LiveData<List<TileSource>> =
+  val offlineTileSources: LiveData<TileSource?> =
     offlineAreaRepository
       .getOfflineTileSourcesFlow()
       .combine(mapStateRepository.offlineImageryEnabledFlow) { offlineSources, enabled ->
-        if (enabled) offlineSources else listOf()
+        if (enabled) offlineSources else null
       }
       .asLiveData()
 

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
@@ -39,9 +39,9 @@ import com.google.android.gms.maps.model.TileOverlayOptions
 import com.google.android.gms.maps.model.TileProvider
 import com.google.android.ground.Config
 import com.google.android.ground.model.geometry.Coordinates
+import com.google.android.ground.model.imagery.MogCollectionSource
 import com.google.android.ground.model.imagery.TileSource
-import com.google.android.ground.model.imagery.TileSource.Type.MOG_COLLECTION
-import com.google.android.ground.model.imagery.TileSource.Type.TILED_WEB_MAP
+import com.google.android.ground.model.imagery.TiledWebMapSource
 import com.google.android.ground.persistence.remote.RemoteStorageManager
 import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.map.Bounds
@@ -273,10 +273,9 @@ class GoogleMapsFragment : SupportMapFragment(), MapFragment {
   }
 
   override fun addTileOverlay(source: TileSource) =
-    when (source.type) {
-      MOG_COLLECTION -> addRemoteMogTileOverlay(source.url)
-      TILED_WEB_MAP -> addLocalTileOverlay(source.url, source.clipBounds)
-      else -> error("Unsupported tile source type ${source.type}")
+    when (source) {
+      is MogCollectionSource -> addRemoteMogTileOverlay(source.url)
+      is TiledWebMapSource -> addLocalTileOverlay(source.url, source.clipBounds)
     }
 
   private fun addRemoteMogTileOverlay(url: String) {

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
@@ -269,7 +269,7 @@ class GoogleMapsFragment : SupportMapFragment(), MapFragment {
   override fun addTileOverlay(source: TileSource) =
     when (source) {
       is LocalTileSource -> addLocalTileOverlay(source.localFilePath, source.clipBounds)
-      is RemoteMogTileSource -> addRemoteMogTileOverlay(source.remoteUrl)
+      is RemoteMogTileSource -> addRemoteMogTileOverlay(source.remotePath)
     }
 
   private fun addLocalTileOverlay(url: String, bounds: List<Bounds>) {

--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/GoogleMapsFragment.kt
@@ -39,9 +39,9 @@ import com.google.android.gms.maps.model.TileOverlayOptions
 import com.google.android.gms.maps.model.TileProvider
 import com.google.android.ground.Config
 import com.google.android.ground.model.geometry.Coordinates
-import com.google.android.ground.model.imagery.MogCollectionSource
+import com.google.android.ground.model.imagery.LocalTileSource
+import com.google.android.ground.model.imagery.RemoteMogTileSource
 import com.google.android.ground.model.imagery.TileSource
-import com.google.android.ground.model.imagery.TiledWebMapSource
 import com.google.android.ground.persistence.remote.RemoteStorageManager
 import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.map.Bounds
@@ -266,17 +266,17 @@ class GoogleMapsFragment : SupportMapFragment(), MapFragment {
     }
   }
 
+  override fun addTileOverlay(source: TileSource) =
+    when (source) {
+      is LocalTileSource -> addLocalTileOverlay(source.localFilePath, source.clipBounds)
+      is RemoteMogTileSource -> addRemoteMogTileOverlay(source.remoteUrl)
+    }
+
   private fun addLocalTileOverlay(url: String, bounds: List<Bounds>) {
     addTileOverlay(
       ClippingTileProvider(TemplateUrlTileProvider(url), bounds.map { it.toGoogleMapsObject() })
     )
   }
-
-  override fun addTileOverlay(source: TileSource) =
-    when (source) {
-      is MogCollectionSource -> addRemoteMogTileOverlay(source.url)
-      is TiledWebMapSource -> addLocalTileOverlay(source.url, source.clipBounds)
-    }
 
   private fun addRemoteMogTileOverlay(url: String) {
     // TODO(#1730): Make sub-paths configurable and stop hardcoding here.

--- a/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorFragment.kt
@@ -64,7 +64,7 @@ class OfflineAreaSelectorFragment : AbstractMapContainerFragment() {
     viewLifecycleOwner.lifecycleScope.launch {
       mapContainerViewModel.mapLoiFeatures.collect { map.setFeatures(it) }
     }
-    viewModel.remoteTileSources.forEach { map.addTileOverlay(it) }
+    map.addTileOverlay(viewModel.remoteTileSource)
   }
 
   override fun getMapViewModel(): BaseMapViewModel = viewModel

--- a/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/offlineareas/selector/OfflineAreaSelectorViewModel.kt
@@ -69,7 +69,7 @@ internal constructor(
     locationOfInterestRepository,
   ) {
 
-  val remoteTileSources = offlineAreaRepository.getDefaultTileSources()
+  val remoteTileSource = offlineAreaRepository.getRemoteTileSource()
   private var viewport: Bounds? = null
   private val offlineAreaSizeLoadingSymbol =
     resources.getString(R.string.offline_area_size_loading_symbol)


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->
Fixes https://github.com/google/ground-android/issues/1790
<!-- Add one or more issues below if already present. Otherwise, create one. -->

<!-- PR description. -->
Things done:
 * Convert `TileSource` enum to sealed data class
 * Simplify `OfflineAreaRepository`
 * Replace `List<TileSource>` with `TileSource` when adding overlay for simplicity. If we need to support multiple tile sources, then we can change it back later.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
This is a pure refactor and doesn't change app behavior.

Verified for regressions by testing that remote mog overlay is loaded in offline area screen and locally downloaded tiles are loaded on home screen.


<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
