### PR TITLE
Navigate To Home only after Survey Activated and Subscribed

### DIFF
--- a/ground/src/main/java/com/google/android/ground/persistence/local/LocalValueStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/LocalValueStore.kt
@@ -104,6 +104,13 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
       preferences.edit().putString(DRAFT_SUBMISSION_ID, value).apply()
     }
 
+  /** Is survey subscribed or not for the updated */
+  var isSurveySubscribed: Boolean
+    get() = allowThreadDiskReads { preferences.getBoolean(SURVEY_SUBSCRIBED_OFFLINE, false) }
+    set(value) = allowThreadDiskWrites {
+      preferences.edit().putBoolean(SURVEY_SUBSCRIBED_OFFLINE, value).apply()
+    }
+
   /** Removes all values stored in the local store. */
   fun clear() = allowThreadDiskWrites { preferences.edit().clear().apply() }
 
@@ -151,5 +158,6 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
     const val DROP_PIN_INSTRUCTIONS_SHOWN = "drop_pin_instructions_shown"
     const val DRAFT_SUBMISSION_ID = "draft_submission_id"
     const val DATA_SHARING_CONSENT_PREFIX = "data_consent_"
+    const val SURVEY_SUBSCRIBED_OFFLINE = "survey_subscribed_offline"
   }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/FirestoreDataStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/FirestoreDataStore.kt
@@ -24,6 +24,7 @@ import com.google.android.ground.model.mutation.LocationOfInterestMutation
 import com.google.android.ground.model.mutation.Mutation
 import com.google.android.ground.model.mutation.SubmissionMutation
 import com.google.android.ground.model.toListItem
+import com.google.android.ground.persistence.local.LocalValueStore
 import com.google.android.ground.persistence.remote.RemoteDataStore
 import com.google.android.ground.persistence.remote.firebase.schema.GroundFirestore
 import com.google.firebase.firestore.WriteBatch
@@ -50,6 +51,7 @@ internal constructor(
   private val firebaseFunctions: FirebaseFunctions,
   private val firestoreProvider: FirebaseFirestoreProvider,
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+  private val localValueStore: LocalValueStore,
 ) : RemoteDataStore {
 
   private suspend fun db() = GroundFirestore(firestoreProvider.get())
@@ -78,6 +80,7 @@ internal constructor(
   override suspend fun subscribeToSurveyUpdates(surveyId: String) {
     Timber.d("Subscribing to FCM topic $surveyId")
     Firebase.messaging.subscribeToTopic(surveyId).await()
+    localValueStore.isSurveySubscribed = true
   }
 
   /**


### PR DESCRIPTION
 ActivateSurveyUseCase and MakeSurveyAvailableOfflineUseCase are somehow working in parallel internally

Earlier, `onSuccess` is not called only after complete all the steps of activating + making survey offline

and because of that, onSuccess invoked, emitting SurveyActivated, in a partial phase, user was able to navigateToHome and the ongoing job, which is making the survey offline gets cancelled 

https://github.com/user-attachments/assets/8ee6898a-d246-445b-aff2-8dc254f741eb

