### PR TITLE
PhotoTask: Don't show draft toast on photo capture

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/home/HomeScreenFragment.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/home/HomeScreenFragment.kt
@@ -116,9 +116,15 @@ class HomeScreenFragment :
             )
           )
 
-        ephemeralPopups
-          .InfoPopup(binding.root, R.string.draft_restored, EphemeralPopups.PopupDuration.SHORT)
-          .show()
+        if (!homeScreenViewModel.awaitingPhotoCapture) {
+          ephemeralPopups
+            .InfoPopup(binding.root, R.string.draft_restored, EphemeralPopups.PopupDuration.SHORT)
+            .show()
+        } else {
+          // We're restoring after an instantaneous photo capture for a photo task; don't show a
+          // draft restored toast.
+          homeScreenViewModel.awaitingPhotoCapture = false
+        }
       }
     }
 

--- a/app/src/main/java/org/groundplatform/android/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/home/HomeScreenViewModel.kt
@@ -37,7 +37,7 @@ import org.groundplatform.android.ui.common.AbstractViewModel
 import org.groundplatform.android.ui.common.SharedViewModel
 import timber.log.Timber
 
-private const val WAITING_PHOTO_CAPTURE_KEY = "awaiting_photo_capture"
+private const val AWAITING_PHOTO_CAPTURE_KEY = "awaiting_photo_capture"
 
 @SharedViewModel
 class HomeScreenViewModel
@@ -67,9 +67,9 @@ internal constructor(
    * does not prove simple.
    * */
   var awaitingPhotoCapture: Boolean
-    get() = savedStateHandle[WAITING_PHOTO_CAPTURE_KEY] ?: false
+    get() = savedStateHandle[AWAITING_PHOTO_CAPTURE_KEY] ?: false
     set(newValue) {
-      savedStateHandle[WAITING_PHOTO_CAPTURE_KEY] = newValue
+      savedStateHandle[AWAITING_PHOTO_CAPTURE_KEY] = newValue
     }
 
   init {

--- a/app/src/main/java/org/groundplatform/android/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/home/HomeScreenViewModel.kt
@@ -17,6 +17,7 @@ package org.groundplatform.android.ui.home
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -36,6 +37,8 @@ import org.groundplatform.android.ui.common.AbstractViewModel
 import org.groundplatform.android.ui.common.SharedViewModel
 import timber.log.Timber
 
+private const val WAITING_PHOTO_CAPTURE_KEY = "awaiting_photo_capture"
+
 @SharedViewModel
 class HomeScreenViewModel
 @Inject
@@ -49,12 +52,25 @@ internal constructor(
   val userRepository: UserRepository,
 ) : AbstractViewModel() {
 
+  private val savedStateHandle: SavedStateHandle = SavedStateHandle()
   private val _openDrawerRequests: MutableSharedFlow<Unit> = MutableSharedFlow()
   val openDrawerRequestsFlow: SharedFlow<Unit> = _openDrawerRequests.asSharedFlow()
 
   // TODO: Allow tile source configuration from a non-survey accessible source.
   // Issue URL: https://github.com/google/ground-android/issues/1730
   val showOfflineAreaMenuItem: LiveData<Boolean> = MutableLiveData(true)
+
+  /* Indicates the application is being restored after a photo capture.
+   *
+   * We need to persist this state here to control [HomeScreenFragement] UI treatments when returning
+   * from a photo capture task—we do it this way because saving instance state bundles across fragments
+   * does not prove simple.
+   * */
+  var awaitingPhotoCapture: Boolean
+    get() = savedStateHandle[WAITING_PHOTO_CAPTURE_KEY] ?: false
+    set(newValue) {
+      savedStateHandle[WAITING_PHOTO_CAPTURE_KEY] = newValue
+    }
 
   init {
     viewModelScope.launch { kickLocalMutationSyncWorkers() }


### PR DESCRIPTION
This PR adds a new flag to track whether or not we are restoring the application from an instantaneous photo capture. If so, we do not bother showing the draft resotred toast.

Since the HomeScreenFragment controls the toast display, we unfortunately need to track this state as shared state in the HomeScreenVM, giving access to this state in the PhotoTaskFragment. We might want to consider moving the toast display into the Task fragments themselves to better encapsulate this state in the future.

Fixes #3080

@gino-m 
