### PR TITLE
Ignore survey clicks while the survey is being activated.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
@@ -72,6 +72,10 @@ internal constructor(
   fun activateSurvey(surveyId: String) =
     viewModelScope.launch {
       runCatching {
+          // Ignore extra clicks while survey is loading, see #2729.
+          if (_uiState.value is UiState.ActivatingSurvey) {
+            return@runCatching
+          }
           _uiState.emit(UiState.ActivatingSurvey)
           activateSurveyUseCase(surveyId)
         }

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
@@ -73,11 +73,10 @@ internal constructor(
     viewModelScope.launch {
       runCatching {
           // Ignore extra clicks while survey is loading, see #2729.
-          if (_uiState.value is UiState.ActivatingSurvey) {
-            return@runCatching
+          if (_uiState.value !is UiState.ActivatingSurvey) {
+            _uiState.emit(UiState.ActivatingSurvey)
+            activateSurveyUseCase(surveyId)
           }
-          _uiState.emit(UiState.ActivatingSurvey)
-          activateSurveyUseCase(surveyId)
         }
         .fold(
           onSuccess = {

--- a/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
@@ -69,14 +69,16 @@ internal constructor(
     }
 
   /** Triggers the specified survey to be loaded and activated. */
-  fun activateSurvey(surveyId: String) =
+  fun activateSurvey(surveyId: String) {
+    if (_uiState.value is UiState.ActivatingSurvey) {
+      // Ignore extra clicks while survey is loading, see #2729.
+      Timber.v("Ignoring extra survey click.")
+      return
+    }
     viewModelScope.launch {
       runCatching {
-          // Ignore extra clicks while survey is loading, see #2729.
-          if (_uiState.value !is UiState.ActivatingSurvey) {
-            _uiState.emit(UiState.ActivatingSurvey)
-            activateSurveyUseCase(surveyId)
-          }
+          _uiState.emit(UiState.ActivatingSurvey)
+          activateSurveyUseCase(surveyId)
         }
         .fold(
           onSuccess = {
@@ -89,6 +91,7 @@ internal constructor(
           },
         )
     }
+  }
 
   private fun navigateToHomeScreen() {
     navigator.navigate(HomeScreenFragmentDirections.showHomeScreen())


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2729

<!-- PR description. -->
Prevent secondary loading of survey while the current survey is still being loaded. Unfortunately, there still exists UX problems of the user not getting any feedback about the survey still in the loading state even after the loading bar has gone away.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m PTAL!
