### PR TITLE
Added WEBP_LOSSY and update Deprecated Bitmap.CompressFormat

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/ImageEditor.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/map/gms/mog/ImageEditor.kt
@@ -19,6 +19,7 @@ package com.google.android.ground.ui.map.gms.mog
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
+import android.os.Build
 import java.io.ByteArrayOutputStream
 
 /** Utility for modifying images. */
@@ -47,7 +48,11 @@ object ImageEditor {
     // compressing WEBP each tile adds on the order of 1ms to each tile which we can consider
     // negligible.
     val stream = ByteArrayOutputStream()
-    bitmap.compress(Bitmap.CompressFormat.WEBP, 100, stream)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      bitmap.compress(Bitmap.CompressFormat.WEBP_LOSSY, 100, stream)
+    } else {
+      bitmap.compress(Bitmap.CompressFormat.WEBP, 100, stream)
+    }
     return stream.toByteArray()
   }
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2965 

Parent Ticket #2338 

<!-- PR description. -->
`Bitmap.CompressFormat.WEBP` is deprecated and this PR added API level check and update with `WEBP_LOSSY`.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@shobhitagarwal1612  PTAL?
