### PR TITLE
Impose a character limit on text data responses.

### DIFF
--- a/app/src/main/java/org/groundplatform/android/Config.kt
+++ b/app/src/main/java/org/groundplatform/android/Config.kt
@@ -44,6 +44,9 @@ object Config {
    */
   const val CLUSTERING_ZOOM_THRESHOLD = 14f
 
+  /** Limit on the permitted character length for free text question responses. */
+  const val TEXT_DATA_CHAR_LIMIT = 255
+
   // TODO: Make sub-paths configurable and
   //  stop hardcoding here.
   // Issue URL: https://github.com/google/ground-android/issues/1730

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/components/TextTaskInput.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/components/TextTaskInput.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -27,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.groundplatform.android.Config
 import org.groundplatform.android.ExcludeFromJacocoGeneratedReport
 import org.groundplatform.android.ui.theme.AppTheme
 
@@ -38,6 +40,7 @@ fun TextTaskInput(
   valueChanged: (text: String) -> Unit = {},
 ) {
   TextField(
+    label = { Text("${value.length} / ${Config.TEXT_DATA_CHAR_LIMIT}") },
     value = value,
     onValueChange = { valueChanged(it) },
     modifier =

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/components/TextTaskInput.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/components/TextTaskInput.kt
@@ -15,17 +15,22 @@
  */
 package org.groundplatform.android.ui.datacollection.components
 
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.groundplatform.android.Config
@@ -39,17 +44,26 @@ fun TextTaskInput(
   keyboardType: KeyboardType = KeyboardType.Text,
   valueChanged: (text: String) -> Unit = {},
 ) {
-  TextField(
-    label = { Text("${value.length} / ${Config.TEXT_DATA_CHAR_LIMIT}") },
+  OutlinedTextField(
+    supportingText = {
+      Row(modifier = modifier.fillMaxWidth()) {
+        Spacer(modifier = modifier.weight(1f))
+        Text(
+          "${value.length} / ${Config.TEXT_DATA_CHAR_LIMIT}",
+          textAlign = TextAlign.End,
+        )
+      }
+    },
+    isError = value.length > Config.TEXT_DATA_CHAR_LIMIT,
     value = value,
     onValueChange = { valueChanged(it) },
     modifier =
-      modifier
-        .fillMaxWidth()
-        .wrapContentHeight(align = Alignment.Top)
-        // TODO: Add horizontal padding as 16.dp when global padding is removed.
-        // Issue URL: https://github.com/google/ground-android/issues/2976
-        .padding(vertical = 8.dp),
+    modifier
+      .fillMaxWidth()
+      .wrapContentHeight(align = Alignment.Top)
+      // TODO: Add horizontal padding as 16.dp when global padding is removed.
+      // Issue URL: https://github.com/google/ground-android/issues/2976
+      .padding(vertical = 8.dp),
     textStyle = MaterialTheme.typography.bodyLarge,
     singleLine = true,
     keyboardOptions = KeyboardOptions(keyboardType = keyboardType),

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/components/TextTaskInput.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/components/TextTaskInput.kt
@@ -27,9 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -48,22 +46,19 @@ fun TextTaskInput(
     supportingText = {
       Row(modifier = modifier.fillMaxWidth()) {
         Spacer(modifier = modifier.weight(1f))
-        Text(
-          "${value.length} / ${Config.TEXT_DATA_CHAR_LIMIT}",
-          textAlign = TextAlign.End,
-        )
+        Text("${value.length} / ${Config.TEXT_DATA_CHAR_LIMIT}", textAlign = TextAlign.End)
       }
     },
     isError = value.length > Config.TEXT_DATA_CHAR_LIMIT,
     value = value,
     onValueChange = { valueChanged(it) },
     modifier =
-    modifier
-      .fillMaxWidth()
-      .wrapContentHeight(align = Alignment.Top)
-      // TODO: Add horizontal padding as 16.dp when global padding is removed.
-      // Issue URL: https://github.com/google/ground-android/issues/2976
-      .padding(vertical = 8.dp),
+      modifier
+        .fillMaxWidth()
+        .wrapContentHeight(align = Alignment.Top)
+        // TODO: Add horizontal padding as 16.dp when global padding is removed.
+        // Issue URL: https://github.com/google/ground-android/issues/2976
+        .padding(vertical = 8.dp),
     textStyle = MaterialTheme.typography.bodyLarge,
     singleLine = true,
     keyboardOptions = KeyboardOptions(keyboardType = keyboardType),

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/AbstractTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/AbstractTaskViewModel.kt
@@ -44,6 +44,13 @@ open class AbstractTaskViewModel internal constructor() : AbstractViewModel() {
   /** Checks if the current value is valid and updates error value. */
   fun validate(): Int? = validate(task, taskTaskData.value)
 
+  /**
+   * Performs input validation on the given [Task] and associated [TaskData].
+   *
+   * Returns an [Int] identifier for an error string if validation fails, returns null otherwise.
+   * Subclasses may override this method to validate input data and display an error message to the
+   * user.
+   */
   open fun validate(task: Task, taskData: TaskData?): Int? {
     // Empty response for a required task.
     if (task.isRequired && (taskData == null || taskData.isEmpty())) {

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,6 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.groundplatform.android.Config
 import org.groundplatform.android.ExcludeFromJacocoGeneratedReport
 import org.groundplatform.android.R
 import org.groundplatform.android.model.task.MultipleChoice
@@ -98,6 +100,7 @@ fun MultipleChoiceItemView(
     if (item.isOtherOption) {
       Row(modifier = modifier.padding(horizontal = 48.dp)) {
         TextField(
+          label = { Text(text = "${item.otherText.length} / ${Config.TEXT_DATA_CHAR_LIMIT}") },
           value = item.otherText,
           textStyle = MaterialTheme.typography.bodyLarge,
           onValueChange = { otherValueChanged(it) },

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -106,7 +105,10 @@ fun MultipleChoiceItemView(
           supportingText = {
             Row(modifier = modifier.fillMaxWidth()) {
               Spacer(modifier = modifier.weight(1f))
-              Text("${item.otherText.length} / ${Config.TEXT_DATA_CHAR_LIMIT}", textAlign = TextAlign.End)
+              Text(
+                "${item.otherText.length} / ${Config.TEXT_DATA_CHAR_LIMIT}",
+                textAlign = TextAlign.End,
+              )
             }
           },
           isError = item.otherText.length > Config.TEXT_DATA_CHAR_LIMIT,

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
@@ -17,12 +17,14 @@ package org.groundplatform.android.ui.datacollection.tasks.multiplechoice
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -35,6 +37,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.groundplatform.android.Config
@@ -99,8 +102,14 @@ fun MultipleChoiceItemView(
 
     if (item.isOtherOption) {
       Row(modifier = modifier.padding(horizontal = 48.dp)) {
-        TextField(
-          label = { Text(text = "${item.otherText.length} / ${Config.TEXT_DATA_CHAR_LIMIT}") },
+        OutlinedTextField(
+          supportingText = {
+            Row(modifier = modifier.fillMaxWidth()) {
+              Spacer(modifier = modifier.weight(1f))
+              Text("${item.otherText.length} / ${Config.TEXT_DATA_CHAR_LIMIT}", textAlign = TextAlign.End)
+            }
+          },
+          isError = item.otherText.length > Config.TEXT_DATA_CHAR_LIMIT,
           value = item.otherText,
           textStyle = MaterialTheme.typography.bodyLarge,
           onValueChange = { otherValueChanged(it) },

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskViewModel.kt
@@ -60,8 +60,8 @@ class MultipleChoiceTaskViewModel @Inject constructor() : AbstractTaskViewModel(
   }
 
   override fun validate(task: Task, taskData: TaskData?): Int? {
-    if (task.type != Task.Type.MULTIPLE_CHOICE) return super.validate(task, taskData)
-    if (!selectedIds.contains(OTHER_ID)) return super.validate(task, taskData)
+    if (task.type != Task.Type.MULTIPLE_CHOICE || !selectedIds.contains(OTHER_ID))
+      return super.validate(task, taskData)
 
     if (otherText.length > Config.TEXT_DATA_CHAR_LIMIT)
       return R.string.text_task_data_character_limit

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskViewModel.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
+import org.groundplatform.android.Config
+import org.groundplatform.android.R
 import org.groundplatform.android.model.job.Job
 import org.groundplatform.android.model.submission.MultipleChoiceTaskData
 import org.groundplatform.android.model.submission.MultipleChoiceTaskData.Companion.fromList
@@ -55,6 +57,16 @@ class MultipleChoiceTaskViewModel @Inject constructor() : AbstractTaskViewModel(
     }
     updateResponse()
     updateMultipleChoiceItems()
+  }
+
+  override fun validate(task: Task, taskData: TaskData?): Int? {
+    if (task.type != Task.Type.MULTIPLE_CHOICE) return super.validate(task, taskData)
+    if (!selectedIds.contains(OTHER_ID)) return super.validate(task, taskData)
+
+    if (otherText.length > Config.TEXT_DATA_CHAR_LIMIT)
+      return R.string.text_task_data_character_limit
+
+    return super.validate(task, taskData)
   }
 
   /**

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/text/TextTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/text/TextTaskViewModel.kt
@@ -20,8 +20,11 @@ import androidx.lifecycle.asLiveData
 import javax.inject.Inject
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
+import org.groundplatform.android.Config
+import org.groundplatform.android.R
 import org.groundplatform.android.model.submission.TaskData
 import org.groundplatform.android.model.submission.TextTaskData
+import org.groundplatform.android.model.task.Task
 import org.groundplatform.android.ui.datacollection.tasks.AbstractTaskViewModel
 
 class TextTaskViewModel @Inject constructor() : AbstractTaskViewModel() {
@@ -29,4 +32,13 @@ class TextTaskViewModel @Inject constructor() : AbstractTaskViewModel() {
   /** Transcoded text to be displayed for the current [TaskData]. */
   val responseText: LiveData<String> =
     taskTaskData.filterIsInstance<TextTaskData?>().map { it?.text ?: "" }.asLiveData()
+
+  override fun validate(task: Task, taskData: TaskData?): Int? {
+    if (task.type != Task.Type.TEXT) return super.validate(task, taskData)
+
+    if ((taskData as TextTaskData).text.length > Config.TEXT_DATA_CHAR_LIMIT)
+      return R.string.text_task_data_character_limit
+
+    return super.validate(task, taskData)
+  }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,7 +206,7 @@
   <string name="polygon_vertex_add_dialog_message">Area permit can&#8217;t intersect with itself</string>
   <string name="polygon_vertex_add_dialog_positive_button">OK</string>
   <string name="clear">Clear</string>
-  <string name="text_task_data_character_limit">Please enter a value of 255 characters or less.</string>
+  <string name="text_task_data_character_limit">255 characters max</string>
 
   <string name="area_message">Area: %1$.2f m²</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,7 @@
   <string name="data_collection_cancellation_confirm_button">Confirm</string>
   <string name="something_went_wrong">Something went wrong</string>
   <string name="clear">Clear</string>
+  <string name="text_task_data_character_limit">Please enter a value of 255 characters or less.</string>
 
   <string name="area_message">Area: %1$.2f m²</string>
 </resources>

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
@@ -22,6 +22,8 @@ import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
+import org.groundplatform.android.Config
+import org.groundplatform.android.R
 import org.groundplatform.android.model.job.Job
 import org.groundplatform.android.model.submission.MultipleChoiceTaskData
 import org.groundplatform.android.model.task.MultipleChoice
@@ -31,6 +33,7 @@ import org.groundplatform.android.ui.common.ViewModelFactory
 import org.groundplatform.android.ui.datacollection.DataCollectionViewModel
 import org.groundplatform.android.ui.datacollection.components.ButtonAction
 import org.groundplatform.android.ui.datacollection.tasks.BaseTaskFragmentTest
+import org.groundplatform.android.ui.datacollection.tasks.text.TextTaskFragment
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -135,6 +138,21 @@ class MultipleChoiceTaskFragmentTest :
     runner().selectOption("Other").inputOtherText(userInput).assertButtonIsEnabled("Next")
 
     hasValue(MultipleChoiceTaskData(multipleChoice, listOf("[ $userInput ]")))
+  }
+
+  @Test
+  fun `text over the character limit is invalid`() = runWithTestDispatcher {
+    val multipleChoice = MultipleChoice(options, MultipleChoice.Cardinality.SELECT_MULTIPLE, true)
+    setupTaskFragment<MultipleChoiceTaskFragment>(
+      job,
+      task.copy(multipleChoice = multipleChoice, isRequired = true),
+    )
+    val userInput = "a".repeat(Config.TEXT_DATA_CHAR_LIMIT + 1)
+    // TODO: We should actually validate that the error toast is displayed after Next is clicked.
+    // Unfortunately, matching toasts with espresso is not straightforward, so we leave it at
+    // an explicit validation check for now.
+    runner().selectOption("Other").inputOtherText(userInput)
+    assertThat(viewModel.validate()).isEqualTo(R.string.text_task_data_character_limit)
   }
 
   @Test

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceTaskFragmentTest.kt
@@ -33,7 +33,6 @@ import org.groundplatform.android.ui.common.ViewModelFactory
 import org.groundplatform.android.ui.datacollection.DataCollectionViewModel
 import org.groundplatform.android.ui.datacollection.components.ButtonAction
 import org.groundplatform.android.ui.datacollection.tasks.BaseTaskFragmentTest
-import org.groundplatform.android.ui.datacollection.tasks.text.TextTaskFragment
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/text/TextTaskFragmentTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/text/TextTaskFragmentTest.kt
@@ -16,9 +16,12 @@
 
 package org.groundplatform.android.ui.datacollection.tasks.text
 
+import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
+import org.groundplatform.android.Config
+import org.groundplatform.android.R
 import org.groundplatform.android.model.job.Job
 import org.groundplatform.android.model.submission.TextTaskData
 import org.groundplatform.android.model.task.Task
@@ -78,6 +81,17 @@ class TextTaskFragmentTest : BaseTaskFragmentTest<TextTaskFragment, TextTaskView
       .assertButtonIsDisabled("Next")
 
     hasValue(null)
+  }
+
+  @Test
+  fun `text over the character limit is invalid`() = runWithTestDispatcher {
+    setupTaskFragment<TextTaskFragment>(job, task)
+
+    runner().inputText("a".repeat(Config.TEXT_DATA_CHAR_LIMIT + 1))
+    // TODO: We should actually validate that the error toast is displayed after Next is clicked.
+    // Unfortunately, matching toasts with espresso is not straightforward, so we leave it at
+    // an explicit validation check for now.
+    assertThat(viewModel.validate()).isEqualTo(R.string.text_task_data_character_limit)
   }
 
   @Test


### PR DESCRIPTION
This commit establishes an initial character limit for freeform text responses (including "other" entries for multiple choice questions). We set an initial limit of 255 characters, configurable in Config.kt. This commit also introduces an error message to indicate to users that they have hit the limit.

Fixes #2219 