### PR TITLE
[Data collection] Restore position to last task when restoring draft

### DIFF
--- a/ground/src/main/java/com/google/android/ground/Config.kt
+++ b/ground/src/main/java/com/google/android/ground/Config.kt
@@ -25,7 +25,7 @@ object Config {
   const val SHARED_PREFS_MODE = Context.MODE_PRIVATE
 
   // Local db settings.
-  const val DB_VERSION = 120
+  const val DB_VERSION = 121
   const val DB_NAME = "ground.db"
 
   // Firebase Cloud Firestore settings.

--- a/ground/src/main/java/com/google/android/ground/model/submission/DraftSubmission.kt
+++ b/ground/src/main/java/com/google/android/ground/model/submission/DraftSubmission.kt
@@ -23,4 +23,5 @@ data class DraftSubmission(
   val loiName: String?,
   val surveyId: String,
   val deltas: List<ValueDelta>,
+  val currentTaskId: String?,
 )

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/converter/ConverterExt.kt
@@ -487,6 +487,7 @@ fun DraftSubmissionEntity.toModelObject(survey: Survey): DraftSubmission {
     loiName = loiName,
     surveyId = surveyId,
     deltas = SubmissionDeltasConverter.fromString(job, deltas),
+    currentTaskId = currentTaskId,
   )
 }
 
@@ -498,4 +499,5 @@ fun DraftSubmission.toLocalDataStoreObject() =
     loiName = loiName,
     surveyId = surveyId,
     deltas = SubmissionDeltasConverter.toString(deltas),
+    currentTaskId = currentTaskId,
   )

--- a/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/DraftSubmissionEntity.kt
+++ b/ground/src/main/java/com/google/android/ground/persistence/local/room/entity/DraftSubmissionEntity.kt
@@ -30,4 +30,5 @@ data class DraftSubmissionEntity(
   @ColumnInfo(name = "survey_id") val surveyId: String,
   @ColumnInfo(name = "deltas") val deltas: String?,
   @ColumnInfo(name = "loi_name") val loiName: String?,
+  @ColumnInfo(name = "current_task_id") val currentTaskId: String?,
 )

--- a/ground/src/main/java/com/google/android/ground/repository/SubmissionRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/SubmissionRepository.kt
@@ -83,9 +83,10 @@ constructor(
     surveyId: String,
     deltas: List<ValueDelta>,
     loiName: String?,
+    currentTaskId: String,
   ) {
     val newId = uuidGenerator.generateUuid()
-    val draft = DraftSubmission(newId, jobId, loiId, loiName, surveyId, deltas)
+    val draft = DraftSubmission(newId, jobId, loiId, loiName, surveyId, deltas, currentTaskId)
     localSubmissionStore.saveDraftSubmission(draftSubmission = draft)
     localValueStore.draftSubmissionId = newId
   }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -152,7 +152,7 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
     if (currentAdapter == null || currentAdapter.tasks != tasks) {
       viewPager.adapter = viewPagerAdapterFactory.create(this, tasks)
     }
-    updateProgressBar(taskPosition, false)
+    viewPager.doOnLayout { onTaskChanged(taskPosition) }
   }
 
   private fun onTaskChanged(taskPosition: TaskPosition) {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -198,8 +198,6 @@ internal constructor(
 
   /** Moves back to the previous task in the sequence if the current value is valid or empty. */
   suspend fun onPreviousClicked(taskViewModel: AbstractTaskViewModel) {
-    check(getPositionInTaskSequence().first != 0)
-
     val task = taskViewModel.task
     val taskValue = taskViewModel.taskTaskData.firstOrNull()
 
@@ -287,6 +285,7 @@ internal constructor(
         surveyId = surveyId,
         deltas = getDeltas(),
         loiName = customLoiName,
+        currentTaskId = currentTaskId.value,
       )
     }
   }

--- a/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/HomeScreenFragment.kt
@@ -112,6 +112,7 @@ class HomeScreenFragment :
             draft.jobId,
             true,
             SubmissionDeltasConverter.toString(draft.deltas),
+            draft.currentTaskId ?: "",
           )
         )
 

--- a/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -302,6 +302,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
             cardUiData.loi.job.id,
             false,
             null,
+            "",
           )
         )
       is MapCardUiData.AddLoiCardUiData ->
@@ -312,6 +313,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
             cardUiData.job.id,
             false,
             null,
+            "",
           )
         )
     }

--- a/ground/src/main/res/navigation/nav_graph.xml
+++ b/ground/src/main/res/navigation/nav_graph.xml
@@ -106,6 +106,10 @@
       android:name="draftValues"
       type="string"
       app:nullable="true" />
+    <argument
+      android:name="currentTaskId"
+      type="string"
+      app:nullable="true" />
 
     <fragment
       android:id="@+id/data_collection_fragment"

--- a/ground/src/main/res/navigation/nav_graph.xml
+++ b/ground/src/main/res/navigation/nav_graph.xml
@@ -134,6 +134,10 @@
         android:name="draftValues"
         type="string"
         app:nullable="true" />
+      <argument
+        android:name="currentTaskId"
+        type="string"
+        app:nullable="true" />
     </fragment>
 
     <fragment

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -134,6 +134,7 @@ class DataCollectionFragmentTest : BaseHiltTest() {
         eq(SURVEY.id),
         capture(deltaCaptor),
         eq(LOCATION_OF_INTEREST_NAME),
+        eq(TASK_ID_2),
       )
 
     listOf(TASK_1_VALUE_DELTA).forEach { value -> assertThat(deltaCaptor.value).contains(value) }
@@ -149,13 +150,23 @@ class DataCollectionFragmentTest : BaseHiltTest() {
 
     // Both deletion and creating happens twice as we do it on every previous/next step
     verify(submissionRepository, times(2)).deleteDraftSubmission()
-    verify(submissionRepository, times(2))
+    verify(submissionRepository, times(1))
       .saveDraftSubmission(
         eq(JOB.id),
         eq(LOCATION_OF_INTEREST.id),
         eq(SURVEY.id),
         capture(deltaCaptor),
         eq(LOCATION_OF_INTEREST_NAME),
+        eq(TASK_ID_2),
+      )
+    verify(submissionRepository, times(1))
+      .saveDraftSubmission(
+        eq(JOB.id),
+        eq(LOCATION_OF_INTEREST.id),
+        eq(SURVEY.id),
+        capture(deltaCaptor),
+        eq(LOCATION_OF_INTEREST_NAME),
+        eq(TASK_ID_1),
       )
 
     listOf(TASK_1_VALUE_DELTA, TASK_2_VALUE_DELTA).forEach { value ->
@@ -189,6 +200,7 @@ class DataCollectionFragmentTest : BaseHiltTest() {
           JOB.id,
           true,
           SubmissionDeltasConverter.toString(expectedDeltas),
+          "",
         )
         .build()
         .toBundle()
@@ -309,6 +321,7 @@ class DataCollectionFragmentTest : BaseHiltTest() {
             JOB.id,
             false,
             null,
+            "",
           )
           .build()
           .toBundle()


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2832

<!-- PR description. -->
Reuses `currentTaskId` mechanism to set the initial task position when restoring from draft.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
[draft-position.webm](https://github.com/user-attachments/assets/d62e79a0-0026-4454-aa05-dae193f30238)

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@sufyanAbbasi @gino-m  PTAL?
