### PR TITLE
[Code health] Access remote data store via mutation repository

### DIFF
--- a/app/src/main/java/org/groundplatform/android/persistence/remote/firebase/FirestoreDataStore.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/remote/firebase/FirestoreDataStore.kt
@@ -103,6 +103,9 @@ internal constructor(
   override suspend fun applyMutations(mutations: List<Mutation>, user: User) {
     val batch = db().batch()
     for (mutation in mutations) {
+      check(mutation.userId == user.id) {
+        "Expected user ${mutation.userId} but found ${user.id} when uploading mutation"
+      }
       when (mutation) {
         is LocationOfInterestMutation -> addLocationOfInterestMutationToBatch(mutation, user, batch)
         is SubmissionMutation -> addSubmissionMutationToBatch(mutation, user, batch)

--- a/app/src/test/java/org/groundplatform/android/persistence/sync/LocalMutationSyncWorkerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/persistence/sync/LocalMutationSyncWorkerTest.kt
@@ -93,9 +93,7 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
           appContext,
           workerParameters,
           mutationRepository,
-          fakeRemoteDataStore,
           mockMediaUploadWorkManager,
-          userRepository,
           ioDispatcher,
         )
     }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2883

<!-- PR description. -->
Access data layer via repository.

Also adds a safety check to prevent uploading of mutations from another user account.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->


