### PR TITLE
Add submission count to card data

### DIFF
--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -77,9 +77,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
     super.onCreate(savedInstanceState)
     mapContainerViewModel = getViewModel(HomeScreenMapContainerViewModel::class.java)
     homeScreenViewModel = getViewModel(HomeScreenViewModel::class.java)
-    jobMapComposables = JobMapComposables { loi ->
-      submissionRepository.getTotalSubmissionCount(loi)
-    }
+    jobMapComposables = JobMapComposables()
 
     launchWhenStarted {
       val canUserSubmitData = userRepository.canUserSubmitData()

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -53,7 +53,6 @@ import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 /** Main app view, displaying the map and related controls (center cross-hairs, add button, etc). */
@@ -78,6 +77,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
     mapContainerViewModel = getViewModel(HomeScreenMapContainerViewModel::class.java)
     homeScreenViewModel = getViewModel(HomeScreenViewModel::class.java)
     jobMapComposables = JobMapComposables()
+    jobMapComposables.setSelectedFeature { mapContainerViewModel.selectLocationOfInterest(it) }
 
     launchWhenStarted {
       val canUserSubmitData = userRepository.canUserSubmitData()
@@ -102,7 +102,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
       // Bind data for cards
       mapContainerViewModel.processDataCollectionEntryPoints().launchWhenStartedAndCollect {
         (loiCard, jobCards) ->
-        runBlocking { jobMapComposables.updateData(canUserSubmitData, loiCard, jobCards) }
+        jobMapComposables.updateData(canUserSubmitData, loiCard, jobCards)
       }
     }
 
@@ -274,8 +274,6 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
 
   override fun onMapReady(map: MapFragment) {
     mapContainerViewModel.mapLoiFeatures.launchWhenStartedAndCollect { map.setFeatures(it) }
-
-    jobMapComposables.setSelectedFeature { mapContainerViewModel.selectLocationOfInterest(it) }
   }
 
   override fun getMapViewModel(): BaseMapViewModel = mapContainerViewModel

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -188,9 +188,13 @@ internal constructor(
     combine(loisInViewport, featureClicked, adHocLoiJobs) { loisInView, feature, jobs ->
       val loiCard =
         loisInView
-          .filter { it.geometry == feature?.geometry }
-          .firstOrNull()
-          ?.let { SelectedLoiSheetData(it) }
+          .firstOrNull { it.geometry == feature?.geometry }
+          ?.let {
+            SelectedLoiSheetData(
+              loi = it,
+              submissionCount = submissionRepository.getTotalSubmissionCount(it),
+            )
+          }
       if (loiCard == null && feature != null) {
         // The feature is not in view anymore.
         featureClicked.value = null

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/jobs/DataCollectionEntryPointData.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/jobs/DataCollectionEntryPointData.kt
@@ -22,6 +22,7 @@ import com.google.android.ground.model.locationofinterest.LocationOfInterest
 /** Data classes used to populate the data collection entry UI, like the LOI bottom sheet. */
 sealed interface DataCollectionEntryPointData
 
-data class SelectedLoiSheetData(val loi: LocationOfInterest) : DataCollectionEntryPointData
+data class SelectedLoiSheetData(val loi: LocationOfInterest, val submissionCount: Int) :
+  DataCollectionEntryPointData
 
 data class AdHocDataCollectionButtonData(val job: Job) : DataCollectionEntryPointData

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/jobs/JobMapComposables.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/jobs/JobMapComposables.kt
@@ -71,7 +71,7 @@ import com.google.android.ground.ui.common.LocationOfInterestHelper
 import kotlinx.coroutines.launch
 
 /** Manages a set of [Composable] components that renders [LocationOfInterest] cards and dialogs. */
-class JobMapComposables(private val getSubmissionCount: suspend (loi: LocationOfInterest) -> Int) {
+class JobMapComposables {
   private var collectDataListener: MutableState<(DataCollectionEntryPointData) -> Unit> =
     mutableStateOf({})
   private var canUserSubmitData = mutableStateOf(false)
@@ -108,7 +108,7 @@ class JobMapComposables(private val getSubmissionCount: suspend (loi: LocationOf
     newLoiJobs.clear()
     newLoiJobs.addAll(addLoiJobs)
     if (selectedLoi != null) {
-      submissionCount.intValue = getSubmissionCount(selectedLoi.loi)
+      submissionCount.intValue = selectedLoi.submissionCount
       jobCardOpened.value = true
       selectedFeatureListener(selectedLoi.loi.id)
     }

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/jobs/JobMapComposables.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/jobs/JobMapComposables.kt
@@ -98,7 +98,7 @@ class JobMapComposables {
   }
 
   /** Overwrites existing cards. */
-  suspend fun updateData(
+  fun updateData(
     canUserSubmitData: Boolean,
     selectedLoi: SelectedLoiSheetData?,
     addLoiJobs: List<AdHocDataCollectionButtonData>,

--- a/app/src/test/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModelTest.kt
+++ b/app/src/test/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModelTest.kt
@@ -36,7 +36,6 @@ import com.google.android.ground.ui.map.CameraPosition
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
-import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -47,6 +46,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
+import javax.inject.Inject
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
@@ -84,7 +84,7 @@ class HomeScreenMapContainerViewModelTest : BaseHiltTest() {
   fun `renders the job card when zoomed into LOI and clicked on`() = runWithTestDispatcher {
     viewModel.onFeatureClicked(features = setOf(LOCATION_OF_INTEREST_FEATURE))
     val pair = viewModel.processDataCollectionEntryPoints().first()
-    assertThat(pair.first).isEqualTo(SelectedLoiSheetData(LOCATION_OF_INTEREST))
+    assertThat(pair.first).isEqualTo(SelectedLoiSheetData(LOCATION_OF_INTEREST, 0))
     assertThat(pair.second).isEqualTo(listOf(AdHocDataCollectionButtonData(ADHOC_JOB)))
   }
 

--- a/app/src/test/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModelTest.kt
+++ b/app/src/test/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModelTest.kt
@@ -36,6 +36,7 @@ import com.google.android.ground.ui.map.CameraPosition
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -46,7 +47,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
-import javax.inject.Inject
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Follow up to https://github.com/google/ground-android/pull/3036

Further simplifies the `JobMapComposables` by replacing async function call to fetch submission count by adding it to card data. We no longer need to evaluate it on-the-fly as there is only 1 card rendered at a time.

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001 @sufyanAbbasi  PTAL?
