### PR TITLE
[Bug] Prevent saving to draft after task is submitted

### DIFF
--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -280,12 +280,19 @@ internal constructor(
 
   /** Persists the collected data as draft to local storage. */
   private fun saveDraft(taskId: String) {
+    val deltas = getDeltas()
+
+    // Prevent saving draft if the task is submitted or there are no deltas.
+    if (_uiState.value == UiState.TaskSubmitted || deltas.isEmpty()) {
+      return
+    }
+
     externalScope.launch(ioDispatcher) {
       submissionRepository.saveDraftSubmission(
         jobId = jobId,
         loiId = loiId,
         surveyId = surveyId,
-        deltas = getDeltas(),
+        deltas = deltas,
         loiName = customLoiName,
         currentTaskId = taskId,
       )


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes an issue in data collection flow where the draft was getting saved after task submission causing the data collection fragment to be reopened just after collecting data.

<!-- PR description. -->
Changes verified by running the app locally with and without this fix.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001  PTAL?
