### PR TITLE
[Code health] Don't expose task stepper with unbounded page count in DataCollectionViewModel

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -204,10 +204,8 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
       viewModel.clearDraft()
       false
     } else {
-      // Otherwise, select the previous step.
-      // TODO: Don't expose step function publicly which allows arbitrary number of pages.
-      // Issue URL: https://github.com/google/ground-android/issues/2956
-      viewModel.step(-1)
+      // Otherwise, select the previous task.
+      viewModel.moveToPreviousTask()
       true
     }
 

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -49,12 +49,6 @@ import com.google.android.ground.ui.datacollection.tasks.polygon.DrawAreaTaskVie
 import com.google.android.ground.ui.datacollection.tasks.text.TextTaskViewModel
 import com.google.android.ground.ui.datacollection.tasks.time.TimeTaskViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
-import javax.inject.Provider
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.set
-import kotlin.math.abs
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -66,6 +60,12 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Provider
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.set
+import kotlin.math.abs
 
 /** View model for the Data Collection fragment. */
 @HiltViewModel
@@ -204,7 +204,7 @@ internal constructor(
     // Skip validation if the task is empty
     if (taskValue.isNullOrEmpty()) {
       data[task] = taskValue
-      step(-1)
+      moveToPreviousTask()
       return
     }
 
@@ -215,7 +215,7 @@ internal constructor(
     }
 
     data[task] = taskValue
-    step(-1)
+    moveToPreviousTask()
   }
 
   /**
@@ -232,7 +232,7 @@ internal constructor(
     data[taskViewModel.task] = taskViewModel.taskTaskData.value
 
     if (!isLastPosition()) {
-      step(1)
+      moveToNextTask()
     } else {
       clearDraft()
       saveChanges(getDeltas())
@@ -354,8 +354,16 @@ internal constructor(
       }
   }
 
+  private fun moveToNextTask() {
+    step(1)
+  }
+
+  fun moveToPreviousTask() {
+    step(-1)
+  }
+
   /** Displays the task at the relative position to the current one. Supports negative steps. */
-  fun step(stepCount: Int) {
+  private fun step(stepCount: Int) {
     val reverse = stepCount < 0
     val task =
       getTaskSequence(startId = currentTaskId.value, reversed = reverse)

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -49,6 +49,11 @@ import com.google.android.ground.ui.datacollection.tasks.polygon.DrawAreaTaskVie
 import com.google.android.ground.ui.datacollection.tasks.text.TextTaskViewModel
 import com.google.android.ground.ui.datacollection.tasks.time.TimeTaskViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import javax.inject.Provider
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.set
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -60,11 +65,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import javax.inject.Inject
-import javax.inject.Provider
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.set
 
 /** View model for the Data Collection fragment. */
 @HiltViewModel

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -65,7 +65,6 @@ import javax.inject.Provider
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
-import kotlin.math.abs
 
 /** View model for the Data Collection fragment. */
 @HiltViewModel
@@ -355,20 +354,16 @@ internal constructor(
   }
 
   private fun moveToNextTask() {
-    step(1)
+    step(false)
   }
 
   fun moveToPreviousTask() {
-    step(-1)
+    step(true)
   }
 
-  /** Displays the task at the relative position to the current one. Supports negative steps. */
-  private fun step(stepCount: Int) {
-    val reverse = stepCount < 0
-    val task =
-      getTaskSequence(startId = currentTaskId.value, reversed = reverse)
-        .take(abs(stepCount) + 1)
-        .last()
+  /** Displays the task at the relative position to the current one. */
+  private fun step(reversed: Boolean) {
+    val task = getTaskSequence(startId = currentTaskId.value, reversed).take(2).last()
     savedStateHandle[TASK_POSITION_ID] = task.id
 
     // Save collected data as draft


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2956

<!-- PR description. -->
This is a no-op change and improves the code readability slightly by exposing methods with concise task controller.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

Note: While working on this, I found more improvements for abstracting out the task sequence logic into a separate handler. Will file a separate bug and PR as a follow up to this.

Filed: https://github.com/google/ground-android/issues/2958

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001  @gino-m  PTAL?
