### PR TITLE
Introduce TaskDataHandler

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
@@ -7,6 +7,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+/**
+ * Manages the state of [TaskData] associated with [Task] instances.
+ *
+ * This class provides methods to set, retrieve, and observe the data associated with tasks.
+ */
 class TaskDataHandler {
 
   private val _dataState = MutableStateFlow(LinkedHashMap<Task, TaskData?>())
@@ -15,32 +20,35 @@ class TaskDataHandler {
     get() = _dataState.asStateFlow()
 
   /**
-   * Sets the data for a specific task.
+   * Sets the [TaskData] for a given [Task].
    *
-   * @param key The task for which to set the data.
-   * @param newValue The new data value for the task.
+   * If the new value is the same as the current value, no update is performed.
+   *
+   * @param task The [Task] for which to set the data.
+   * @param newValue The new [TaskData] value for the task.
    */
-  fun setData(key: Task, newValue: TaskData?) {
-    if (getData(key) == newValue) return
+  fun setData(task: Task, newValue: TaskData?) {
+    if (getData(task) == newValue) return
     // Ensure that the map is recreated to ensure that the state flow is emitted.
-    val data = LinkedHashMap(_dataState.value).apply { set(key, newValue) }
-    _dataState.value = data
+    _dataState.value = LinkedHashMap(_dataState.value).apply { this[task] = newValue }
   }
 
   /**
-   * Retrieves the data associated with a specific task.
+   * Retrieves the [TaskData] associated with a given [Task].
    *
-   * @param task The task to retrieve data for.
-   * @return The data associated with the task, or null if no data is found.
+   * @param task The [Task] to retrieve data for.
+   * @return The [TaskData] associated with the task, or `null` if no data is found.
    */
-  fun getData(task: Task): TaskData? {
-    return _dataState.value[task]
-  }
+  fun getData(task: Task): TaskData? = _dataState.value[task]
 
   /**
-   * Returns the map of task IDs to their current [TaskData] value.
+   * Returns a [TaskSelections] map representing the current state of task data.
    *
-   * @param taskValueOverride An optional override for a specific task's value.
+   * This method allows for an optional override of a specific task's value.
+   *
+   * @param taskValueOverride An optional pair of task ID and [TaskData] to override.
+   * @return A [TaskSelections] map containing the current task data, with any specified override
+   *   applied.
    */
   fun getTaskSelections(taskValueOverride: Pair<String, TaskData?>? = null): TaskSelections =
     buildMap {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
@@ -1,0 +1,56 @@
+package com.google.android.ground.ui.datacollection
+
+import com.google.android.ground.model.submission.TaskData
+import com.google.android.ground.model.task.Task
+import com.google.android.ground.model.task.TaskSelections
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class TaskDataHandler {
+
+  private val _dataState = MutableStateFlow(LinkedHashMap<Task, TaskData?>())
+
+  val dataState: StateFlow<Map<Task, TaskData?>>
+    get() = _dataState.asStateFlow()
+
+  /**
+   * Sets the data for a specific task.
+   *
+   * @param key The task for which to set the data.
+   * @param newValue The new data value for the task.
+   */
+  fun setData(key: Task, newValue: TaskData?) {
+    if (getData(key) == newValue) return
+    // Ensure that the map is recreated to ensure that the state flow is emitted.
+    val data = LinkedHashMap(_dataState.value).apply { set(key, newValue) }
+    _dataState.value = data
+  }
+
+  /**
+   * Retrieves the data associated with a specific task.
+   *
+   * @param task The task to retrieve data for.
+   * @return The data associated with the task, or null if no data is found.
+   */
+  fun getData(task: Task): TaskData? {
+    return _dataState.value[task]
+  }
+
+  /**
+   * Returns the map of task IDs to their current [TaskData] value.
+   *
+   * @param taskValueOverride An optional override for a specific task's value.
+   */
+  fun getTaskSelections(taskValueOverride: Pair<String, TaskData?>? = null): TaskSelections =
+    buildMap {
+      _dataState.value.forEach { (task, value) ->
+        if (taskValueOverride?.first == task.id) {
+            taskValueOverride.second
+          } else {
+            value
+          }
+          ?.apply { put(task.id, this) }
+      }
+    }
+}

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.android.ground.ui.datacollection
 
 import com.google.android.ground.model.submission.TaskData

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
@@ -61,15 +61,17 @@ class TaskDataHandlerTest {
   }
 
   @Test
-  fun `getTaskSelections returns correct selections`() = runTest {
+  fun `getTaskSelections returns correct values`() = runTest {
     val handler = TaskDataHandler()
     val task1 = createTask("task1")
     val task2 = createTask("task2")
+    val task3 = createTask("task3")
     val taskData1 = createTaskData("data1")
     val taskData2 = createTaskData("data2")
 
     handler.setData(task1, taskData1)
     handler.setData(task2, taskData2)
+    handler.setData(task3, null)
 
     val selections = handler.getTaskSelections()
     assertThat(selections).hasSize(2)
@@ -78,7 +80,7 @@ class TaskDataHandlerTest {
   }
 
   @Test
-  fun `getTaskSelections with override returns correct selections`() = runTest {
+  fun `getTaskSelections with override returns correct values`() = runTest {
     val handler = TaskDataHandler()
     val task1 = createTask("task1")
     val task2 = createTask("task2")

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
@@ -1,0 +1,134 @@
+package com.google.android.ground.ui.datacollection
+
+import com.google.android.ground.model.submission.TextTaskData
+import com.google.android.ground.model.task.Task
+import com.sharedtest.FakeData
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class TaskDataHandlerTest {
+
+  @Test
+  fun `setData updates dataState correctly`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+    val taskData1 = createTaskData("data1")
+
+    handler.setData(task1, taskData1)
+
+    val dataState = handler.dataState.first()
+    assertEquals(1, dataState.size)
+    assertEquals(taskData1, dataState[task1])
+  }
+
+  @Test
+  fun `setData with same value does not update dataState`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+    val taskData1 = createTaskData("data1")
+
+    handler.setData(task1, taskData1)
+    val initialDataState = handler.dataState.first()
+
+    handler.setData(task1, taskData1)
+    val newDataState = handler.dataState.first()
+
+    assertEquals(initialDataState, newDataState)
+  }
+
+  @Test
+  fun `getData returns correct data`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+    val taskData1 = createTaskData("data1")
+
+    handler.setData(task1, taskData1)
+
+    assertEquals(taskData1, handler.getData(task1))
+  }
+
+  @Test
+  fun `getData returns null for unknown task`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+
+    assertNull(handler.getData(task1))
+  }
+
+  @Test
+  fun `getTaskSelections returns correct selections`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+    val task2 = createTask("task2")
+    val taskData1 = createTaskData("data1")
+    val taskData2 = createTaskData("data2")
+
+    handler.setData(task1, taskData1)
+    handler.setData(task2, taskData2)
+
+    val selections = handler.getTaskSelections()
+    assertEquals(2, selections.size)
+    assertEquals(taskData1, selections["task1"])
+    assertEquals(taskData2, selections["task2"])
+  }
+
+  @Test
+  fun `getTaskSelections with override returns correct selections`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+    val task2 = createTask("task2")
+    val taskData1 = createTaskData("data1")
+    val taskData2 = createTaskData("data2")
+    val taskDataOverride = createTaskData("override")
+
+    handler.setData(task1, taskData1)
+    handler.setData(task2, taskData2)
+
+    val selections = handler.getTaskSelections(Pair("task1", taskDataOverride))
+    assertEquals(2, selections.size)
+    assertEquals(taskDataOverride, selections["task1"])
+    assertEquals(taskData2, selections["task2"])
+  }
+
+  @Test
+  fun `getTaskSelections with null override returns correct selections`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+    val task2 = createTask("task2")
+    val taskData1 = createTaskData("data1")
+    val taskData2 = createTaskData("data2")
+
+    handler.setData(task1, taskData1)
+    handler.setData(task2, taskData2)
+
+    val selections = handler.getTaskSelections(Pair("task1", null))
+    assertEquals(1, selections.size)
+    assertEquals(taskData2, selections["task2"])
+    assertNull(selections["task1"])
+  }
+
+  @Test
+  fun `setData with null value`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+    val taskData1 = createTaskData("data1")
+
+    handler.setData(task1, taskData1)
+    handler.setData(task1, null)
+
+    val dataState = handler.dataState.first()
+    assertEquals(1, dataState.size)
+    assertNull(dataState[task1])
+  }
+
+  private fun createTask(taskId: String): Task =
+    FakeData.newTask(id = taskId, type = Task.Type.TEXT)
+
+  private fun createTaskData(value: String): TextTaskData = TextTaskData(value)
+}

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
@@ -39,18 +39,19 @@ class TaskDataHandlerTest {
     val taskData1 = createTaskData("data1")
     val taskData2 = createTaskData("data2")
 
-    val emittedStates = mutableListOf<Map<Task, TaskData?>>()
-    val collectJob = launch(UnconfinedTestDispatcher()) { handler.dataState.toList(emittedStates) }
+    val emissions = mutableListOf<Map<Task, TaskData?>>()
+    val job = launch(UnconfinedTestDispatcher()) { handler.dataState.toList(emissions) }
 
     handler.setData(task1, taskData1)
     handler.setData(task1, taskData2)
 
-    assertThat(emittedStates).hasSize(3)
-    assertThat(emittedStates[0]).isEqualTo(emptyMap<Task, TaskData>())
-    assertThat(emittedStates[1]).isEqualTo(mapOf(task1 to taskData1))
-    assertThat(emittedStates[2]).isEqualTo(mapOf(task1 to taskData2))
+    // Verify that both updates were emitted
+    assertThat(emissions).hasSize(3)
+    assertThat(emissions[0]).isEqualTo(emptyMap<Task, TaskData>())
+    assertThat(emissions[1]).isEqualTo(mapOf(task1 to taskData1))
+    assertThat(emissions[2]).isEqualTo(mapOf(task1 to taskData2))
 
-    collectJob.cancel()
+    job.cancel()
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -60,16 +61,17 @@ class TaskDataHandlerTest {
     val task1 = createTask("task1")
     val taskData1 = createTaskData("data1")
 
-    val emittedStates = mutableListOf<Map<Task, TaskData?>>()
-    val collectJob = launch(UnconfinedTestDispatcher()) { handler.dataState.toList(emittedStates) }
+    val emissions = mutableListOf<Map<Task, TaskData?>>()
+    val job = launch(UnconfinedTestDispatcher()) { handler.dataState.toList(emissions) }
 
     handler.setData(task1, taskData1)
-    handler.setData(task1, taskData1)
+    handler.setData(task1, taskData1) // Same value set again
 
-    assertThat(emittedStates).hasSize(2)
-    assertThat(emittedStates[0]).isEqualTo(emptyMap<Task, TaskData>())
-    assertThat(emittedStates[1]).isEqualTo(mapOf(task1 to taskData1))
-    collectJob.cancel()
+    assertThat(emissions).hasSize(2)
+    assertThat(emissions[0]).isEqualTo(emptyMap<Task, TaskData>())
+    assertThat(emissions[1]).isEqualTo(mapOf(task1 to taskData1))
+
+    job.cancel()
   }
 
   @Test

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
@@ -21,35 +21,35 @@ class TaskDataHandlerTest {
   @Test
   fun `setData updates dataState correctly`() = runTest {
     val handler = TaskDataHandler()
-    val task1 = createTask("task1")
-    val taskData1 = createTaskData("data1")
+    val task = createTask("task1")
+    val taskData = createTaskData("data1")
 
-    handler.setData(task1, taskData1)
+    handler.setData(task, taskData)
 
     val dataState = handler.dataState.first()
     assertThat(dataState).hasSize(1)
-    assertThat(dataState[task1]).isEqualTo(taskData1)
+    assertThat(dataState[task]).isEqualTo(taskData)
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `dataState emits when value is updated`() = runTest {
     val handler = TaskDataHandler()
-    val task1 = createTask("task1")
+    val task = createTask("task1")
     val taskData1 = createTaskData("data1")
     val taskData2 = createTaskData("data2")
 
     val emissions = mutableListOf<Map<Task, TaskData?>>()
     val job = launch(UnconfinedTestDispatcher()) { handler.dataState.toList(emissions) }
 
-    handler.setData(task1, taskData1)
-    handler.setData(task1, taskData2)
+    handler.setData(task, taskData1)
+    handler.setData(task, taskData2)
 
     // Verify that both updates were emitted
     assertThat(emissions).hasSize(3)
     assertThat(emissions[0]).isEqualTo(emptyMap<Task, TaskData>())
-    assertThat(emissions[1]).isEqualTo(mapOf(task1 to taskData1))
-    assertThat(emissions[2]).isEqualTo(mapOf(task1 to taskData2))
+    assertThat(emissions[1]).isEqualTo(mapOf(task to taskData1))
+    assertThat(emissions[2]).isEqualTo(mapOf(task to taskData2))
 
     job.cancel()
   }
@@ -58,18 +58,18 @@ class TaskDataHandlerTest {
   @Test
   fun `dataState does not emit when same value is set`() = runTest {
     val handler = TaskDataHandler()
-    val task1 = createTask("task1")
-    val taskData1 = createTaskData("data1")
+    val task = createTask("task1")
+    val taskData = createTaskData("data1")
 
     val emissions = mutableListOf<Map<Task, TaskData?>>()
     val job = launch(UnconfinedTestDispatcher()) { handler.dataState.toList(emissions) }
 
-    handler.setData(task1, taskData1)
-    handler.setData(task1, taskData1) // Same value set again
+    handler.setData(task, taskData)
+    handler.setData(task, taskData) // Same value set again
 
     assertThat(emissions).hasSize(2)
     assertThat(emissions[0]).isEqualTo(emptyMap<Task, TaskData>())
-    assertThat(emissions[1]).isEqualTo(mapOf(task1 to taskData1))
+    assertThat(emissions[1]).isEqualTo(mapOf(task to taskData))
 
     job.cancel()
   }
@@ -77,20 +77,20 @@ class TaskDataHandlerTest {
   @Test
   fun `getData returns correct data`() = runTest {
     val handler = TaskDataHandler()
-    val task1 = createTask("task1")
-    val taskData1 = createTaskData("data1")
+    val task = createTask("task1")
+    val taskData = createTaskData("data1")
 
-    handler.setData(task1, taskData1)
+    handler.setData(task, taskData)
 
-    assertThat(handler.getData(task1)).isEqualTo(taskData1)
+    assertThat(handler.getData(task)).isEqualTo(taskData)
   }
 
   @Test
   fun `getData returns null for unknown task`() = runTest {
     val handler = TaskDataHandler()
-    val task1 = createTask("task1")
+    val task = createTask("task1")
 
-    assertThat(handler.getData(task1)).isNull()
+    assertThat(handler.getData(task)).isNull()
   }
 
   @Test
@@ -150,15 +150,15 @@ class TaskDataHandlerTest {
   @Test
   fun `setData with null value`() = runTest {
     val handler = TaskDataHandler()
-    val task1 = createTask("task1")
-    val taskData1 = createTaskData("data1")
+    val task = createTask("task1")
+    val taskData = createTaskData("data1")
 
-    handler.setData(task1, taskData1)
-    handler.setData(task1, null)
+    handler.setData(task, taskData)
+    handler.setData(task, null)
 
     val dataState = handler.dataState.first()
     assertThat(dataState).hasSize(1)
-    assertThat(dataState[task1]).isNull()
+    assertThat(dataState[task]).isNull()
   }
 
   private fun createTask(taskId: String): Task =

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.android.ground.ui.datacollection
 
 import com.google.android.ground.model.submission.TaskData

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
@@ -2,14 +2,13 @@ package com.google.android.ground.ui.datacollection
 
 import com.google.android.ground.model.submission.TextTaskData
 import com.google.android.ground.model.task.Task
+import com.google.common.truth.Truth.assertThat
 import com.sharedtest.FakeData
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class TaskDataHandlerTest {
@@ -23,8 +22,8 @@ class TaskDataHandlerTest {
     handler.setData(task1, taskData1)
 
     val dataState = handler.dataState.first()
-    assertEquals(1, dataState.size)
-    assertEquals(taskData1, dataState[task1])
+    assertThat(dataState).hasSize(1)
+    assertThat(dataState[task1]).isEqualTo(taskData1)
   }
 
   @Test
@@ -39,7 +38,7 @@ class TaskDataHandlerTest {
     handler.setData(task1, taskData1)
     val newDataState = handler.dataState.first()
 
-    assertEquals(initialDataState, newDataState)
+    assertThat(newDataState).isEqualTo(initialDataState)
   }
 
   @Test
@@ -50,7 +49,7 @@ class TaskDataHandlerTest {
 
     handler.setData(task1, taskData1)
 
-    assertEquals(taskData1, handler.getData(task1))
+    assertThat(handler.getData(task1)).isEqualTo(taskData1)
   }
 
   @Test
@@ -58,7 +57,7 @@ class TaskDataHandlerTest {
     val handler = TaskDataHandler()
     val task1 = createTask("task1")
 
-    assertNull(handler.getData(task1))
+    assertThat(handler.getData(task1)).isNull()
   }
 
   @Test
@@ -73,9 +72,9 @@ class TaskDataHandlerTest {
     handler.setData(task2, taskData2)
 
     val selections = handler.getTaskSelections()
-    assertEquals(2, selections.size)
-    assertEquals(taskData1, selections["task1"])
-    assertEquals(taskData2, selections["task2"])
+    assertThat(selections).hasSize(2)
+    assertThat(selections["task1"]).isEqualTo(taskData1)
+    assertThat(selections["task2"]).isEqualTo(taskData2)
   }
 
   @Test
@@ -91,9 +90,9 @@ class TaskDataHandlerTest {
     handler.setData(task2, taskData2)
 
     val selections = handler.getTaskSelections(Pair("task1", taskDataOverride))
-    assertEquals(2, selections.size)
-    assertEquals(taskDataOverride, selections["task1"])
-    assertEquals(taskData2, selections["task2"])
+    assertThat(selections).hasSize(2)
+    assertThat(selections["task1"]).isEqualTo(taskDataOverride)
+    assertThat(selections["task2"]).isEqualTo(taskData2)
   }
 
   @Test
@@ -108,9 +107,9 @@ class TaskDataHandlerTest {
     handler.setData(task2, taskData2)
 
     val selections = handler.getTaskSelections(Pair("task1", null))
-    assertEquals(1, selections.size)
-    assertEquals(taskData2, selections["task2"])
-    assertNull(selections["task1"])
+    assertThat(selections).hasSize(1)
+    assertThat(selections["task2"]).isEqualTo(taskData2)
+    assertThat(selections["task1"]).isNull()
   }
 
   @Test
@@ -123,8 +122,8 @@ class TaskDataHandlerTest {
     handler.setData(task1, null)
 
     val dataState = handler.dataState.first()
-    assertEquals(1, dataState.size)
-    assertNull(dataState[task1])
+    assertThat(dataState).hasSize(1)
+    assertThat(dataState[task1]).isNull()
   }
 
   private fun createTask(taskId: String): Task =


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #2993 

Introduces a wrapper class for handling task data values. Provides a way to subscribe for changes to the task value. 

This is a no-op change. This will be integrated along with TaskSequenceHandler in DataCollectionViewModel in future CLs.

<!-- PR description. -->
See https://github.com/google/ground-android/issues/2993#issue-2776885263 for detailed description.

@scolsen @anandwana001 PTAL?
