### PR TITLE
Refactor database and worker classes to use IoDispatcher for coroutine context

### DIFF
--- a/app/src/main/java/org/groundplatform/android/persistence/sync/LocalMutationSyncWorker.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/sync/LocalMutationSyncWorker.kt
@@ -23,8 +23,9 @@ import androidx.work.ListenableWorker.Result.success
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.groundplatform.android.coroutines.IoDispatcher
 import org.groundplatform.android.model.mutation.Mutation
 import org.groundplatform.android.persistence.remote.RemoteDataStore
 import org.groundplatform.android.repository.MutationRepository
@@ -46,10 +47,11 @@ constructor(
   private val remoteDataStore: RemoteDataStore,
   private val mediaUploadWorkManager: MediaUploadWorkManager,
   private val userRepository: UserRepository,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : CoroutineWorker(context, params) {
 
   override suspend fun doWork(): Result =
-    withContext(Dispatchers.IO) {
+    withContext(ioDispatcher) {
       val queue = mutationRepository.getIncompleteUploads()
       Timber.d("Uploading ${queue.size} additions / changes")
       val results = queue.map { processMutations(it.mutations()) }

--- a/app/src/main/java/org/groundplatform/android/persistence/sync/MediaUploadWorker.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/sync/MediaUploadWorker.kt
@@ -24,8 +24,9 @@ import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.io.FileNotFoundException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.groundplatform.android.coroutines.IoDispatcher
 import org.groundplatform.android.model.mutation.SubmissionMutation
 import org.groundplatform.android.model.submission.PhotoTaskData
 import org.groundplatform.android.persistence.remote.RemoteStorageManager
@@ -52,10 +53,11 @@ constructor(
   private val remoteStorageManager: RemoteStorageManager,
   private val mutationRepository: MutationRepository,
   private val userMediaRepository: UserMediaRepository,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : CoroutineWorker(context, workerParams) {
 
   override suspend fun doWork(): Result =
-    withContext(Dispatchers.IO) {
+    withContext(ioDispatcher) {
       val mutations = mutationRepository.getIncompleteMediaMutations()
       Timber.d("Uploading photos for ${mutations.size} submission mutations")
       val results = mutations.map { uploadAllMedia(it) }

--- a/app/src/main/java/org/groundplatform/android/persistence/sync/SurveySyncWorker.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/sync/SurveySyncWorker.kt
@@ -26,8 +26,9 @@ import androidx.work.ListenableWorker.Result.success
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.groundplatform.android.coroutines.IoDispatcher
 import org.groundplatform.android.usecases.survey.SyncSurveyUseCase
 import timber.log.Timber
 
@@ -39,10 +40,11 @@ constructor(
   @Assisted context: Context,
   @Assisted params: WorkerParameters,
   private val syncSurvey: SyncSurveyUseCase,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : CoroutineWorker(context, params) {
   private val surveyId: String? = params.inputData.getString(SURVEY_ID_PARAM_KEY)
 
-  override suspend fun doWork(): Result = withContext(Dispatchers.IO) { doWorkInternal() }
+  override suspend fun doWork(): Result = withContext(ioDispatcher) { doWorkInternal() }
 
   private suspend fun doWorkInternal(): Result {
     if (surveyId == null) {

--- a/app/src/test/java/org/groundplatform/android/persistence/sync/LocalMutationSyncWorkerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/persistence/sync/LocalMutationSyncWorkerTest.kt
@@ -27,10 +27,12 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.groundplatform.android.BaseHiltTest
 import org.groundplatform.android.FakeData
+import org.groundplatform.android.coroutines.IoDispatcher
 import org.groundplatform.android.model.geometry.Point
 import org.groundplatform.android.model.mutation.LocationOfInterestMutation
 import org.groundplatform.android.model.mutation.Mutation
@@ -78,6 +80,8 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
 
   @Inject lateinit var userRepository: UserRepository
 
+  @Inject @IoDispatcher lateinit var ioDispatcher: CoroutineDispatcher
+
   private val factory =
     object : WorkerFactory() {
       override fun createWorker(
@@ -92,6 +96,7 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
           fakeRemoteDataStore,
           mockMediaUploadWorkManager,
           userRepository,
+          ioDispatcher,
         )
     }
 

--- a/app/src/test/java/org/groundplatform/android/persistence/sync/MediaUploadWorkerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/persistence/sync/MediaUploadWorkerTest.kt
@@ -23,13 +23,13 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.google.common.truth.Truth.assertWithMessage
-import com.google.firebase.crashlytics.FirebaseCrashlytics
-import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import org.groundplatform.android.BaseHiltTest
 import org.groundplatform.android.FakeData
+import org.groundplatform.android.coroutines.IoDispatcher
 import org.groundplatform.android.model.mutation.Mutation
 import org.groundplatform.android.model.mutation.Mutation.SyncStatus.COMPLETED
 import org.groundplatform.android.model.mutation.Mutation.SyncStatus.FAILED
@@ -55,7 +55,6 @@ import org.groundplatform.android.repository.UserMediaRepository
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
 import org.robolectric.RobolectricTestRunner
 
 @HiltAndroidTest
@@ -70,7 +69,7 @@ class MediaUploadWorkerTest : BaseHiltTest() {
   @Inject lateinit var localUserStore: LocalUserStore
   @Inject lateinit var localSurveyStore: LocalSurveyStore
   @Inject lateinit var localLocationOfInterestStore: LocalLocationOfInterestStore
-  @BindValue @Mock lateinit var mockFirebaseCrashlytics: FirebaseCrashlytics
+  @Inject @IoDispatcher lateinit var ioDispatcher: CoroutineDispatcher
 
   private val factory =
     object : WorkerFactory() {
@@ -85,6 +84,7 @@ class MediaUploadWorkerTest : BaseHiltTest() {
           fakeRemoteStorageManager,
           mutationRepository,
           userMediaRepository,
+          ioDispatcher,
         )
     }
 

--- a/app/src/test/java/org/groundplatform/android/persistence/sync/SurveySyncServiceTest.kt
+++ b/app/src/test/java/org/groundplatform/android/persistence/sync/SurveySyncServiceTest.kt
@@ -29,10 +29,12 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.groundplatform.android.BaseHiltTest
 import org.groundplatform.android.FakeData.SURVEY
+import org.groundplatform.android.coroutines.IoDispatcher
 import org.groundplatform.android.usecases.survey.SyncSurveyUseCase
 import org.junit.Before
 import org.junit.Test
@@ -46,6 +48,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class SurveySyncServiceTest : BaseHiltTest() {
   @Inject @ApplicationContext lateinit var context: Context
+  @Inject @IoDispatcher lateinit var ioDispatcher: CoroutineDispatcher
   @BindValue @Mock lateinit var syncSurvey: SyncSurveyUseCase
 
   private lateinit var workManager: WorkManager
@@ -65,7 +68,7 @@ class SurveySyncServiceTest : BaseHiltTest() {
               appContext: Context,
               workerClassName: String,
               workerParameters: WorkerParameters,
-            ) = SurveySyncWorker(context, workerParameters, syncSurvey)
+            ) = SurveySyncWorker(context, workerParameters, syncSurvey, ioDispatcher)
           }
         )
         .build()

--- a/app/src/test/java/org/groundplatform/android/persistence/sync/SurveySyncWorkerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/persistence/sync/SurveySyncWorkerTest.kt
@@ -27,8 +27,11 @@ import androidx.work.workDataOf
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import org.groundplatform.android.BaseHiltTest
 import org.groundplatform.android.FakeData.SURVEY
+import org.groundplatform.android.coroutines.IoDispatcher
 import org.groundplatform.android.persistence.sync.SurveySyncWorker.Companion.SURVEY_ID_PARAM_KEY
 import org.groundplatform.android.usecases.survey.SyncSurveyUseCase
 import org.junit.Before
@@ -44,13 +47,15 @@ class SurveySyncWorkerTest : BaseHiltTest() {
   private lateinit var context: Context
   @BindValue @Mock lateinit var syncSurvey: SyncSurveyUseCase
 
+  @Inject @IoDispatcher lateinit var ioDispatcher: CoroutineDispatcher
+
   private val factory =
     object : WorkerFactory() {
       override fun createWorker(
         appContext: Context,
         workerClassName: String,
         workerParameters: WorkerParameters,
-      ) = SurveySyncWorker(appContext, workerParameters, syncSurvey)
+      ) = SurveySyncWorker(appContext, workerParameters, syncSurvey, ioDispatcher)
     }
 
   @Before


### PR DESCRIPTION
Fixes https://github.com/google/ground-android/issues/3097

Refactor database and worker classes to use IoDispatcher for coroutine context

PR description:

Refactored database and worker classes to use IoDispatcher for coroutine context instead of relying on default dispatchers or hardcoded executors. This ensures that I/O operations, such as database queries and background work, are executed on a thread pool optimized for I/O, improving performance and consistency across the application.

Checklist:

Refactored LocalDatabaseModule to continue using IoDispatcher for setQueryExecutor
Refactored LocalMutationSyncWorker.ktMediaUploadWorker/SurveySyncWorker/ to inject and use IoDispatcher instead of Dispatchers.IO