### PR TITLE
SyncStatus: Use new mutations repository upload queue flow; renaming.

### DIFF
--- a/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
+++ b/ground/src/main/java/com/google/android/ground/repository/MutationRepository.kt
@@ -93,7 +93,7 @@ constructor(
    * Returns a [Flow] which emits the upload queue once and on each change, sorted in chronological
    * order (FIFO).
    */
-  private fun getUploadQueueFlow(): Flow<List<UploadQueueEntry>> =
+  fun getUploadQueueFlow(): Flow<List<UploadQueueEntry>> =
     localLocationOfInterestStore.getAllMutationsFlow().combine(
       localSubmissionStore.getAllMutationsFlow()
     ) { loiMutations, submissionMutations ->

--- a/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncListItem.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncListItem.kt
@@ -50,7 +50,7 @@ import com.google.android.ground.ui.theme.AppTheme
 import java.util.Date
 
 @Composable
-fun SyncListItem(modifier: Modifier, detail: MutationDetail) {
+fun SyncListItem(modifier: Modifier, detail: SyncStatusDetail) {
   Column {
     Row(modifier.fillMaxWidth().padding(top = 8.dp, end = 24.dp, bottom = 8.dp, start = 16.dp)) {
       Column(modifier.weight(1f)) {
@@ -80,8 +80,8 @@ fun SyncListItem(modifier: Modifier, detail: MutationDetail) {
             fontWeight = FontWeight(400),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
           )
-        Text(text = detail.loiLabel, style = textStyle)
-        Text(text = detail.loiSubtitle, style = textStyle)
+        Text(text = detail.label, style = textStyle)
+        Text(text = detail.subtitle, style = textStyle)
       }
       Column(modifier = modifier.padding(start = 16.dp).align(alignment = CenterVertically)) {
         Row(verticalAlignment = CenterVertically) {
@@ -140,11 +140,11 @@ private fun Mutation.SyncStatus.toIcon(): Int =
 @Preview(showBackground = true, showSystemUi = true)
 @ExcludeFromJacocoGeneratedReport
 fun PreviewSyncListItem(
-  detail: MutationDetail =
-    MutationDetail(
+  detail: SyncStatusDetail =
+    SyncStatusDetail(
       user = "Jane Doe",
-      loiLabel = "Map the farms",
-      loiSubtitle = "IDX21311",
+      label = "Map the farms",
+      subtitle = "IDX21311",
       mutation =
         SubmissionMutation(
           job = Job(id = "123"),

--- a/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusDetail.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusDetail.kt
@@ -17,10 +17,16 @@ package com.google.android.ground.ui.syncstatus
 
 import com.google.android.ground.model.mutation.Mutation
 
-/** A tiny helper class for bundling mutation history display data. */
-data class MutationDetail(
+/**
+ * Defines the set of data needed to display the human-readable status of a queued local [Mutation].
+ */
+data class SyncStatusDetail(
+  /** The username of the user who made this change. */
   val user: String,
+  /** The underlying [Mutation]. */
   val mutation: Mutation,
-  val loiLabel: String,
-  val loiSubtitle: String,
+  /** A human-readable label summarizing what data changed. */
+  val label: String,
+  /** A human-readable label providing further information on the change. */
+  val subtitle: String,
 )

--- a/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/syncstatus/SyncStatusFragment.kt
@@ -34,7 +34,10 @@ import com.google.android.ground.ui.common.AbstractFragment
 import com.google.android.ground.ui.theme.AppTheme
 import dagger.hilt.android.AndroidEntryPoint
 
-/** Fragment containing a list of mutations and their respective upload statuses. */
+/**
+ * This fragment summarizes the synchronization statuses of local changes that are being uploaded to
+ * a remote server.
+ */
 @AndroidEntryPoint
 class SyncStatusFragment : AbstractFragment() {
 
@@ -61,7 +64,7 @@ class SyncStatusFragment : AbstractFragment() {
 
   @Composable
   private fun ShowSyncItems() {
-    val list by viewModel.mutations.observeAsState()
+    val list by viewModel.uploadStatus.observeAsState()
     list?.let {
       LazyColumn(Modifier.fillMaxSize().testTag("sync list")) {
         items(it) {


### PR DESCRIPTION
This commit uses the newly introduced getUploadQueueFlow() in the MutationRepository to fetch mutations for the sync status UI. In additiion, I have renamed some classes and added some documentation for clarity. In addition, we now handle SubmissionMutations separately from LOI Mutations, allowing us to better inform users. We also no longer check for the authenticated user in the sync view model, since this is done in the mutation repository before the uplaod queue is returned.

Fixes #2894

@gino-m 