### PR TITLE
Fix data loss when locking screen during data collection 

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionViewModel.kt
@@ -215,6 +215,7 @@ internal constructor(
 
       val taskData: TaskData? = if (shouldLoadFromDraft) getValueFromDraft(task) else null
       viewModel.initialize(job, task, taskData)
+      taskDataHandler.setData(task, taskData)
       viewModel
     } catch (e: Exception) {
       Timber.e("ignoring task with invalid type: $task.type")


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3081

<!-- PR description. -->
Store the value to TaskDataHandler whenever we are resuming the draft.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
I was able to reproduce the issue wherein the value for previous tasks was getting lost when locking and unlocking the screen multiple times. With this change, the data loss issue is no longer reproducible.

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001  PTAL?
