### PR TITLE
Use list instead of sequence in TaskSequenceHandler

### DIFF
--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -345,17 +345,17 @@ internal constructor(
   fun isLastPosition(taskId: String): Boolean = taskSequenceHandler.isLastPosition(taskId)
 
   /**
-   * Returns true if the given [taskId] with [newValue] would be last in the sequence of displayed
+   * Returns true if the given [task] with [newValue] would be last in the sequence of displayed
    * tasks. Required for handling conditional tasks, see #2394.
    */
-  fun isLastPositionWithValue(taskId: String, newValue: TaskData?): Boolean {
-    if (taskDataHandler.getData(taskId) == newValue) {
+  fun isLastPositionWithValue(task: Task, newValue: TaskData?): Boolean {
+    if (taskDataHandler.getData(task) == newValue) {
       // Reuse the existing task sequence if the value has already been saved (i.e. after pressing
       // "Next" and going back).
-      return isLastPosition(taskId)
+      return isLastPosition(task.id)
     }
 
-    return taskSequenceHandler.checkIfTaskIsLastWithValue(taskValueOverride = taskId to newValue)
+    return taskSequenceHandler.checkIfTaskIsLastWithValue(taskValueOverride = task.id to newValue)
   }
 
   companion object {

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionViewModel.kt
@@ -148,14 +148,14 @@ internal constructor(
   init {
     // Set current task's ID for new task submissions.
     if (currentTaskId.value == "") {
-      savedStateHandle[TASK_POSITION_ID] = taskSequenceHandler.getTaskSequence().first().id
+      savedStateHandle[TASK_POSITION_ID] = taskSequenceHandler.getValidTasks().first().id
     }
 
     _uiState.update { UiState.TaskListAvailable(tasks, getTaskPosition(getCurrentTaskId())) }
 
-    // Update the computed task sequence cache if the task's data is updated.
+    // Invalidates the cache if any of the task's data is updated.
     viewModelScope.launch {
-      taskDataHandler.dataState.collectLatest { taskSequenceHandler.refreshTaskSequence() }
+      taskDataHandler.dataState.collectLatest { taskSequenceHandler.invalidateCache() }
     }
   }
 
@@ -274,13 +274,13 @@ internal constructor(
   }
 
   /** Retrieves a list of [ValueDelta] for tasks that are part of the current sequence. */
-  private fun getDeltas(): List<ValueDelta> =
-    taskSequenceHandler
-      .getTaskSequence()
-      .mapNotNull { task ->
-        taskDataHandler.getData(task)?.let { ValueDelta(task.id, task.type, it) }
-      }
-      .toList()
+  private fun getDeltas(): List<ValueDelta> {
+    val tasksDataMap = taskDataHandler.dataState.value
+    val validTasks = taskSequenceHandler.getValidTasks()
+    return tasksDataMap
+      .filterKeys { validTasks.contains(it) }
+      .map { (task, taskData) -> ValueDelta(task.id, task.type, taskData) }
+  }
 
   /** Persists the changes locally and enqueues a worker to sync with remote datastore. */
   private fun saveChanges(deltas: List<ValueDelta>) {

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/TaskDataHandler.kt
@@ -54,13 +54,7 @@ class TaskDataHandler {
    * @param task The [Task] to retrieve data for.
    * @return The [TaskData] associated with the task, or `null` if no data is found.
    */
-  @Deprecated("Use getData(taskId: String) instead")
   fun getData(task: Task): TaskData? = _dataState.value[task]
-
-  // TODO: Refactor task data handler to use TaskId as key instead of Task.
-  // Issue URL: https://github.com/google/ground-android/issues/3009
-  fun getData(taskId: String): TaskData? =
-    _dataState.value.filterKeys { it.id == taskId }.values.firstOrNull()
 
   /**
    * Returns a [TaskSelections] map representing the current state of task data.

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/tasks/AbstractTaskFragment.kt
@@ -155,7 +155,7 @@ abstract class AbstractTaskFragment<T : AbstractTaskViewModel> : AbstractFragmen
           button.showIfTrue(value.isNotNullOrEmpty())
         }
         button.enableIfTrue(value.isNotNullOrEmpty())
-        val isLastPosition = dataCollectionViewModel.isLastPositionWithValue(taskId, value)
+        val isLastPosition = dataCollectionViewModel.isLastPositionWithValue(viewModel.task, value)
         button.toggleDone(done = isLastPosition)
       }
       .disable()

--- a/app/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
+++ b/app/src/test/java/com/google/android/ground/ui/datacollection/TaskDataHandlerTest.kt
@@ -109,24 +109,6 @@ class TaskDataHandlerTest {
   }
 
   @Test
-  fun `getData with taskId returns correct data`() = runTest {
-    val handler = TaskDataHandler()
-    val task = createTask("task1")
-    val taskData = createTaskData("data1")
-
-    handler.setData(task, taskData)
-
-    assertThat(handler.getData(task.id)).isEqualTo(taskData)
-  }
-
-  @Test
-  fun `getData with taskId returns null for unknown task`() = runTest {
-    val handler = TaskDataHandler()
-
-    assertThat(handler.getData("task1")).isNull()
-  }
-
-  @Test
   fun `getTaskSelections returns correct values`() = runTest {
     val handler = TaskDataHandler()
     val task1 = createTask("task1")

--- a/app/src/test/java/com/google/android/ground/ui/datacollection/TaskSequenceHandlerTest.kt
+++ b/app/src/test/java/com/google/android/ground/ui/datacollection/TaskSequenceHandlerTest.kt
@@ -94,7 +94,7 @@ class TaskSequenceHandlerTest {
   @Test
   fun `constructor should throw error when tasks are empty`() {
     assertThrows(IllegalArgumentException::class.java) {
-      TaskSequenceHandler(tasks = emptyList(), taskDataHandler)
+      TaskSequenceHandler(allTasks = emptyList(), taskDataHandler)
     }
   }
 
@@ -102,14 +102,14 @@ class TaskSequenceHandlerTest {
   fun `getTaskSequence returns all tasks when condition is met`() {
     satisfyAllConditions()
 
-    val sequence = taskSequenceHandler.getTaskSequence()
+    val sequence = taskSequenceHandler.getValidTasks()
 
     assertThat(sequence.toList()).isEqualTo(allTasks)
   }
 
   @Test
   fun `getTaskSequence returns partial tasks when condition is not met`() {
-    val sequence = taskSequenceHandler.getTaskSequence()
+    val sequence = taskSequenceHandler.getValidTasks()
 
     assertThat(sequence.toList()).isEqualTo(listOf(task1, task2))
   }
@@ -118,7 +118,7 @@ class TaskSequenceHandlerTest {
   fun `generateTaskSequence returns all tasks if conditions are satisfied`() {
     satisfyAllConditions()
 
-    val sequence = taskSequenceHandler.generateTaskSequence()
+    val sequence = taskSequenceHandler.generateValidTasksList()
 
     assertThat(sequence.toList()).isEqualTo(allTasks)
   }
@@ -152,14 +152,14 @@ class TaskSequenceHandlerTest {
   }
 
   @Test
-  fun `refreshTaskSequence updates the cached task sequence`() {
-    val initialSequence = taskSequenceHandler.getTaskSequence()
+  fun `invalidateCache forces the list to be re-calculated`() {
+    val initialSequence = taskSequenceHandler.getValidTasks()
     assertThat(initialSequence.toList()).isEqualTo(listOf(task1, task2))
 
     satisfyAllConditions()
-    taskSequenceHandler.refreshTaskSequence()
+    taskSequenceHandler.invalidateCache()
 
-    val finalSequence = taskSequenceHandler.getTaskSequence()
+    val finalSequence = taskSequenceHandler.getValidTasks()
     assertThat(finalSequence.toList()).isEqualTo(listOf(task1, conditionalTask, task2))
   }
 


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3009
Fixes #3025 

<!-- PR description. -->
As discussed in https://github.com/google/ground-android/pull/3008#issuecomment-2618061017, we can replace `sequence` with `list` in `TaskSequenceHandler` to improve lookup performance.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
Verified for regressions by running the app locally.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001 @sufyanAbbasi  PTAL?
