### PR TITLE
Hide close button after data is collected

### DIFF
--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -38,11 +38,11 @@ import com.google.android.ground.ui.compose.ConfirmationDialog
 import com.google.android.ground.ui.home.HomeScreenFragmentDirections
 import com.google.android.ground.util.renderComposableDialog
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /** Fragment allowing the user to collect data to complete a task. */
 @AndroidEntryPoint

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -196,7 +196,10 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
   }
 
   override fun onBack(): Boolean {
-    if (viewPager.currentItem == 0) {
+    if (viewModel.uiState.value == UiState.TaskSubmitted) {
+      // Pressing back button after submitting task should navigate back to home screen.
+      navigateBack()
+    } else if (viewPager.currentItem == 0) {
       showExitWarningDialog()
     } else {
       viewModel.moveToPreviousTask()
@@ -210,13 +213,15 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
         title = R.string.data_collection_cancellation_title,
         description = R.string.data_collection_cancellation_description,
         confirmButtonText = R.string.data_collection_cancellation_confirm_button,
-        onConfirmClicked = {
-          isNavigatingUp = true
-          viewModel.clearDraft()
-          findNavController().navigateUp()
-        },
+        onConfirmClicked = { navigateBack() },
       )
     }
+  }
+
+  private fun navigateBack() {
+    isNavigatingUp = true
+    viewModel.clearDraft()
+    findNavController().navigateUp()
   }
 
   private companion object {

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -38,11 +38,11 @@ import com.google.android.ground.ui.compose.ConfirmationDialog
 import com.google.android.ground.ui.home.HomeScreenFragmentDirections
 import com.google.android.ground.util.renderComposableDialog
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 /** Fragment allowing the user to collect data to complete a task. */
 @AndroidEntryPoint
@@ -164,7 +164,7 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
 
     // Display a confirmation dialog and move to home screen after that.
     renderComposableDialog {
-      DataSubmissionConfirmationDialog {
+      DataSubmissionConfirmationScreen {
         findNavController().navigate(HomeScreenFragmentDirections.showHomeScreen())
       }
     }

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -21,8 +21,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.constraintlayout.widget.Guideline
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnLayout
@@ -166,14 +164,8 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
 
     // Display a confirmation dialog and move to home screen after that.
     renderComposableDialog {
-      val openAlertDialog = remember { mutableStateOf(true) }
-      when {
-        openAlertDialog.value -> {
-          DataSubmissionConfirmationDialog {
-            openAlertDialog.value = false
-            findNavController().navigate(HomeScreenFragmentDirections.showHomeScreen())
-          }
-        }
+      DataSubmissionConfirmationDialog {
+        findNavController().navigate(HomeScreenFragmentDirections.showHomeScreen())
       }
     }
   }

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -40,11 +40,11 @@ import com.google.android.ground.ui.compose.ConfirmationDialog
 import com.google.android.ground.ui.home.HomeScreenFragmentDirections
 import com.google.android.ground.util.renderComposableDialog
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 /** Fragment allowing the user to collect data to complete a task. */
 @AndroidEntryPoint
@@ -161,6 +161,9 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
   }
 
   private fun onTaskSubmitted() {
+    // Hide close button
+    binding.dataCollectionToolbar.navigationIcon = null
+
     // Display a confirmation dialog and move to home screen after that.
     renderComposableDialog {
       val openAlertDialog = remember { mutableStateOf(true) }

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationDialog.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationDialog.kt
@@ -29,8 +29,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -50,32 +48,23 @@ import com.google.android.ground.ui.theme.AppTheme
 
 @Composable
 fun DataSubmissionConfirmationDialog(onDismissed: () -> Unit) {
-  val showDialog = remember { mutableStateOf(true) }
-
-  fun onCloseClicked() {
-    showDialog.value = false
-    onDismissed()
-  }
-
-  if (showDialog.value) {
-    if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-      Row(
-        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
-        horizontalArrangement = Arrangement.SpaceEvenly,
-        verticalAlignment = Alignment.CenterVertically,
-      ) {
-        DataSubmittedImage()
-        BodyContent { onCloseClicked() }
-      }
-    } else {
-      Column(
-        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
-        verticalArrangement = Arrangement.SpaceEvenly,
-        horizontalAlignment = Alignment.CenterHorizontally,
-      ) {
-        DataSubmittedImage()
-        BodyContent { onCloseClicked() }
-      }
+  if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+    Row(
+      modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+      horizontalArrangement = Arrangement.SpaceEvenly,
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      DataSubmittedImage()
+      BodyContent { onDismissed() }
+    }
+  } else {
+    Column(
+      modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+      verticalArrangement = Arrangement.SpaceEvenly,
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      DataSubmittedImage()
+      BodyContent { onDismissed() }
     }
   }
 }

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationDialog.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationDialog.kt
@@ -16,7 +16,6 @@
 package com.google.android.ground.ui.datacollection
 
 import android.content.res.Configuration
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -24,10 +23,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -51,45 +48,30 @@ import com.google.android.ground.ui.theme.AppTheme
 
 @Composable
 fun DataSubmissionConfirmationDialog(onDismiss: () -> Unit) {
-  val configuration = LocalConfiguration.current
-  if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+  if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
     Row(
       modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+      horizontalArrangement = Arrangement.SpaceEvenly,
       verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.Center,
     ) {
-      Column(
-        modifier = Modifier.weight(1f).wrapContentWidth(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-      ) {
-        DataCollectionThumbnail(modifier = Modifier.weight(0.8f))
-      }
-      Column(
-        modifier = Modifier.fillMaxSize().weight(1f),
-        verticalArrangement = Arrangement.Center,
-      ) {
-        DetailColumn()
-        Spacer(modifier = Modifier.height(24.dp))
-        CloseButton(modifier = Modifier.align(Alignment.CenterHorizontally), onDismiss = onDismiss)
-      }
+      DataSubmittedImage()
+      BodyContent(onDismiss)
     }
   } else {
-    Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
-      Spacer(modifier = Modifier.height(150.dp))
-      DataCollectionThumbnail(modifier = Modifier.padding(horizontal = 8.dp))
-      Spacer(modifier = Modifier.height(100.dp))
-      DetailColumn()
-      Spacer(modifier = Modifier.height(32.dp))
-      CloseButton(modifier = Modifier.align(Alignment.CenterHorizontally), onDismiss = onDismiss)
+    Column(
+      modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+      verticalArrangement = Arrangement.SpaceEvenly,
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      DataSubmittedImage()
+      BodyContent(onDismiss)
     }
   }
 }
 
 @Composable
-private fun DataCollectionThumbnail(modifier: Modifier = Modifier) {
+private fun DataSubmittedImage() {
   Image(
-    modifier = modifier,
     painter = painterResource(id = R.drawable.data_submitted),
     contentDescription = stringResource(R.string.data_submitted_image),
     contentScale = ContentScale.Fit,
@@ -97,11 +79,10 @@ private fun DataCollectionThumbnail(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun DetailColumn() {
-  Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+private fun BodyContent(onDismiss: () -> Unit) {
+  Column(horizontalAlignment = Alignment.CenterHorizontally) {
     Text(
       text = stringResource(R.string.data_collection_complete),
-      color = MaterialTheme.colorScheme.onSurface,
       fontFamily = FontFamily(Font(R.font.text_500)),
       lineHeight = 28.sp,
       fontSize = 22.sp,
@@ -114,27 +95,19 @@ private fun DetailColumn() {
       fontSize = 14.sp,
       lineHeight = 20.sp,
       fontWeight = FontWeight(400),
-      color = MaterialTheme.colorScheme.onSurface,
       fontFamily = FontFamily(Font(R.font.text_500)),
       textAlign = TextAlign.Center,
     )
-  }
-}
-
-@Composable
-private fun CloseButton(modifier: Modifier = Modifier, onDismiss: () -> Unit) {
-  OutlinedButton(
-    modifier = modifier,
-    border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outline),
-    onClick = { onDismiss() },
-  ) {
-    Text(
-      modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-      text = stringResource(id = R.string.close),
-      fontSize = 14.sp,
-      lineHeight = 20.sp,
-      fontFamily = FontFamily(Font(R.font.text_500)),
-    )
+    Spacer(modifier = Modifier.height(30.dp))
+    OutlinedButton(onClick = { onDismiss() }) {
+      Text(
+        modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+        text = stringResource(id = R.string.close),
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        fontFamily = FontFamily(Font(R.font.text_500)),
+      )
+    }
   }
 }
 

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationDialog.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationDialog.kt
@@ -29,6 +29,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -47,24 +49,33 @@ import com.google.android.ground.R
 import com.google.android.ground.ui.theme.AppTheme
 
 @Composable
-fun DataSubmissionConfirmationDialog(onDismiss: () -> Unit) {
-  if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-    Row(
-      modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
-      horizontalArrangement = Arrangement.SpaceEvenly,
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      DataSubmittedImage()
-      BodyContent(onDismiss)
-    }
-  } else {
-    Column(
-      modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
-      verticalArrangement = Arrangement.SpaceEvenly,
-      horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-      DataSubmittedImage()
-      BodyContent(onDismiss)
+fun DataSubmissionConfirmationDialog(onDismissed: () -> Unit) {
+  val showDialog = remember { mutableStateOf(true) }
+
+  fun onCloseClicked() {
+    showDialog.value = false
+    onDismissed()
+  }
+
+  if (showDialog.value) {
+    if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+      Row(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        DataSubmittedImage()
+        BodyContent { onCloseClicked() }
+      }
+    } else {
+      Column(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        verticalArrangement = Arrangement.SpaceEvenly,
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        DataSubmittedImage()
+        BodyContent { onCloseClicked() }
+      }
     }
   }
 }

--- a/app/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationScreen.kt
+++ b/app/src/main/java/com/google/android/ground/ui/datacollection/DataSubmissionConfirmationScreen.kt
@@ -47,7 +47,7 @@ import com.google.android.ground.R
 import com.google.android.ground.ui.theme.AppTheme
 
 @Composable
-fun DataSubmissionConfirmationDialog(onDismissed: () -> Unit) {
+fun DataSubmissionConfirmationScreen(onDismissed: () -> Unit) {
   if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
     Row(
       modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
@@ -115,6 +115,6 @@ private fun BodyContent(onDismiss: () -> Unit) {
 @Preview(heightDp = 320, widthDp = 800)
 @Preview
 @ExcludeFromJacocoGeneratedReport
-fun DataSubmissionConfirmationDialogPreview() {
-  AppTheme { DataSubmissionConfirmationDialog {} }
+fun DataSubmissionConfirmationScreenPreview() {
+  AppTheme { DataSubmissionConfirmationScreen {} }
 }

--- a/app/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/app/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -266,6 +266,28 @@ class DataCollectionFragmentTest : BaseHiltTest() {
   }
 
   @Test
+  fun `Displays close button on first task`() = runWithTestDispatcher {
+    setupFragment()
+
+    assertThat(getToolbar()?.navigationIcon).isNotNull()
+  }
+
+  @Test
+  fun `Clicking done on final task hides the navigation close button`() = runWithTestDispatcher {
+    setupFragment()
+
+    runner()
+      .inputText(TASK_1_RESPONSE)
+      .clickNextButton()
+      .validateTextIsNotDisplayed(TASK_1_NAME)
+      .validateTextIsDisplayed(TASK_2_NAME)
+      .selectOption(TASK_2_OPTION_LABEL)
+      .clickDoneButton() // Click "done" on final task
+
+    assertThat(getToolbar()?.navigationIcon).isNull()
+  }
+
+  @Test
   fun `Clicking done on final task saves the submission and LOI when LOI is not provided`() =
     runWithTestDispatcher {
       setupFragmentWithNoLoi()
@@ -486,6 +508,11 @@ class DataCollectionFragmentTest : BaseHiltTest() {
   }
 
   private fun runner() = TaskFragmentRunner(this, fragment)
+
+  private fun getToolbar() =
+    fragment.view?.findViewById<com.google.android.material.appbar.MaterialToolbar>(
+      R.id.data_collection_toolbar
+    )
 
   companion object {
     private const val TASK_ID_0 = "0"


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3050

<!-- PR description. -->
Things done in this PR:
 1. Hide the close button when displaying the confirmation screen
 2. Handle edge case for back press on confirmation screen to directly navigate up
 3. Simplify compose UI creation of the dialog

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
Tested locally

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
