### PR TITLE
Move logic for showing data sharing terms to domain layers

### DIFF
--- a/app/src/main/java/com/google/android/ground/domain/usecases/datasharingterms/GetDataSharingTermsUseCase.kt
+++ b/app/src/main/java/com/google/android/ground/domain/usecases/datasharingterms/GetDataSharingTermsUseCase.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.domain.usecases.datasharingterms
+
+import com.google.android.ground.persistence.local.LocalValueStore
+import com.google.android.ground.proto.Survey.DataSharingTerms
+import com.google.android.ground.repository.SurveyRepository
+import javax.inject.Inject
+
+class GetDataSharingTermsUseCase
+@Inject
+constructor(
+  private val localValueStore: LocalValueStore,
+  private val surveyRepository: SurveyRepository,
+) {
+
+  /** Returns the data sharing terms for the currently active survey, if not already accepted. */
+  operator fun invoke(): DataSharingTerms? {
+    val survey = surveyRepository.activeSurvey ?: return null
+
+    if (localValueStore.getDataSharingConsent(survey.id)) {
+      // User previously agreed to the terms.
+      return null
+    }
+
+    return survey.dataSharingTerms
+  }
+}

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -45,11 +45,11 @@ import com.google.android.ground.ui.map.MapFragment
 import com.google.android.ground.util.createComposeView
 import com.google.android.ground.util.renderComposableDialog
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import timber.log.Timber
-import javax.inject.Inject
 
 /** Main app view, displaying the map and related controls (center cross-hairs, add button, etc). */
 @AndroidEntryPoint

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -139,9 +139,15 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
       }
       .onFailure {
         Timber.e(it, "Failed to get data sharing terms")
-        if (it is GetDataSharingTermsUseCase.InvalidCustomSharingTermsException) {
-          ephemeralPopups.ErrorPopup().show(getString(R.string.invalid_data_sharing_terms))
-        }
+        ephemeralPopups
+          .ErrorPopup()
+          .show(
+            if (it is GetDataSharingTermsUseCase.InvalidCustomSharingTermsException) {
+              R.string.invalid_data_sharing_terms
+            } else {
+              R.string.something_went_wrong
+            }
+          )
       }
   }
 

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -40,6 +40,8 @@ import com.google.android.ground.ui.home.mapcontainer.jobs.SelectedLoiSheetData
 import com.google.android.ground.ui.map.Feature
 import com.google.android.ground.ui.map.FeatureType
 import com.google.android.ground.ui.map.isLocationOfInterest
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -57,8 +59,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @SharedViewModel

--- a/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/app/src/main/java/com/google/android/ground/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -161,7 +161,7 @@ internal constructor(
       }
   }
 
