### PR TITLE
[Startup] Fix Play services install and sign in flow

### DIFF
--- a/ground/src/main/java/com/google/android/ground/MainActivity.kt
+++ b/ground/src/main/java/com/google/android/ground/MainActivity.kt
@@ -91,7 +91,9 @@ class MainActivity : AbstractActivity() {
     viewModel = viewModelFactory[this, MainViewModel::class.java]
 
     lifecycleScope.launch {
-      viewModel.navigationRequests.filterNotNull().collect { updateUi(binding.root, it) }
+      repeatOnLifecycle(Lifecycle.State.RESUMED) {
+        viewModel.mainUiState.filterNotNull().collect { updateUi(binding.root, it) }
+      }
     }
   }
 

--- a/ground/src/main/java/com/google/android/ground/MainUiState.kt
+++ b/ground/src/main/java/com/google/android/ground/MainUiState.kt
@@ -18,15 +18,15 @@ package com.google.android.ground
 
 sealed class MainUiState {
 
-  data object OnPermissionDenied : MainUiState()
+  data object PermissionDeniedDialog : MainUiState()
 
-  data object OnUserSignedOut : MainUiState()
+  data object SignInScreen : MainUiState()
 
-  data object OnUserSigningIn : MainUiState()
+  data object SignInProgressDialog : MainUiState()
 
-  data object TosNotAccepted : MainUiState()
+  data object TermsOfService : MainUiState()
 
-  data object NoActiveSurvey : MainUiState()
+  data object SurveySelector : MainUiState()
 
-  data object ShowHomeScreen : MainUiState()
+  data object HomeScreen : MainUiState()
 }

