### PR TITLE
Reuse addNextButton() for Capture location and drop pin tasks

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -147,10 +147,13 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
       .setOnClickListener { moveToPrevious() }
       .enableIfTrue(!dataCollectionViewModel.isFirstPosition(taskId))
 
-  protected fun addNextButton() =
+  protected fun addNextButton(hideIfEmpty: Boolean = false) =
     addButton(ButtonAction.NEXT)
       .setOnClickListener { handleNext() }
       .setOnValueChanged { button, value ->
+        if (hideIfEmpty) {
+          button.showIfTrue(value.isNotNullOrEmpty())
+        }
         button.enableIfTrue(value.isNotNullOrEmpty())
         button.toggleDone(checkLastPositionWithTaskData(value))
       }
@@ -179,7 +182,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
     dataCollectionViewModel.onNextClicked(viewModel)
   }
 
-  fun handleNext() {
+  private fun handleNext() {
     if (getTask().isAddLoiTask) {
       launchLoiNameDialog()
     } else {

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/location/CaptureLocationTaskFragment.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.lifecycleScope
 import com.google.android.ground.R
-import com.google.android.ground.model.submission.isNotNullOrEmpty
 import com.google.android.ground.model.submission.isNullOrEmpty
 import com.google.android.ground.ui.datacollection.components.ButtonAction
 import com.google.android.ground.ui.datacollection.components.TaskView
@@ -83,13 +82,7 @@ class CaptureLocationTaskFragment @Inject constructor() :
     addButton(ButtonAction.CAPTURE_LOCATION)
       .setOnClickListener { viewModel.updateResponse() }
       .setOnValueChanged { button, value -> button.showIfTrue(value.isNullOrEmpty()) }
-    addButton(ButtonAction.NEXT)
-      .setOnClickListener { handleNext() }
-      .setOnValueChanged { button, value ->
-        button.showIfTrue(value.isNotNullOrEmpty())
-        button.toggleDone(checkLastPositionWithTaskData(value))
-      }
-      .hide()
+    addNextButton(hideIfEmpty = true)
   }
 
   @Suppress("LabeledExpression")

--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/tasks/point/DropPinTaskFragment.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import com.google.android.ground.R
-import com.google.android.ground.model.submission.isNotNullOrEmpty
 import com.google.android.ground.model.submission.isNullOrEmpty
 import com.google.android.ground.ui.datacollection.components.ButtonAction
 import com.google.android.ground.ui.datacollection.components.InstructionsDialog
@@ -67,13 +66,7 @@ class DropPinTaskFragment @Inject constructor() : AbstractTaskFragment<DropPinTa
     addButton(ButtonAction.DROP_PIN)
       .setOnClickListener { viewModel.dropPin() }
       .setOnValueChanged { button, value -> button.showIfTrue(value.isNullOrEmpty()) }
-    addButton(ButtonAction.NEXT)
-      .setOnClickListener { handleNext() }
-      .setOnValueChanged { button, value ->
-        button.showIfTrue(value.isNotNullOrEmpty())
-        button.toggleDone(checkLastPositionWithTaskData(value))
-      }
-      .hide()
+    addNextButton(hideIfEmpty = true)
   }
 
   override fun onTaskResume() {


### PR DESCRIPTION
This PR is a pure refactor which is split from https://github.com/google/ground-android/pull/2986 so that main logic change can be separated from refactors.

Things done:
 * Adds support for hiding the next button in the base helper method
 * Reuse the same function in drop pin and capture location tasks.

@anandwana001 PTAL?