### PR TITLE
Use extension function for creating bitmap from vector drawables

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/util/BitmapUtil.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/util/BitmapUtil.kt
@@ -18,43 +18,44 @@ package com.google.android.ground.ui.util
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.Canvas
 import android.graphics.ImageDecoder
 import android.net.Uri
 import android.os.Build
+import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class BitmapUtil @Inject internal constructor(@ApplicationContext private val context: Context) {
 
-  /** Retrieves an image for the given url as a [Bitmap]. */
-  fun fromUri(url: Uri?): Bitmap {
-    require(url != null) { "Uri cannot be null" }
-
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+  /**
+   * Retrieves an image for the given URI as a [Bitmap].
+   *
+   * For Android P (API 28) and above, it uses [ImageDecoder] for better performance and support for
+   * various image formats. For older APIs, it falls back to [BitmapFactory.decodeStream].
+   *
+   * @param url The URI of the image.
+   * @return The decoded [Bitmap].
+   * @throws IllegalArgumentException If the URI cannot be opened or decoded.
+   */
+  fun fromUri(url: Uri): Bitmap =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, url))
     } else {
       // Use InputStream and BitmapFactory for older APIs
-      context.contentResolver.openInputStream(url)?.use { inputStream ->
-        BitmapFactory.decodeStream(inputStream)
-      } ?: throw IllegalArgumentException("Unable to open URI: $url")
+      context.contentResolver.openInputStream(url)?.use { BitmapFactory.decodeStream(it) }
+        ?: throw IllegalArgumentException("Unable to open URI: $url")
     }
-  }
 
-  fun fromVector(resId: Int): Bitmap {
-    val vectorDrawable = ContextCompat.getDrawable(context, resId)!!
-
-    // Specify a bounding rectangle for the Drawable.
-    vectorDrawable.setBounds(0, 0, vectorDrawable.intrinsicWidth, vectorDrawable.intrinsicHeight)
-    val bitmap =
-      Bitmap.createBitmap(
-        vectorDrawable.intrinsicWidth,
-        vectorDrawable.intrinsicHeight,
-        Bitmap.Config.ARGB_8888,
-      )
-    val canvas = Canvas(bitmap)
-    vectorDrawable.draw(canvas)
-    return bitmap
-  }
+  /**
+   * Retrieves an image for the given vector resource as a [Bitmap].
+   *
+   * @param resId The resource ID of the vector drawable.
+   * @return The decoded [Bitmap], or null if the resource is not found.
+   * @throws IllegalArgumentException If the resource is not a vector drawable.
+   */
+  fun fromVector(@DrawableRes resId: Int): Bitmap =
+    ContextCompat.getDrawable(context, resId)?.toBitmap()
+      ?: throw IllegalArgumentException("Resource not found: $resId")
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
This is a no-op change which replaces custom implementation for creating bitmaps with extension function `toBitmap()`.

Verified that this doesn't introduce any regressions by opening the draw area fragment which uses this util function. Also adds ktdoc to all public methods.

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001 @gino-m  PTAL?
