### PR TITLE
Unstick stuck uploads

### DIFF
--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomLocationOfInterestStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/stores/RoomLocationOfInterestStore.kt
@@ -120,6 +120,11 @@ class RoomLocationOfInterestStore @Inject internal constructor() : LocalLocation
       mutations.filter { it.surveyId == survey.id }.map { it.toModelObject() }
     }
 
+  override fun getAllMutationsFlow(): Flow<List<LocationOfInterestMutation>> =
+    locationOfInterestMutationDao.getAllMutationsFlow().map { mutations ->
+      mutations.map { it.toModelObject() }
+    }
+
   override suspend fun findByLocationOfInterestId(
     id: String,
     vararg states: MutationEntitySyncStatus,

--- a/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalLocationOfInterestStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalLocationOfInterestStore.kt
@@ -46,6 +46,8 @@ interface LocalLocationOfInterestStore :
    */
   fun getAllSurveyMutations(survey: Survey): Flow<List<LocationOfInterestMutation>>
 
+  fun getAllMutationsFlow(): Flow<List<LocationOfInterestMutation>>
+
   suspend fun findByLocationOfInterestId(
     id: String,
     vararg states: MutationEntitySyncStatus,

--- a/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalSubmissionStore.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/stores/LocalSubmissionStore.kt
@@ -59,6 +59,8 @@ interface LocalSubmissionStore : LocalMutationStore<SubmissionMutation, Submissi
    */
   fun getAllSurveyMutationsFlow(survey: Survey): Flow<List<SubmissionMutation>>
 
+  fun getAllMutationsFlow(): Flow<List<SubmissionMutation>>
+
   suspend fun findByLocationOfInterestId(
     loidId: String,
     vararg states: MutationEntitySyncStatus,

--- a/ground/src/main/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorker.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorker.kt
@@ -123,10 +123,10 @@ constructor(
       // Mark all mutations as having failed since the remote datastore only commits when all
       // mutations have succeeded.
       Timber.d(t, "Local mutation sync failed")
+      mutationRepository.markAsFailed(mutations, t)
       val crashlytics = FirebaseCrashLogger()
       crashlytics.setSelectedSurveyId(mutations.first().surveyId)
       crashlytics.logException(t)
-      mutationRepository.markAsFailed(mutations, t)
       false
     }
   }

--- a/ground/src/main/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorker.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/sync/LocalMutationSyncWorker.kt
@@ -25,7 +25,9 @@ import androidx.work.WorkerParameters
 import com.google.android.ground.FirebaseCrashLogger
 import com.google.android.ground.model.User
 import com.google.android.ground.model.mutation.Mutation
-import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus
+import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus.FAILED
+import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus.IN_PROGRESS
+import com.google.android.ground.persistence.local.room.fields.MutationEntitySyncStatus.PENDING
 import com.google.android.ground.persistence.local.stores.LocalUserStore
 import com.google.android.ground.persistence.remote.RemoteDataStore
 import com.google.android.ground.persistence.sync.LocalMutationSyncWorker.Companion.createInputData
@@ -60,7 +62,7 @@ constructor(
 
   private suspend fun doWorkInternal(): Result =
     try {
-      val mutations = getPendingOrEligibleFailedMutations()
+      val mutations = getIncompleteMutations()
       Timber.d("Syncing ${mutations.size} changes for LOI $locationOfInterestId")
       val result = processMutations(mutations)
       mediaUploadWorkManager.enqueueSyncWorker(locationOfInterestId)
@@ -71,16 +73,12 @@ constructor(
     }
 
   /**
-   * Attempts to fetch all mutations from the [MutationRepository] that are in `PENDING` state or in
-   * `FAILED` state but eligible for retry.
+   * Attempts to fetch all mutations from the [MutationRepository] that are `PENDING`, `FAILED`, or
+   * `IN_PROGRESS` state. The latter should never occur since only on worker should be scheduled per
+   * LOI at a given time.
    */
-  private suspend fun getPendingOrEligibleFailedMutations(): List<Mutation> {
-    val pendingMutations =
-      mutationRepository.getMutations(locationOfInterestId, MutationEntitySyncStatus.PENDING)
-    val failedMutationsEligibleForRetry =
-      mutationRepository.getMutations(locationOfInterestId, MutationEntitySyncStatus.FAILED)
-    return pendingMutations + failedMutationsEligibleForRetry
-  }
+  private suspend fun getIncompleteMutations(): List<Mutation> =
+    mutationRepository.getMutations(locationOfInterestId, PENDING, FAILED, IN_PROGRESS)
 
   /**
    * Groups mutations by user id, loads each user, applies mutations, and removes processed

--- a/ground/src/main/java/com/google/android/ground/persistence/sync/MediaUploadWorker.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/sync/MediaUploadWorker.kt
@@ -69,6 +69,7 @@ constructor(
       mutationRepository.getSubmissionMutations(
         loiId,
         MutationEntitySyncStatus.MEDIA_UPLOAD_PENDING,
+        MutationEntitySyncStatus.MEDIA_UPLOAD_IN_PROGRESS,
         MutationEntitySyncStatus.MEDIA_UPLOAD_AWAITING_RETRY,
       )
     val results = uploadMedia(mutations)

--- a/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
@@ -49,7 +49,8 @@ constructor(
    * subscribe and a new list on each subsequent change.
    */
   fun getSurveyMutationsFlow(survey: Survey): Flow<List<Mutation>> {
-    // TODO: Show mutations for all surveys, not just current one.
+    // TODO(https://github.com/google/ground-android/issues/2838): Show mutations for all surveys,
+    // not just current one.
     val locationOfInterestMutations = localLocationOfInterestStore.getAllSurveyMutations(survey)
     val submissionMutations = localSubmissionStore.getAllSurveyMutationsFlow(survey)
 

--- a/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
@@ -57,6 +57,13 @@ constructor(
     return locationOfInterestMutations.combine(submissionMutations, this::combineAndSortMutations)
   }
 
+  fun getAllMutationsFlow(): Flow<List<Mutation>> {
+    val locationOfInterestMutations = localLocationOfInterestStore.getAllMutationsFlow()
+    val submissionMutations = localSubmissionStore.getAllMutationsFlow()
+
+    return locationOfInterestMutations.combine(submissionMutations, this::combineAndSortMutations)
+  }
+
   /**
    * Returns all local submission mutations associated with the the given LOI ID that have one of
    * the provided sync statues.

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenViewModel.kt
@@ -18,6 +18,7 @@ package com.google.android.ground.ui.home
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
+import com.google.android.ground.model.mutation.Mutation.SyncStatus.COMPLETED
 import com.google.android.ground.model.submission.DraftSubmission
 import com.google.android.ground.persistence.local.LocalValueStore
 import com.google.android.ground.persistence.sync.MutationSyncWorkManager
@@ -68,8 +69,9 @@ internal constructor(
    */
   private suspend fun kickLocalMutationSyncWorkers() {
     val mutations = mutationRepository.getAllMutationsFlow().first()
-    val loiIds = mutations.map { it.locationOfInterestId }.toSet()
-    loiIds.forEach { loiId -> mutationSyncWorkManager.enqueueSyncWorker(loiId) }
+    val incompleteLoiIds =
+      mutations.filter { it.syncStatus != COMPLETED }.map { it.locationOfInterestId }.toSet()
+    incompleteLoiIds.forEach { loiId -> mutationSyncWorkManager.enqueueSyncWorker(loiId) }
   }
 
   /** Attempts to return draft submission for the currently active survey. */


### PR DESCRIPTION
Forces mutation workers to scan all incomplete mutations when home screen is first opened. The should happen when the home screen is opened after app update.

Towards #2726
Fixes #2751
