### PR TITLE
Use TaskDataHandler in DataCollectionViewModel

### DIFF
--- a/app/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
@@ -68,12 +68,12 @@ class TaskDataHandler {
   fun getTaskSelections(taskValueOverride: Pair<String, TaskData?>? = null): TaskSelections =
     buildMap {
       _dataState.value.forEach { (task, value) ->
-        if (taskValueOverride?.first == task.id) {
-            taskValueOverride.second
-          } else {
-            value
-          }
-          ?.apply { put(task.id, this) }
+        if (task.id != taskValueOverride?.first) {
+          value?.let { put(task.id, it) }
+        }
       }
+
+      // Override task value
+      taskValueOverride?.let { (taskId, taskValue) -> taskValue?.let { put(taskId, it) } }
     }
 }

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -155,7 +155,8 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
           button.showIfTrue(value.isNotNullOrEmpty())
         }
         button.enableIfTrue(value.isNotNullOrEmpty())
-        button.toggleDone(checkLastPositionWithTaskData(value))
+        val isLastPosition = checkLastPositionWithTaskData(value)
+        button.toggleDone(done = isLastPosition)
       }
       .disable()
 
@@ -242,7 +243,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
    * Returns true if the current task with the given task data would be last in sequence. Useful for
    * handling conditional tasks, see #2394.
    */
-  protected fun checkLastPositionWithTaskData(value: TaskData?) =
+  private fun checkLastPositionWithTaskData(value: TaskData?) =
     dataCollectionViewModel.checkLastPositionWithTaskData(taskId, value)
 
   private fun getTask(): Task = viewModel.task

--- a/app/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
+++ b/app/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
@@ -146,6 +146,26 @@ class TaskDataHandlerTest {
   }
 
   @Test
+  fun `getTaskSelections with override having new value returns correct values`() = runTest {
+    val handler = TaskDataHandler()
+    val task1 = createTask("task1")
+    val task2 = createTask("task2")
+    val taskData1 = createTaskData("data1")
+    val taskData2 = createTaskData("data2")
+    val taskOverride = createTask("overrideTask")
+    val taskDataOverride = createTaskData("overrideValue")
+
+    handler.setData(task1, taskData1)
+    handler.setData(task2, taskData2)
+
+    val selections = handler.getTaskSelections(Pair(taskOverride.id, taskDataOverride))
+    assertThat(selections).hasSize(3)
+    assertThat(selections["task1"]).isEqualTo(taskData1)
+    assertThat(selections["task2"]).isEqualTo(taskData2)
+    assertThat(selections["overrideTask"]).isEqualTo(taskDataOverride)
+  }
+
+  @Test
   fun `getTaskSelections with null override returns correct selections`() = runTest {
     val handler = TaskDataHandler()
     val task1 = createTask("task1")


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #2993

<!-- PR description. -->
In #2995, we introduced `TaskDataHandler` for managing data state. This PR aims at using it in `DataCollectionViewModel`.

This shouldn't change the behavior and is no-op.

Split from https://github.com/google/ground-android/pull/2986

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001 @scolsen  PTAL?
