### PR TITLE
Adds exception handling for coroutine cancellation when using await()

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -273,6 +273,7 @@ exceptions:
     SwallowedException:
         active: true
         ignoredExceptionTypes:
+            - 'CancellationException'
             - 'InterruptedException'
             - 'MalformedURLException'
             - 'NumberFormatException'

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/FirebaseStorageManager.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/FirebaseStorageManager.kt
@@ -22,7 +22,9 @@ import java.io.File
 import java.util.StringJoiner
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
+import timber.log.Timber
 
 // TODO: Add column to Submission table for storing uploaded media urls
 // TODO: Synced to remote db as well
@@ -42,7 +44,11 @@ class FirebaseStorageManager @Inject constructor() : RemoteStorageManager {
   // Do not delete the file after successful upload. It is used as a cache
   // while viewing submissions when network is unavailable.
   override suspend fun uploadMediaFromFile(file: File, remoteDestinationPath: String) {
-    createReference(remoteDestinationPath).putFile(Uri.fromFile(file)).await()
+    try {
+      createReference(remoteDestinationPath).putFile(Uri.fromFile(file)).await()
+    } catch (e: CancellationException) {
+      Timber.i(e, "Uploading media to remote storage cancelled")
+    }
   }
 
   companion object {

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/base/FluentCollectionReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/base/FluentCollectionReference.kt
@@ -24,7 +24,6 @@ open class FluentCollectionReference
 protected constructor(
   private val reference: CollectionReference,
   protected val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-  protected val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
 
   protected fun reference(): CollectionReference = reference

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/base/FluentCollectionReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/base/FluentCollectionReference.kt
@@ -17,14 +17,9 @@
 package com.google.android.ground.persistence.remote.firebase.base
 
 import com.google.firebase.firestore.CollectionReference
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 
 open class FluentCollectionReference
-protected constructor(
-  private val reference: CollectionReference,
-  protected val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) {
+protected constructor(private val reference: CollectionReference) {
 
   protected fun reference(): CollectionReference = reference
 

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/JobCollectionReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/JobCollectionReference.kt
@@ -19,14 +19,19 @@ package com.google.android.ground.persistence.remote.firebase.schema
 import com.google.android.ground.model.job.Job
 import com.google.android.ground.persistence.remote.firebase.base.FluentCollectionReference
 import com.google.firebase.firestore.CollectionReference
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
-import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 class JobCollectionReference internal constructor(ref: CollectionReference) :
   FluentCollectionReference(ref) {
+
   suspend fun get(): List<Job> =
-    withContext(ioDispatcher) {
+    try {
       val docs = reference().get().await()
       docs.map { doc -> JobConverter.toJob(doc) }
+    } catch (e: CancellationException) {
+      Timber.i(e, "Fetching Jobs was cancelled")
+      listOf()
     }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiCollectionReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiCollectionReference.kt
@@ -22,9 +22,9 @@ import com.google.android.ground.persistence.remote.firebase.base.FluentCollecti
 import com.google.android.ground.persistence.remote.firebase.schema.LoiConverter.toLoi
 import com.google.android.ground.proto.LocationOfInterest as LocationOfInterestProto
 import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.Query
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.tasks.await
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
@@ -42,28 +42,32 @@ class LoiCollectionReference internal constructor(ref: CollectionReference) :
 
   /** Retrieves all "predefined" LOIs in the specified survey. Main-safe. */
   suspend fun fetchPredefined(survey: Survey): List<LocationOfInterest> =
-    withContext(ioDispatcher) {
-      // Use !=false rather than ==true to not break legacy dev surveys.
-      // TODO(#2375): Switch to whereEqualTo(true) once legacy dev surveys deleted or migrated.
-      val query =
-        reference().whereEqualTo(SOURCE_FIELD, LocationOfInterestProto.Source.IMPORTED.number)
-      toLois(survey, query.get().await())
-    }
+    // Use !=false rather than ==true to not break legacy dev surveys.
+    // TODO(#2375): Switch to whereEqualTo(true) once legacy dev surveys deleted or migrated.
+    fetchLois(
+      survey,
+      reference().whereEqualTo(SOURCE_FIELD, LocationOfInterestProto.Source.IMPORTED.number),
+    )
 
   /** Retrieves LOIs created by the specified email in the specified survey. Main-safe. */
   suspend fun fetchUserDefined(survey: Survey, ownerUserId: String): List<LocationOfInterest> =
-    withContext(ioDispatcher) {
-      val query =
-        reference()
-          .whereEqualTo(SOURCE_FIELD, LocationOfInterestProto.Source.FIELD_DATA.number)
-          .whereEqualTo(OWNER_FIELD, ownerUserId)
-      toLois(survey, query.get().await())
-    }
+    fetchLois(
+      survey,
+      reference()
+        .whereEqualTo(SOURCE_FIELD, LocationOfInterestProto.Source.FIELD_DATA.number)
+        .whereEqualTo(OWNER_FIELD, ownerUserId),
+    )
 
-  private fun toLois(survey: Survey, snapshot: QuerySnapshot): List<LocationOfInterest> =
-    snapshot.documents.mapNotNull {
-      toLoi(survey, it)
-        .onFailure { t -> Timber.e(t, "Invalid LOI ${it.id} in remote survey ${survey.id}") }
-        .getOrNull()
+  private suspend fun fetchLois(survey: Survey, query: Query): List<LocationOfInterest> =
+    try {
+      val snapshot = query.get().await()
+      snapshot.documents.mapNotNull {
+        toLoi(survey, it)
+          .onFailure { t -> Timber.e(t, "Invalid LOI ${it.id} in remote survey ${survey.id}") }
+          .getOrNull()
+      }
+    } catch (e: CancellationException) {
+      Timber.i(e, "Fetching LOIs was cancelled")
+      listOf()
     }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiCollectionReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/LoiCollectionReference.kt
@@ -60,12 +60,10 @@ class LoiCollectionReference internal constructor(ref: CollectionReference) :
       toLois(survey, query.get().await())
     }
 
-  private suspend fun toLois(survey: Survey, snapshot: QuerySnapshot): List<LocationOfInterest> =
-    withContext(defaultDispatcher) {
-      snapshot.documents.mapNotNull {
-        toLoi(survey, it)
-          .onFailure { t -> Timber.e(t, "Invalid LOI ${it.id} in remote survey ${survey.id}") }
-          .getOrNull()
-      }
+  private fun toLois(survey: Survey, snapshot: QuerySnapshot): List<LocationOfInterest> =
+    snapshot.documents.mapNotNull {
+      toLoi(survey, it)
+        .onFailure { t -> Timber.e(t, "Invalid LOI ${it.id} in remote survey ${survey.id}") }
+        .getOrNull()
     }
 }

--- a/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/TermsOfServiceDocumentReference.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/remote/firebase/schema/TermsOfServiceDocumentReference.kt
@@ -19,7 +19,9 @@ package com.google.android.ground.persistence.remote.firebase.schema
 import com.google.android.ground.model.TermsOfService
 import com.google.android.ground.persistence.remote.firebase.base.FluentDocumentReference
 import com.google.firebase.firestore.DocumentReference
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
+import timber.log.Timber
 
 class TermsOfServiceDocumentReference internal constructor(ref: DocumentReference) :
   FluentDocumentReference(ref) {
@@ -27,7 +29,12 @@ class TermsOfServiceDocumentReference internal constructor(ref: DocumentReferenc
   fun terms() = TermsOfServiceDocumentReference(reference())
 
   suspend fun get(): TermsOfService? {
-    val documentSnapshot = reference().get().await()
-    return TermsOfServiceConverter.toTerms(documentSnapshot)
+    try {
+      val documentSnapshot = reference().get().await()
+      return TermsOfServiceConverter.toTerms(documentSnapshot)
+    } catch (e: CancellationException) {
+      Timber.i(e, "Fetching TermsOfService was cancelled")
+      return null
+    }
   }
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #2854

<!-- PR description. -->
As per documentation, calling `await()` when the coroutine is cancelled throws `JobCancellationException`. Since it is a normal part of the coroutine lifecycle, these can be safely ignored and the error can be handled accordingly. 

The classes are identified based on logs/stacktraces from the crashlytics dashboard. There could be more of them, so we should keep the issue open until no more of these errors are observed.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