--- a/ground/src/main/java/com/google/android/ground/ui/startup/StartupFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/startup/StartupFragment.kt
@@ -26,6 +26,7 @@ import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.common.EphemeralPopups
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -53,6 +54,8 @@ class StartupFragment : AbstractFragment() {
     viewLifecycleOwner.lifecycleScope.launch {
       try {
         viewModel.initializeLogin()
+      } catch (e: CancellationException) {
+        Timber.d(e, "Startup job cancelled")
       } catch (t: Throwable) {
         onInitFailed(t)
       }

--- a/ground/src/main/java/com/google/android/ground/ui/startup/StartupViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/startup/StartupViewModel.kt
@@ -18,6 +18,7 @@ package com.google.android.ground.ui.startup
 import com.google.android.ground.repository.UserRepository
 import com.google.android.ground.system.GoogleApiManager
 import com.google.android.ground.ui.common.AbstractViewModel
+import timber.log.Timber
 import javax.inject.Inject
 
 class StartupViewModel
@@ -29,7 +30,9 @@ internal constructor(
 
   /** Initializes the login flow, installing Google Play Services if necessary. */
   suspend fun initializeLogin() {
+    Timber.d("Checking for Play services")
     googleApiManager.installGooglePlayServices()
+    Timber.d("Initializing user repository")
     userRepository.init()
   }
 }

--- a/ground/src/main/java/com/google/android/ground/ui/startup/StartupViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/startup/StartupViewModel.kt
@@ -18,8 +18,8 @@ package com.google.android.ground.ui.startup
 import com.google.android.ground.repository.UserRepository
 import com.google.android.ground.system.GoogleApiManager
 import com.google.android.ground.ui.common.AbstractViewModel
-import timber.log.Timber
 import javax.inject.Inject
+import timber.log.Timber
 
 class StartupViewModel
 @Inject

--- a/ground/src/test/java/com/google/android/ground/MainViewModelTest.kt
+++ b/ground/src/test/java/com/google/android/ground/MainViewModelTest.kt
@@ -75,11 +75,11 @@ class MainViewModelTest : BaseHiltTest() {
   fun testSignInStateChanged_onSignedOut() = runWithTestDispatcher {
     setupUserPreferences()
 
-    viewModel.navigationRequests.test {
+    viewModel.mainUiState.test {
       fakeAuthenticationManager.signOut()
       advanceUntilIdle()
 
-      assertThat(awaitItem()).isEqualTo(MainUiState.OnUserSignedOut)
+      assertThat(awaitItem()).isEqualTo(MainUiState.SignInScreen)
       verifyUserPreferencesCleared()
       verifyUserNotSaved()
       assertThat(tosRepository.isTermsOfServiceAccepted).isFalse()
@@ -88,11 +88,11 @@ class MainViewModelTest : BaseHiltTest() {
 
   @Test
   fun testSignInStateChanged_onSigningIn() = runWithTestDispatcher {
-    viewModel.navigationRequests.test {
+    viewModel.mainUiState.test {
       fakeAuthenticationManager.setState(SignInState.SigningIn)
       advanceUntilIdle()
 
-      assertThat(awaitItem()).isEqualTo(MainUiState.OnUserSigningIn)
+      assertThat(awaitItem()).isEqualTo(MainUiState.SignInProgressDialog)
       verifyUserNotSaved()
       assertThat(tosRepository.isTermsOfServiceAccepted).isFalse()
     }
@@ -106,11 +106,11 @@ class MainViewModelTest : BaseHiltTest() {
     tosRepository.isTermsOfServiceAccepted = false
     fakeRemoteDataStore.termsOfService = Result.success(FakeData.TERMS_OF_SERVICE)
 
-    viewModel.navigationRequests.test {
+    viewModel.mainUiState.test {
       fakeAuthenticationManager.signIn()
       advanceUntilIdle()
 
-      assertThat(awaitItem()).isEqualTo(MainUiState.TosNotAccepted)
+      assertThat(awaitItem()).isEqualTo(MainUiState.TermsOfService)
       verifyUserSaved()
       assertThat(tosRepository.isTermsOfServiceAccepted).isFalse()
     }
@@ -121,11 +121,11 @@ class MainViewModelTest : BaseHiltTest() {
     tosRepository.isTermsOfServiceAccepted = false
     fakeRemoteDataStore.termsOfService = null
 
-    viewModel.navigationRequests.test {
+    viewModel.mainUiState.test {
       fakeAuthenticationManager.signIn()
       advanceUntilIdle()
 
-      assertThat(awaitItem()).isEqualTo(MainUiState.TosNotAccepted)
+      assertThat(awaitItem()).isEqualTo(MainUiState.TermsOfService)
       verifyUserSaved()
       assertThat(tosRepository.isTermsOfServiceAccepted).isFalse()
     }
@@ -142,12 +142,12 @@ class MainViewModelTest : BaseHiltTest() {
         )
       )
 
-    viewModel.navigationRequests.test {
+    viewModel.mainUiState.test {
       fakeAuthenticationManager.signIn()
       advanceUntilIdle()
       // TODO(#2667): Update these implementation to make it clearer why this would be the case.
       assertThat(tosRepository.isTermsOfServiceAccepted).isFalse()
-      assertThat(awaitItem()).isEqualTo(MainUiState.TosNotAccepted)
+      assertThat(awaitItem()).isEqualTo(MainUiState.TermsOfService)
     }
   }
 
@@ -157,12 +157,12 @@ class MainViewModelTest : BaseHiltTest() {
       tosRepository.isTermsOfServiceAccepted = false
       fakeRemoteDataStore.termsOfService = Result.failure(Error("user error"))
 
-      viewModel.navigationRequests.test {
+      viewModel.mainUiState.test {
         fakeAuthenticationManager.signIn()
         advanceUntilIdle()
 
         assertThat(tosRepository.isTermsOfServiceAccepted).isFalse()
-        assertThat(awaitItem()).isEqualTo(MainUiState.TosNotAccepted)
+        assertThat(awaitItem()).isEqualTo(MainUiState.TermsOfService)
       }
     }
 
@@ -170,11 +170,11 @@ class MainViewModelTest : BaseHiltTest() {
   fun testSignInStateChanged_onSignInError() = runWithTestDispatcher {
     setupUserPreferences()
 
-    viewModel.navigationRequests.test {
+    viewModel.mainUiState.test {
       fakeAuthenticationManager.setState(SignInState.Error(Exception()))
       advanceUntilIdle()
 
-      assertThat(awaitItem()).isEqualTo(MainUiState.OnUserSignedOut)
+      assertThat(awaitItem()).isEqualTo(MainUiState.SignInScreen)
       verifyUserPreferencesCleared()
       verifyUserNotSaved()
       assertThat(tosRepository.isTermsOfServiceAccepted).isFalse()


### PR DESCRIPTION
Replaces ephemeral navigation requests with a "main UI state" which gets applied at start up. This patch resolves existing issues, but there are likely several race conditions lurking due to complexity of the startup/install flow. We should revisit the design on this flow to make it easier to understand and to avoid cancellation exceptions or duplicate side effects (https://github.com/google/ground-android/issues/2923).

Fixes #2919 by restore UI state on on resume.
Fixes #2783 

