### PR TITLE
Improve design of TaskSequenceHandler by removing a confusing method

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskSequenceHandler.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskSequenceHandler.kt
@@ -87,23 +87,6 @@ class TaskSequenceHandler(
   }
 
   /**
-   * Checks if the specified task with the given data is the last task in the sequence.
-   *
-   * This method allows checking if a specific task with a particular [TaskData] is the last one.
-   *
-   * @param taskId The ID of the task to check.
-   * @param value The [TaskData] associated with the task.
-   * @return `true` if the task with the given data is the last in the sequence, `false` otherwise.
-   * @throws IllegalArgumentException if the provided [taskId] is blank.
-   */
-  // TODO: Check if this method can be eliminated as it is confusing to pass value to this method.
-  // Issue URL: https://github.com/google/ground-android/issues/2987
-  fun isLastPosition(taskId: String, value: TaskData?): Boolean {
-    checkInvalidTaskId(taskId)
-    return taskId == getTaskSequence(taskValueOverride = taskId to value).last().id
-  }
-
-  /**
    * Retrieves the ID of the task that precedes the specified task in the sequence.
    *
    * @param taskId The ID of the task for which to find the previous task.

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskSequenceHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskSequenceHandlerTest.kt
@@ -15,7 +15,6 @@
  */
 package com.google.android.ground.ui.datacollection
 
-import com.google.android.ground.model.submission.NumberTaskData
 import com.google.android.ground.model.submission.TaskData
 import com.google.android.ground.model.task.Task
 import com.google.android.ground.model.task.Task.Type
@@ -126,38 +125,6 @@ class TaskSequenceHandlerTest {
   fun `isLastPosition throws error for invalid task id`() {
     val handler = createHandler()
     assertThrows(IllegalArgumentException::class.java) { handler.isLastPosition("") }
-  }
-
-  @Test
-  fun `isLastPosition with value returns true for the last task`() {
-    val handler =
-      createHandler(
-        shouldIncludeTask = { task, taskValueOverride ->
-          task.id in listOf("task1", "task2") ||
-            (task.id == "task3" &&
-              taskValueOverride?.first == "task3" &&
-              taskValueOverride.second == NumberTaskData("10"))
-        }
-      )
-
-    assertThat(handler.isLastPosition("task3", NumberTaskData("10"))).isTrue()
-  }
-
-  @Test
-  fun `isLastPosition with value returns false for non-last tasks`() {
-    val handler =
-      createHandler(
-        shouldIncludeTask = { task, taskValueOverride ->
-          task.id != "task2" && task.id != "task4" && taskValueOverride?.first != "task3"
-        }
-      )
-    assertThat(handler.isLastPosition("task1", null)).isFalse()
-  }
-
-  @Test
-  fun `isLastPosition with value throws error for invalid task id`() {
-    val handler = createHandler()
-    assertThrows(IllegalArgumentException::class.java) { handler.isLastPosition("", null) }
   }
 
   @Test


### PR DESCRIPTION

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2987

This is a no-op change as this class isn't being used anywhere at the moment.

<!-- PR description. -->
Remove isLastPosition from TaskSequenceHandler which also accepts value as it is confusing and should be moved to downstream.  The class is being used in: https://github.com/google/ground-android/pull/2986

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001 @scolsen  PTAL?
