### PR TITLE
Update setColorFilter with the non-deprecated function

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/IconFactory.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/IconFactory.kt
@@ -17,10 +17,13 @@ package com.google.android.ground.ui
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BlendMode
+import android.graphics.BlendModeColorFilter
 import android.graphics.Canvas
 import android.graphics.PorterDuff
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import android.os.Build
 import androidx.appcompat.content.res.AppCompatResources
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
@@ -52,7 +55,11 @@ class IconFactory @Inject constructor(@ApplicationContext private val context: C
 
     outline.setBounds(0, 0, bitmap.width, bitmap.height)
     outline.draw(canvas)
-    fill!!.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      fill!!.colorFilter = BlendModeColorFilter(color, BlendMode.SRC_ATOP)
+    } else {
+      fill!!.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+    }
     fill.setBounds(0, 0, bitmap.width, bitmap.height)
     fill.draw(canvas)
     overlay!!.setBounds(0, 0, bitmap.width, bitmap.height)


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2960

Parent Ticket #2338

<!-- PR description. -->
As setColorFilter is deprecated by java, this PR is raised to use the new `setColorFilter`. 
Also, as our app has a minimum level of 24,  this new `setColorFilter` API has a minimum of API 29, so added a API level check.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@shobhitagarwal1612  PTAL?