-  fun getDataSharingTerms(): DataSharingTerms? = getDataSharingTermsUseCase()
+  fun getDataSharingTerms(): Result<DataSharingTerms?> = getDataSharingTermsUseCase()
 
   /**
    * Returns a flow of [DataCollectionEntryPointData] associated with the active survey's LOIs and

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -200,4 +200,5 @@
   <string name="data_collection_cancellation_title">¿Quiere parar de recopilar datos?</string>
   <string name="data_collection_cancellation_description">Si sale, los datos que aún no hayan enviado se descartarán.</string>
   <string name="data_collection_cancellation_confirm_button">Confirmar</string>
+  <string name="something_went_wrong">algo salió mal</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -199,4 +199,5 @@
   <string name="data_collection_cancellation_title">Arrêter la collecte de données ?</string>
   <string name="data_collection_cancellation_description">Si vous quittez, les données que vous n&#8217;avez pas encore soumises seront supprimées.</string>
   <string name="data_collection_cancellation_confirm_button">Confirmer</string>
+  <string name="something_went_wrong">Quelque chose s&#8217;est mal passé</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -201,4 +201,5 @@
   <string name="data_collection_cancellation_title">Parar de coletar dados?</string>
   <string name="data_collection_cancellation_description">Se você sair, os dados que ainda não enviou serão descartados.</string>
   <string name="data_collection_cancellation_confirm_button">Confirmar</string>
+  <string name="something_went_wrong">Algo deu errado</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,4 +200,5 @@
   <string name="data_collection_cancellation_title">Stop collecting data?</string>
   <string name="data_collection_cancellation_description">If you exit, data you haven&#8217;t submitted yet will be discarded.</string>
   <string name="data_collection_cancellation_confirm_button">Confirm</string>
+  <string name="something_went_wrong">Something went wrong</string>
 </resources>

--- a/app/src/test/java/com/google/android/ground/domain/usecases/datasharingterms/GetDataSharingTermsUseCaseTest.kt
+++ b/app/src/test/java/com/google/android/ground/domain/usecases/datasharingterms/GetDataSharingTermsUseCaseTest.kt
@@ -83,6 +83,16 @@ class GetDataSharingTermsUseCaseTest : BaseHiltTest() {
   }
 
   @Test
+  fun `Succeeds with null if data sharing terms is missing`() {
+    activateSurvey(SURVEY.copy(dataSharingTerms = null))
+
+    val result = getDataSharingTermsUseCase()
+
+    assertThat(result.isSuccess).isTrue()
+    assertThat(result.getOrNull()).isNull()
+  }
+
+  @Test
   fun `Succeeds with data sharing terms if not already accepted`() {
     activateSurvey(SURVEY)
 

--- a/app/src/test/java/com/google/android/ground/domain/usecases/datasharingterms/GetDataSharingTermsUseCaseTest.kt
+++ b/app/src/test/java/com/google/android/ground/domain/usecases/datasharingterms/GetDataSharingTermsUseCaseTest.kt
@@ -25,22 +25,18 @@ import com.google.android.ground.proto.Survey.DataSharingTerms
 import com.google.android.ground.proto.SurveyKt.dataSharingTerms
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import javax.inject.Inject
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
 class GetDataSharingTermsUseCaseTest : BaseHiltTest() {
-  @Inject
-  lateinit var activateSurveyUseCase: ActivateSurveyUseCase
-  @Inject
-  lateinit var fakeRemoteDataStore: FakeRemoteDataStore
-  @Inject
-  lateinit var getDataSharingTermsUseCase: GetDataSharingTermsUseCase
-  @Inject
-  lateinit var localValueStore: LocalValueStore
+  @Inject lateinit var activateSurveyUseCase: ActivateSurveyUseCase
+  @Inject lateinit var fakeRemoteDataStore: FakeRemoteDataStore
+  @Inject lateinit var getDataSharingTermsUseCase: GetDataSharingTermsUseCase
+  @Inject lateinit var localValueStore: LocalValueStore
 
   private fun activateSurvey(survey: Survey) = runWithTestDispatcher {
     fakeRemoteDataStore.surveys = listOf(survey)
@@ -61,10 +57,10 @@ class GetDataSharingTermsUseCaseTest : BaseHiltTest() {
     val survey =
       SURVEY.copy(
         dataSharingTerms =
-        dataSharingTerms {
-          type = DataSharingTerms.Type.CUSTOM
-          customText = ""
-        }
+          dataSharingTerms {
+            type = DataSharingTerms.Type.CUSTOM
+            customText = ""
+          }
       )
     activateSurvey(survey)
 

--- a/app/src/test/java/com/google/android/ground/domain/usecases/datasharingterms/GetDataSharingTermsUseCaseTest.kt
+++ b/app/src/test/java/com/google/android/ground/domain/usecases/datasharingterms/GetDataSharingTermsUseCaseTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.ground.domain.usecases.datasharingterms
+
+import com.google.android.ground.BaseHiltTest
+import com.google.android.ground.FakeData.SURVEY
+import com.google.android.ground.domain.usecases.survey.ActivateSurveyUseCase
+import com.google.android.ground.persistence.local.LocalValueStore
+import com.google.android.ground.persistence.remote.FakeRemoteDataStore
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import javax.inject.Inject
+
+@HiltAndroidTest
+@RunWith(RobolectricTestRunner::class)
+class GetDataSharingTermsUseCaseTest : BaseHiltTest() {
+  @Inject
+  lateinit var activateSurvey: ActivateSurveyUseCase
+  @Inject
+  lateinit var fakeRemoteDataStore: FakeRemoteDataStore
+  @Inject
+  lateinit var getDataSharingTermsUseCase: GetDataSharingTermsUseCase
+  @Inject
+  lateinit var localValueStore: LocalValueStore
+
+  @Before
+  override fun setUp() {
+    super.setUp()
+    fakeRemoteDataStore.surveys = listOf(SURVEY)
+  }
+
+  @Test
+  fun `Returns null if no survey active`() = runWithTestDispatcher {
+    assertThat(getDataSharingTermsUseCase()).isNull()
+  }
+
+  @Test
+  fun `Returns null if data sharing terms is already accepted`() = runWithTestDispatcher {
+    activateSurvey(SURVEY.id)
+    localValueStore.setDataSharingConsent(SURVEY.id, true)
+
+    assertThat(getDataSharingTermsUseCase()).isNull()
+  }
+
+  @Test
+  fun `Returns data sharing terms if not already accepted`() = runWithTestDispatcher {
+    activateSurvey(SURVEY.id)
+
+    assertThat(getDataSharingTermsUseCase()).isEqualTo(SURVEY.dataSharingTerms)
+  }
+}


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3031

<!-- PR description. -->
Simplifies the logic for showing data sharing terms by replacing flows with getter and moving core logic to domain layer with unit tests.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001 @gino-m @sufyanAbbasi  PTAL?
