### PR TITLE
Prevent crash when displaying status of missing LOI

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusViewModel.kt
@@ -64,7 +64,7 @@ internal constructor(
   ): List<MutationDetail> = mutations.map { toMutationDetail(it) }
 
   private suspend fun toMutationDetail(mutation: Mutation): MutationDetail {
-    // TODO: Find a better solution here; perhaps return a null detail and do not render.
+    // TODO(#2652): Find a better solution here; perhaps return a null detail and do not render.
     val user = userRepository.getAuthenticatedUser()
     return try {
       val loi =
@@ -79,8 +79,8 @@ internal constructor(
       MutationDetail(
         user = user.displayName,
         mutation = mutation,
-        loiLabel = "Unknown Location",
-        loiSubtitle = "Unknown Location",
+        loiLabel = "## SITE DELETED ##",
+        loiSubtitle = "",
       )
     }
   }

--- a/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusViewModel.kt
@@ -64,14 +64,24 @@ internal constructor(
   ): List<MutationDetail> = mutations.map { toMutationDetail(it) }
 
   private suspend fun toMutationDetail(mutation: Mutation): MutationDetail {
-    val loi =
-      locationOfInterestRepository.getOfflineLoi(mutation.surveyId, mutation.locationOfInterestId)
+    // TODO: Find a better solution here; perhaps return a null detail and do not render.
     val user = userRepository.getAuthenticatedUser()
-    return MutationDetail(
-      user = user.displayName,
-      mutation = mutation,
-      loiLabel = locationOfInterestHelper.getJobName(loi) ?: "",
-      loiSubtitle = locationOfInterestHelper.getDisplayLoiName(loi),
-    )
+    return try {
+      val loi =
+        locationOfInterestRepository.getOfflineLoi(mutation.surveyId, mutation.locationOfInterestId)
+      MutationDetail(
+        user = user.displayName,
+        mutation = mutation,
+        loiLabel = locationOfInterestHelper.getJobName(loi) ?: "",
+        loiSubtitle = locationOfInterestHelper.getDisplayLoiName(loi),
+      )
+    } catch (e: IllegalStateException) {
+      MutationDetail(
+        user = user.displayName,
+        mutation = mutation,
+        loiLabel = "Unknown Location",
+        loiSubtitle = "Unknown Location",
+      )
+    }
   }
 }


### PR DESCRIPTION
Instead, we (for now) just print "Unkown Location". We should get a better fix in place hereafter.

Towards #2652

@gino-m 