### PR TITLE
Re-enable Gradle daemon on CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -85,7 +85,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex assembleDevStaging assembleDevStagingUnitTest -PtestBuildType=staging --no-daemon
+        ./gradlew -PdisablePreDex assembleDevStaging assembleDevStagingUnitTest -PtestBuildType=staging
 
   # TODO(#1547): Re-enable once instrumentation tests are fixed.
   #        if [[ "${_PUSH_TO_MASTER}" ]]; then
@@ -100,7 +100,7 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex checkCode --no-daemon 2> check-logs.txt || echo "fail" > build-status.txt
+        ./gradlew -PdisablePreDex checkCode 2> check-logs.txt || echo "fail" > build-status.txt
         cat check-logs.txt
 
   - name: 'gcr.io/$PROJECT_ID/android:34'
@@ -110,10 +110,10 @@ steps:
     args:
       - '-c'
       - |
-        ./gradlew -PdisablePreDex testDevDebugUnitTest --no-daemon 2> unit-test-logs.txt || echo "fail" > build-status.txt
+        ./gradlew -PdisablePreDex testDevDebugUnitTest 2> unit-test-logs.txt || echo "fail" > build-status.txt
         cat unit-test-logs.txt
 
-        ./gradlew jacocoDevDebugUnitTestReport --no-daemon
+        ./gradlew jacocoDevDebugUnitTestReport
 
   - name: 'gcr.io/$PROJECT_ID/android:34'
     id: &authenticate_gcloud 'Authorize gcloud'

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@
 #Thu Dec 26 12:25:19 EST 2019
 android.enableJetifier=true
 android.useAndroidX=true
-
 # Enable Gradle Daemon
 org.gradle.daemon=true
 # Enable Configure on demand
@@ -23,7 +22,7 @@ org.gradle.parallel=true
 # Enable simple gradle caching
 org.gradle.caching=true
 # Increase memory allotted to JVM
-org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx8G -XX:+HeapDumpOnOutOfMemoryError
 # Enable default code style for Kotlin
 kotlin.code.style=official
 android.nonTransitiveRClass=false


### PR DESCRIPTION
Builds frequently fail with:

> Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)

For newer version of Gradle [docs](https://docs.gradle.org/8.3/userguide/gradle_daemon.html#continuous_integration) recommend the following:

> We recommend using the Daemon for both developer machines and Continuous Integration servers.

Related to #2269 

Also, double max Gradle heap size for good measure.