### PR TITLE
Refactor: Replace check for invalid addLoiTask using task type instead of task value

### DIFF
--- a/app/src/main/java/org/groundplatform/android/model/job/Job.kt
+++ b/app/src/main/java/org/groundplatform/android/model/job/Job.kt
@@ -52,9 +52,6 @@ data class Job(
       .apply { check(size <= 1) { "Expected 0 or 1, found $size AddLoiTasks" } }
       .firstOrNull()
 
-  /** Returns true if the job has one or more tasks. */
-  fun hasTasks() = tasks.values.isNotEmpty()
-
   /** Returns whether the job has non-LOI tasks. */
   fun hasNonLoiTasks() = tasks.values.count { !it.isAddLoiTask } > 0
 }

--- a/app/src/test/java/org/groundplatform/android/FakeData.kt
+++ b/app/src/test/java/org/groundplatform/android/FakeData.kt
@@ -15,6 +15,7 @@
  */
 package org.groundplatform.android
 
+import java.util.Date
 import org.groundplatform.android.model.AuditInfo
 import org.groundplatform.android.model.Survey
 import org.groundplatform.android.model.TermsOfService
@@ -40,7 +41,6 @@ import org.groundplatform.android.ui.map.Bounds
 import org.groundplatform.android.ui.map.Feature
 import org.groundplatform.android.ui.map.FeatureType
 import org.groundplatform.android.ui.map.gms.features.FeatureClusterItem
-import java.util.Date
 
 /**
  * Shared test data constants. Tests are expected to override existing or set missing values when

--- a/app/src/test/java/org/groundplatform/android/FakeData.kt
+++ b/app/src/test/java/org/groundplatform/android/FakeData.kt
@@ -15,7 +15,6 @@
  */
 package org.groundplatform.android
 
-import java.util.Date
 import org.groundplatform.android.model.AuditInfo
 import org.groundplatform.android.model.Survey
 import org.groundplatform.android.model.TermsOfService
@@ -41,6 +40,7 @@ import org.groundplatform.android.ui.map.Bounds
 import org.groundplatform.android.ui.map.Feature
 import org.groundplatform.android.ui.map.FeatureType
 import org.groundplatform.android.ui.map.gms.features.FeatureClusterItem
+import java.util.Date
 
 /**
  * Shared test data constants. Tests are expected to override existing or set missing values when
@@ -155,7 +155,17 @@ object FakeData {
     id: String = "",
     type: Task.Type = Task.Type.TEXT,
     multipleChoice: MultipleChoice? = null,
-  ): Task = Task(id, 0, type, "", false, multipleChoice)
+    isAddLoiTask: Boolean = false,
+  ): Task =
+    Task(
+      id = id,
+      index = 0,
+      type = type,
+      label = "",
+      isRequired = false,
+      multipleChoice = multipleChoice,
+      isAddLoiTask = isAddLoiTask,
+    )
 
   fun newLoiMutation(
     point: Point,

--- a/app/src/test/java/org/groundplatform/android/usecases/submission/SubmitDataUseCaseTest.kt
+++ b/app/src/test/java/org/groundplatform/android/usecases/submission/SubmitDataUseCaseTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.usecases.submission
+
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
+import kotlin.test.assertFailsWith
+import org.groundplatform.android.BaseHiltTest
+import org.groundplatform.android.FakeData.newTask
+import org.groundplatform.android.model.job.Job
+import org.groundplatform.android.model.submission.ValueDelta
+import org.groundplatform.android.model.task.Task
+import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@HiltAndroidTest
+@RunWith(RobolectricTestRunner::class)
+class SubmitDataUseCaseTest : BaseHiltTest() {
+
+  @Inject lateinit var localSurveyStore: LocalSurveyStore
+  @Inject lateinit var submitDataUseCase: SubmitDataUseCase
+
+  @Test
+  fun `Invoke with invalid AddLoi task type throws error`() {
+    val task = newTask(id = "1", type = Task.Type.TEXT, isAddLoiTask = true)
+    val taskValue = ValueDelta(taskId = task.id, taskType = task.type, newTaskData = null)
+
+    val exception =
+      assertFailsWith<IllegalStateException> {
+        runWithTestDispatcher {
+          submitDataUseCase.invoke(
+            selectedLoiId = null,
+            job = Job(id = "1", tasks = mapOf(task.id to task)),
+            surveyId = "survey",
+            deltas = listOf(taskValue),
+            loiName = null,
+            collectionId = "",
+          )
+        }
+      }
+
+    assertThat(exception.message).isEqualTo("Invalid AddLoi task")
+  }
+}

--- a/app/src/test/java/org/groundplatform/android/usecases/submission/SubmitDataUseCaseTest.kt
+++ b/app/src/test/java/org/groundplatform/android/usecases/submission/SubmitDataUseCaseTest.kt
@@ -24,7 +24,6 @@ import org.groundplatform.android.FakeData.newTask
 import org.groundplatform.android.model.job.Job
 import org.groundplatform.android.model.submission.ValueDelta
 import org.groundplatform.android.model.task.Task
-import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -33,7 +32,6 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class SubmitDataUseCaseTest : BaseHiltTest() {
 
-  @Inject lateinit var localSurveyStore: LocalSurveyStore
   @Inject lateinit var submitDataUseCase: SubmitDataUseCase
 
   @Test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2981 

<!-- PR description. -->
This caused an issue when AddLocationTask's value was also of type geometry, causing it to be considered as valid AddLoi task.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001  PTAL?
