### PR TITLE
[Code health] Add test coverage for adhoc data submission flow

### DIFF
--- a/ground/src/main/java/com/google/android/ground/domain/usecases/submission/SubmitDataUseCase.kt
+++ b/ground/src/main/java/com/google/android/ground/domain/usecases/submission/SubmitDataUseCase.kt
@@ -68,6 +68,7 @@ constructor(
     val addLoiTaskId = deltas.indexOfFirst { it.taskId == addLoiTask.id }
     if (addLoiTaskId < 0) error("Add LOI task response missing")
     val addLoiValue = deltas.removeAt(addLoiTaskId).newTaskData
+    // TODO: Replace check for valid addLoiTask using task type instead of TaskValue's type.
     if (addLoiValue !is GeometryTaskData) error("Invalid add LOI task response")
     return locationOfInterestRepository.saveLoi(
       addLoiValue.geometry,

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/components/LoiNameDialog.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/components/LoiNameDialog.kt
@@ -27,10 +27,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import com.google.android.ground.R
+
+const val LOI_NAME_TEXT_FIELD_TEST_TAG: String = "loi name text field test tag"
 
 @Composable
 fun LoiNameDialog(
@@ -50,7 +53,12 @@ fun LoiNameDialog(
       Column {
         Text(text = stringResource(R.string.loi_name_dialog_body))
         Spacer(Modifier.height(16.dp))
-        TextField(value = textFieldValue, onValueChange = onTextFieldChange, singleLine = true)
+        TextField(
+          value = textFieldValue,
+          onValueChange = onTextFieldChange,
+          singleLine = true,
+          modifier = Modifier.testTag(LOI_NAME_TEXT_FIELD_TEST_TAG),
+        )
       }
     },
     confirmButton = {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskFragment.kt
@@ -62,6 +62,7 @@ class DropPinTaskFragment @Inject constructor() : AbstractTaskFragment<DropPinTa
   override fun onCreateActionButtons() {
     addSkipButton()
     addUndoButton()
+    // TODO: Disable the button is location is not available.
     addButton(ButtonAction.DROP_PIN)
       .setOnClickListener { viewModel.dropPin() }
       .setOnValueChanged { button, value -> button.showIfTrue(value.isNullOrEmpty()) }

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskViewModel.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskViewModel.kt
@@ -62,7 +62,7 @@ constructor(
     features.postValue(setOf())
   }
 
-  fun updateResponse(point: Point) {
+  private fun updateResponse(point: Point) {
     setValue(DropPinTaskData(point))
     dropMarker(point)
   }

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -16,7 +16,6 @@
 
 package com.google.android.ground.ui.datacollection
 
-import android.os.Bundle
 import com.google.android.ground.BaseHiltTest
 import com.google.android.ground.R
 import com.google.android.ground.domain.usecases.survey.ActivateSurveyUseCase
@@ -167,19 +166,7 @@ class DataCollectionFragmentTest : BaseHiltTest() {
     // Issue URL: https://github.com/google/ground-android/issues/708
     val expectedDeltas = listOf(TASK_1_VALUE_DELTA, TASK_2_VALUE_DELTA)
 
-    // Start the fragment with draft values
-    setupFragment(
-      DataCollectionFragmentArgs.Builder(
-          LOCATION_OF_INTEREST.id,
-          LOCATION_OF_INTEREST_NAME,
-          JOB.id,
-          true,
-          SubmissionDeltasConverter.toString(expectedDeltas),
-          "",
-        )
-        .build()
-        .toBundle()
-    )
+    setupFragmentWithDraft(expectedDeltas)
 
     runner()
       .assertInputTextDisplayed(TASK_1_RESPONSE)
@@ -331,19 +318,22 @@ class DataCollectionFragmentTest : BaseHiltTest() {
     advanceUntilIdle()
   }
 
-  private fun setupFragment(fragmentArgs: Bundle? = null) {
+  private fun setupFragmentWithDraft(expectedValues: List<ValueDelta>) {
+    setupFragment(true, SubmissionDeltasConverter.toString(expectedValues))
+  }
+
+  private fun setupFragment(shouldLoadFromDraft: Boolean = false, draftValues: String? = null) {
     val argsBundle =
-      fragmentArgs
-        ?: DataCollectionFragmentArgs.Builder(
-            LOCATION_OF_INTEREST.id,
-            LOCATION_OF_INTEREST_NAME,
-            JOB.id,
-            false,
-            null,
-            "",
-          )
-          .build()
-          .toBundle()
+      DataCollectionFragmentArgs.Builder(
+          LOCATION_OF_INTEREST.id,
+          LOCATION_OF_INTEREST_NAME,
+          JOB.id,
+          shouldLoadFromDraft,
+          draftValues,
+          /* currentTaskId */ "",
+        )
+        .build()
+        .toBundle()
 
     launchFragmentWithNavController<DataCollectionFragment>(
       argsBundle,

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -50,8 +50,6 @@ import com.sharedtest.FakeData.USER
 import com.sharedtest.persistence.remote.FakeRemoteDataStore
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
-import java.util.Date
-import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -61,6 +59,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowToast
+import java.util.Date
+import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest
@@ -263,7 +263,7 @@ class DataCollectionFragmentTest : BaseHiltTest() {
   }
 
   @Test
-  fun `Clicking done on final task saves the submission when LOI is not provided`() =
+  fun `Clicking done on final task saves the submission and LOI when LOI is not provided`() =
     runWithTestDispatcher {
       setupFragmentWithNoLoi()
 

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -125,6 +125,51 @@ class DataCollectionFragmentTest : BaseHiltTest() {
   }
 
   @Test
+  fun `Next button displays the LoiNameDialog when task has value when LOI is missing`() {
+    setupFragmentWithNoLoi()
+
+    runner().inputText(TASK_0_RESPONSE).clickNextButton().assertLoiNameDialogIsDisplayed()
+  }
+
+  @Test
+  fun `Entering loi name enables the save button in LoiNameDialog`() {
+    setupFragmentWithNoLoi()
+
+    runner()
+      .inputText(TASK_0_RESPONSE)
+      .clickNextButton()
+      .assertButtonIsDisabled("Save")
+      .inputLoiName("Custom Loi Name")
+      .assertButtonIsEnabled("Save")
+  }
+
+  @Test
+  fun `Clicking cancel hides the LoiNameDialog`() {
+    setupFragmentWithNoLoi()
+
+    runner()
+      .inputText(TASK_0_RESPONSE)
+      .clickNextButton()
+      .clickButton("Cancel")
+      .assertLoiNameDialogIsNotDisplayed()
+  }
+
+  @Test
+  fun `Clicking save in LoiNameDialog proceeds to next task`() {
+    setupFragmentWithNoLoi()
+
+    runner()
+      .inputText(TASK_0_RESPONSE)
+      .clickNextButton()
+      .inputLoiName("Custom Loi Name")
+      .clickButton("Save")
+      .validateTextIsDisplayed("Custom Loi Name")
+      .validateTextIsDisplayed(TASK_1_NAME)
+      .validateTextIsNotDisplayed(TASK_0_NAME)
+      .validateTextIsNotDisplayed(TASK_2_NAME)
+  }
+
+  @Test
   fun `Previous button navigates back to first task`() {
     setupFragment()
 

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -50,6 +50,8 @@ import com.sharedtest.FakeData.USER
 import com.sharedtest.persistence.remote.FakeRemoteDataStore
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
+import java.util.Date
+import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -59,8 +61,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowToast
-import java.util.Date
-import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -81,10 +81,26 @@ class DataCollectionFragmentTest : BaseHiltTest() {
   }
 
   @Test
+  fun `Only job name is displayed when LOI is not provided`() {
+    setupFragmentWithNoLoi()
+
+    runner()
+      .validateTextDoesNotExist("Unnamed point")
+      .validateTextIsDisplayed(requireNotNull(JOB.name))
+  }
+
+  @Test
   fun `First task is loaded and is visible`() {
     setupFragment()
 
     runner().validateTextIsDisplayed(TASK_1_NAME).validateTextIsNotDisplayed(TASK_2_NAME)
+  }
+
+  @Test
+  fun `Add LOI task is loaded and is visible when LOI is not provided`() {
+    setupFragmentWithNoLoi()
+
+    runner().validateTextIsDisplayed(TASK_0_NAME).validateTextIsNotDisplayed(TASK_1_NAME)
   }
 
   @Test
@@ -319,14 +335,26 @@ class DataCollectionFragmentTest : BaseHiltTest() {
   }
 
   private fun setupFragmentWithDraft(expectedValues: List<ValueDelta>) {
-    setupFragment(true, SubmissionDeltasConverter.toString(expectedValues))
+    setupFragment(
+      shouldLoadFromDraft = true,
+      draftValues = SubmissionDeltasConverter.toString(expectedValues),
+    )
   }
 
-  private fun setupFragment(shouldLoadFromDraft: Boolean = false, draftValues: String? = null) {
+  private fun setupFragmentWithNoLoi() {
+    setupFragment(loiId = null, loiName = null)
+  }
+
+  private fun setupFragment(
+    loiId: String? = LOCATION_OF_INTEREST.id,
+    loiName: String? = LOCATION_OF_INTEREST_NAME,
+    shouldLoadFromDraft: Boolean = false,
+    draftValues: String? = null,
+  ) {
     val argsBundle =
       DataCollectionFragmentArgs.Builder(
-          LOCATION_OF_INTEREST.id,
-          LOCATION_OF_INTEREST_NAME,
+          loiId,
+          loiName,
           JOB.id,
           shouldLoadFromDraft,
           draftValues,
@@ -346,6 +374,12 @@ class DataCollectionFragmentTest : BaseHiltTest() {
   private fun runner() = TaskFragmentRunner(this, fragment)
 
   companion object {
+    private const val TASK_ID_0 = "0"
+    const val TASK_0_NAME = "task 0"
+    private const val TASK_0_RESPONSE = "response 0"
+    private val TASK_0_VALUE = TextTaskData.fromString(TASK_0_RESPONSE)
+    private val TASK_0_VALUE_DELTA = ValueDelta(TASK_ID_0, Task.Type.TEXT, TASK_0_VALUE)
+
     private const val TASK_ID_1 = "1"
     const val TASK_1_NAME = "task 1"
     private const val TASK_1_RESPONSE = "response 1"
@@ -383,10 +417,11 @@ class DataCollectionFragmentTest : BaseHiltTest() {
 
     private val TASKS =
       listOf(
-        Task(TASK_ID_1, 0, Task.Type.TEXT, TASK_1_NAME, true),
+        Task(TASK_ID_0, 0, Task.Type.TEXT, TASK_0_NAME, true, isAddLoiTask = true),
+        Task(TASK_ID_1, 1, Task.Type.TEXT, TASK_1_NAME, true),
         Task(
           TASK_ID_2,
-          1,
+          2,
           Task.Type.MULTIPLE_CHOICE,
           TASK_2_NAME,
           true,
@@ -394,7 +429,7 @@ class DataCollectionFragmentTest : BaseHiltTest() {
         ),
         Task(
           TASK_ID_CONDITIONAL,
-          2,
+          3,
           Task.Type.TEXT,
           TASK_CONDITIONAL_NAME,
           true,

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskFragmentRunner.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskFragmentRunner.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -156,6 +157,11 @@ class TaskFragmentRunner(
 
   internal fun validateTextIsNotDisplayed(text: String): TaskFragmentRunner {
     onView(withText(text)).check(matches(not(isDisplayed())))
+    return this
+  }
+
+  internal fun validateTextDoesNotExist(text: String): TaskFragmentRunner {
+    onView(withText(text)).check(doesNotExist())
     return this
   }
 

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskFragmentRunner.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskFragmentRunner.kt
@@ -26,7 +26,9 @@ import androidx.compose.ui.test.hasAnySibling
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -42,6 +44,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.google.android.ground.BaseHiltTest
 import com.google.android.ground.R
+import com.google.android.ground.ui.datacollection.components.LOI_NAME_TEXT_FIELD_TEST_TAG
 import com.google.android.ground.ui.datacollection.tasks.multiplechoice.MULTIPLE_CHOICE_LIST_TEST_TAG
 import com.google.android.ground.ui.datacollection.tasks.multiplechoice.OTHER_INPUT_TEXT_TEST_TAG
 import com.google.android.ground.ui.datacollection.tasks.multiplechoice.SELECT_MULTIPLE_RADIO_TEST_TAG
@@ -231,6 +234,31 @@ class TaskFragmentRunner(
     } else {
       baseHiltTest.composeTestRule.onNodeWithText(text).assertIsNotDisplayed()
     }
+    return this
+  }
+
+  internal fun assertLoiNameDialogIsDisplayed(): TaskFragmentRunner {
+    with(baseHiltTest.composeTestRule) {
+      val resources = fragment?.resources ?: error("Fragment not found")
+      onNodeWithText(resources.getString(R.string.loi_name_dialog_title)).isDisplayed()
+      onNodeWithText(resources.getString(R.string.loi_name_dialog_body)).isDisplayed()
+    }
+    return this
+  }
+
+  internal fun assertLoiNameDialogIsNotDisplayed(): TaskFragmentRunner {
+    with(baseHiltTest.composeTestRule) {
+      val resources = fragment?.resources ?: error("Fragment not found")
+      onNodeWithText(resources.getString(R.string.loi_name_dialog_title)).isNotDisplayed()
+      onNodeWithText(resources.getString(R.string.loi_name_dialog_body)).isNotDisplayed()
+    }
+    return this
+  }
+
+  internal fun inputLoiName(loiName: String): TaskFragmentRunner {
+    baseHiltTest.composeTestRule
+      .onNodeWithTag(LOI_NAME_TEXT_FIELD_TEST_TAG)
+      .performTextInput(loiName)
     return this
   }
 


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2502

<!-- PR description. -->
This is a no-op change and adds test coverage for data submission flow when LOI isn't provided and needs to be created along with the  whole flow (incl. LoiDialogName handling).

Also adds a couple of TODOs for detected code smells.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
Increases overall coverage by 1.28%. See codecov reports https://github.com/google/ground-android/pull/2980#issuecomment-2571700630.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001 @gino-m  PTAL?
