### PR TITLE
Add logic to cache generated task sequence

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskSequenceHandler.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskSequenceHandler.kt
@@ -62,12 +62,12 @@ class TaskSequenceHandler(
    *   element is the [TaskData] to override the default task data. If null, no override is applied.
    * @return A [Sequence] of [Task] objects representing the ordered tasks.
    */
-  fun createTaskSequence(taskValueOverride: Pair<String, TaskData?>? = null): Sequence<Task> =
+  fun generateTaskSequence(taskValueOverride: Pair<String, TaskData?>? = null): Sequence<Task> =
     tasks.filter { task -> shouldIncludeTask(task, taskValueOverride) }.asSequence()
 
   fun getTaskSequence(): Sequence<Task> {
     if (!isSequenceInitialized) {
-      taskSequence = createTaskSequence()
+      taskSequence = generateTaskSequence()
       isSequenceInitialized = true
     }
     return taskSequence

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskSequenceHandler.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskSequenceHandler.kt
@@ -36,6 +36,9 @@ class TaskSequenceHandler(
     (task: Task, taskValueOverride: Pair<String, TaskData?>?) -> Boolean,
 ) {
 
+  private var taskSequence: Sequence<Task> = sequenceOf()
+  private var isSequenceInitialized = false
+
   init {
     require(tasks.isNotEmpty()) { "Can't generate a sequence from an empty task list." }
   }
@@ -50,17 +53,28 @@ class TaskSequenceHandler(
   }
 
   /**
-   * Retrieves the task sequence based on the provided inputs and conditions.
+   * Generates the task sequence based on whether a task should be included or not.
    *
-   * This function determines the order of tasks to be presented, taking into account any overrides
-   * specified by [taskValueOverride].
+   * This determines the order of tasks to be presented to the user, taking into account any
+   * overrides specified by [taskValueOverride].
    *
    * @param taskValueOverride An optional pair where the first element is the task ID and the second
    *   element is the [TaskData] to override the default task data. If null, no override is applied.
    * @return A [Sequence] of [Task] objects representing the ordered tasks.
    */
-  fun getTaskSequence(taskValueOverride: Pair<String, TaskData?>? = null): Sequence<Task> =
+  fun createTaskSequence(taskValueOverride: Pair<String, TaskData?>? = null): Sequence<Task> =
     tasks.filter { task -> shouldIncludeTask(task, taskValueOverride) }.asSequence()
+
+  fun getTaskSequence(): Sequence<Task> {
+    if (!isSequenceInitialized) {
+      taskSequence = createTaskSequence()
+      isSequenceInitialized = true
+    }
+    return taskSequence
+  }
+
+  // TODO: Add a method to update the cached sequence whenever necessary.
+  // Issue URL: https://github.com/google/ground-android/issues/2993
 
   /**
    * Checks if the specified task is the first task in the displayed sequence.

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskSequenceHandler.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskSequenceHandler.kt
@@ -36,7 +36,7 @@ class TaskSequenceHandler(
     (task: Task, taskValueOverride: Pair<String, TaskData?>?) -> Boolean,
 ) {
 
-  private var taskSequence: Sequence<Task> = sequenceOf()
+  private var taskSequence: Sequence<Task> = emptySequence()
   private var isSequenceInitialized = false
 
   init {

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskSequenceHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskSequenceHandlerTest.kt
@@ -66,7 +66,7 @@ class TaskSequenceHandlerTest {
   }
 
   @Test
-  fun `getTaskSequence filters tasks based on shouldIncludeTask and taskValueOverride`() {
+  fun `createTaskSequence filters tasks based on shouldIncludeTask and taskValueOverride`() {
     val handler =
       createHandler(
         shouldIncludeTask = { task, taskValueOverride ->
@@ -75,7 +75,7 @@ class TaskSequenceHandlerTest {
             !(task.id == "task3" && taskValueOverride?.first == "task3")
         }
       )
-    val sequence = handler.getTaskSequence(taskValueOverride = "task3" to null)
+    val sequence = handler.createTaskSequence(taskValueOverride = "task3" to null)
     assertThat(sequence.toList()).isEqualTo(listOf(task1, task5))
   }
 

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskSequenceHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskSequenceHandlerTest.kt
@@ -66,7 +66,7 @@ class TaskSequenceHandlerTest {
   }
 
   @Test
-  fun `createTaskSequence filters tasks based on shouldIncludeTask and taskValueOverride`() {
+  fun `generateTaskSequence filters tasks based on shouldIncludeTask and taskValueOverride`() {
     val handler =
       createHandler(
         shouldIncludeTask = { task, taskValueOverride ->
@@ -75,7 +75,7 @@ class TaskSequenceHandlerTest {
             !(task.id == "task3" && taskValueOverride?.first == "task3")
         }
       )
-    val sequence = handler.createTaskSequence(taskValueOverride = "task3" to null)
+    val sequence = handler.generateTaskSequence(taskValueOverride = "task3" to null)
     assertThat(sequence.toList()).isEqualTo(listOf(task1, task5))
   }
 


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #2993

<!-- PR description. -->
Adds caching mechanism for generated task sequence.

See https://github.com/google/ground-android/issues/2993#issue-2776885263 for detailed description.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@scolsen @anandwana001  PTAL?
