### PR TITLE
Make activateSurvey call blocking

### DIFF
--- a/app/src/main/java/com/google/android/ground/MainViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/MainViewModel.kt
@@ -99,14 +99,18 @@ constructor(
   private fun onUserSignedOut(): MainUiState {
     // Scope of subscription is until view model is cleared. Dispose it manually otherwise, firebase
     // attempts to maintain a connection even after user has logged out and throws an error.
-    surveyRepository.clearActiveSurvey()
     userRepository.clearUserPreferences()
 
     // TODO: Once multi-user login is supported, avoid clearing local db data. This is
     //  currently being done to prevent one user's data to be submitted as another user after
     //  re-login.
     // Issue URL: https://github.com/google/ground-android/issues/1691
-    viewModelScope.launch { withContext(ioDispatcher) { localDatabase.clearAllTables() } }
+    viewModelScope.launch {
+      withContext(ioDispatcher) {
+        surveyRepository.clearActiveSurvey()
+        localDatabase.clearAllTables()
+      }
+    }
     return MainUiState.OnUserSignedOut
   }
 

--- a/app/src/main/java/com/google/android/ground/domain/usecases/survey/ActivateSurveyUseCase.kt
+++ b/app/src/main/java/com/google/android/ground/domain/usecases/survey/ActivateSurveyUseCase.kt
@@ -36,10 +36,14 @@ constructor(
   private val makeSurveyAvailableOffline: MakeSurveyAvailableOfflineUseCase,
   private val surveyRepository: SurveyRepository,
 ) {
-  suspend operator fun invoke(surveyId: String) {
+
+  /**
+   * @return `true` if the survey was successfully activated or was already active, otherwise false.
+   */
+  suspend operator fun invoke(surveyId: String): Boolean {
     if (surveyRepository.isSurveyActive(surveyId)) {
       // Do nothing if survey is already active.
-      return
+      return true
     }
 
     localSurveyStore.getSurveyById(surveyId)
@@ -47,5 +51,7 @@ constructor(
       ?: error("Survey $surveyId not found in remote db")
 
     surveyRepository.activateSurvey(surveyId)
+
+    return surveyRepository.isSurveyActive(surveyId)
   }
 }

--- a/app/src/main/java/com/google/android/ground/domain/usecases/survey/ReactivateLastSurveyUseCase.kt
+++ b/app/src/main/java/com/google/android/ground/domain/usecases/survey/ReactivateLastSurveyUseCase.kt
@@ -36,7 +36,6 @@ constructor(
       true
     } else {
       activateSurvey(getLastActiveSurveyId())
-      surveyRepository.hasActiveSurvey()
     }
 
   private fun getLastActiveSurveyId(): String = localValueStore.lastActiveSurveyId

--- a/app/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
+++ b/app/src/main/java/com/google/android/ground/repository/SurveyRepository.kt
@@ -20,14 +20,16 @@ import com.google.android.ground.coroutines.ApplicationScope
 import com.google.android.ground.model.Survey
 import com.google.android.ground.persistence.local.LocalValueStore
 import com.google.android.ground.persistence.local.stores.LocalSurveyStore
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
@@ -35,8 +37,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeout
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val ACTIVATE_SURVEY_TIMEOUT_MILLS: Long = 3 * 1000
 
@@ -90,7 +90,7 @@ constructor(
 
     // Wait for survey to be updated. Else throw an error after timeout.
     withTimeout(ACTIVATE_SURVEY_TIMEOUT_MILLS) {
-      activeSurveyFlow.filter { survey ->
+      activeSurveyFlow.first { survey ->
         if (surveyId.isBlank()) {
           survey == null
         } else {

--- a/app/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
@@ -87,7 +87,7 @@ internal constructor(
             if (result) {
               onSurveyActivated()
             } else {
-              onSurveyActivationFailed(null)
+              onSurveyActivationFailed()
             }
           },
           onFailure = { onSurveyActivationFailed(it) },
@@ -101,7 +101,7 @@ internal constructor(
     _uiState.emit(UiState.NavigateToHome)
   }
 
-  private suspend fun onSurveyActivationFailed(error: Throwable?) {
+  private suspend fun onSurveyActivationFailed(error: Throwable? = null) {
     Timber.e(error, "Failed to activate survey")
     surveyActivationInProgress = false
     _uiState.emit(UiState.Error)

--- a/app/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/ui/surveyselector/SurveySelectorViewModel.kt
@@ -83,18 +83,28 @@ internal constructor(
           activateSurveyUseCase(surveyId)
         }
         .fold(
-          onSuccess = {
-            surveyActivationInProgress = false
-            _uiState.emit(UiState.SurveyActivated)
-            _uiState.emit(UiState.NavigateToHome)
+          onSuccess = { result ->
+            if (result) {
+              onSurveyActivated()
+            } else {
+              onSurveyActivationFailed(null)
+            }
           },
-          onFailure = { e ->
-            Timber.e(e, "Failed to activate survey")
-            surveyActivationInProgress = false
-            _uiState.emit(UiState.Error)
-          },
+          onFailure = { onSurveyActivationFailed(it) },
         )
     }
+  }
+
+  private suspend fun onSurveyActivated() {
+    surveyActivationInProgress = false
+    _uiState.emit(UiState.SurveyActivated)
+    _uiState.emit(UiState.NavigateToHome)
+  }
+
+  private suspend fun onSurveyActivationFailed(error: Throwable?) {
+    Timber.e(error, "Failed to activate survey")
+    surveyActivationInProgress = false
+    _uiState.emit(UiState.Error)
   }
 
   fun deleteSurvey(surveyId: String) {

--- a/app/src/test/java/com/google/android/ground/repository/UserRepositoryTest.kt
+++ b/app/src/test/java/com/google/android/ground/repository/UserRepositoryTest.kt
@@ -101,6 +101,7 @@ class UserRepositoryTest : BaseHiltTest() {
     val user = FakeData.USER
     val survey = FakeData.SURVEY.copy(acl = mapOf(Pair(user.email, Role.OWNER.toString())))
     fakeAuthenticationManager.setUser(user)
+    localSurveyStore.insertOrUpdateSurvey(survey)
     surveyRepository.activateSurvey(survey.id)
 
     assertThat(userRepository.canUserSubmitData()).isTrue()

--- a/app/src/test/java/com/google/android/ground/ui/home/HomeScreenFragmentTest.kt
+++ b/app/src/test/java/com/google/android/ground/ui/home/HomeScreenFragmentTest.kt
@@ -142,20 +142,8 @@ class HomeScreenFragmentTest : AbstractHomeScreenFragmentTest() {
    */
   @get:Rule override val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-  private val surveyWithoutBasemap: Survey =
-    Survey(
-      "SURVEY",
-      "Survey title",
-      "Test survey description",
-      mapOf(FakeData.JOB.id to FakeData.JOB),
-      mapOf(Pair(FakeData.USER.email, "data-collector")),
-    )
-
   @Test
   fun `all menu item is always enabled`() = runWithTestDispatcher {
-    surveyRepository.activateSurvey(surveyWithoutBasemap.id)
-    advanceUntilIdle()
-
     openDrawer()
     onView(withId(R.id.nav_offline_areas)).check(matches(isEnabled()))
     onView(withId(R.id.sync_status)).check(matches(isEnabled()))

--- a/app/src/test/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragmentTest.kt
+++ b/app/src/test/java/com/google/android/ground/ui/surveyselector/SurveySelectorFragmentTest.kt
@@ -143,6 +143,7 @@ class SurveySelectorFragmentTest : BaseHiltTest() {
   @Test
   fun click_activatesSurvey() = runWithTestDispatcher {
     setSurveyList(listOf(TEST_SURVEY_1, TEST_SURVEY_2))
+    whenever(activateSurvey(TEST_SURVEY_2.id)).thenReturn(true)
 
     launchFragmentWithNavController<SurveySelectorFragment>(
       fragmentArgs = bundleOf(Pair("shouldExitApp", false)),
@@ -156,8 +157,6 @@ class SurveySelectorFragmentTest : BaseHiltTest() {
       .perform(actionOnItemAtPosition<SurveyListAdapter.ViewHolder>(1, click()))
     advanceUntilIdle()
 
-    // Assert survey is activated.
-    verify(activateSurvey).invoke(TEST_SURVEY_2.id)
     // Assert that navigation to home screen was requested
     assertThat(navController.currentDestination?.id).isEqualTo(R.id.home_screen_fragment)
     // No error toast should be displayed


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3020

<!-- PR description. -->
This PR aims to make the behavior of activate survey deterministic by making the call wait until the survey has been activated i.e. the survey gets fetched from local db and is emitted by the flow.

Without this, today the UI assumes that the survey has been activated and the screens are ready to consume it. This may lead to unwanted behavior if the next screen expects the value to be available immediately.

The function waits for 3s before throwing an error. Instead of crashing the app, we display an error toast that "something went wrong" and the user can try again.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->


@gino-m @sufyanAbbasi @anandwana001  PTAL?
