### PR TITLE
Save incomplete DrawAreaTask progress

### DIFF
--- a/app/src/main/java/org/groundplatform/android/persistence/local/room/entity/GeometryWrapper.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/local/room/entity/GeometryWrapper.kt
@@ -16,6 +16,7 @@
 package org.groundplatform.android.persistence.local.room.entity
 
 import org.groundplatform.android.model.geometry.Geometry
+import org.groundplatform.android.model.geometry.LineString
 import org.groundplatform.android.model.geometry.MultiPolygon
 import org.groundplatform.android.model.geometry.Point
 import org.groundplatform.android.model.geometry.Polygon
@@ -27,9 +28,11 @@ data class GeometryWrapper(
   val polygon: Polygon? = null,
   /** Non-null iff this geometry is a multi-polygon. */
   val multiPolygon: MultiPolygon? = null,
+  /** Non-null iff this geometry is a line-string. */
+  val linestring: LineString? = null,
 ) {
 
-  fun getGeometry(): Geometry = point ?: polygon ?: multiPolygon!!
+  fun getGeometry(): Geometry = point ?: polygon ?: multiPolygon ?: linestring!!
 
   companion object {
     fun fromGeometry(geometry: Geometry?): GeometryWrapper =
@@ -37,6 +40,7 @@ data class GeometryWrapper(
         is Point -> GeometryWrapper(point = geometry)
         is Polygon -> GeometryWrapper(polygon = geometry)
         is MultiPolygon -> GeometryWrapper(multiPolygon = geometry)
+        is LineString -> GeometryWrapper(linestring = geometry)
         else -> error("No matching geometry found")
       }
   }

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionViewModel.kt
@@ -274,11 +274,6 @@ internal constructor(
     val taskId = getCurrentTaskId()
     val viewModel = getTaskViewModel(taskId) ?: error("ViewModel not found for task $taskId")
 
-    viewModel.validate()?.let {
-      Timber.d("Ignoring task $taskId with invalid data")
-      return
-    }
-
     taskDataHandler.setData(viewModel.task, viewModel.taskTaskData.value)
     savedStateHandle[TASK_POSITION_ID] = taskId
     saveDraft(taskId)

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
@@ -95,17 +95,27 @@ internal constructor(
   override fun initialize(job: Job, task: Task, taskData: TaskData?) {
     super.initialize(job, task, taskData)
     strokeColor = job.getDefaultColor()
-    (taskData as? DrawAreaTaskData)?.let {
-      updateVertices(it.area.getShellCoordinates())
-      try {
-        completePolygon()
-      } catch (e: IllegalStateException) {
-        // This state can theoretically happen if the coordinates form an incomplete ring, but
-        // construction of a DrawAreaTaskData is impossible without a complete ring anyway so it is
-        // unlikely to happen. This can also happen if `isMarkedComplete` is true at initialization
-        // time, which is also unlikely.
-        Timber.e(e, "Error when loading draw area from saved state")
-        updateVertices(listOf())
+
+    // Apply saved state if it exists.
+    when (taskData) {
+      is DrawAreaTaskIncompleteData -> {
+        updateVertices(taskData.lineString.coordinates)
+      }
+
+      is DrawAreaTaskData -> {
+        updateVertices(taskData.area.getShellCoordinates())
+        try {
+          completePolygon()
+        } catch (e: IllegalStateException) {
+          // This state can theoretically happen if the coordinates form an incomplete ring, but
+          // construction of a DrawAreaTaskData is impossible without a complete ring anyway so it
+          // is
+          // unlikely to happen. This can also happen if `isMarkedComplete` is true at
+          // initialization
+          // time, which is also unlikely.
+          Timber.e(e, "Error when loading draw area from saved state")
+          updateVertices(listOf())
+        }
       }
     }
   }


### PR DESCRIPTION

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3081

<!-- PR description. -->
This commit introduces the ability to save incomplete progress for DrawAreaTasks.

- Adds `LineString` support to `GeometryWrapper`.
- Introduces `DrawAreaTaskIncompleteData` to store the `LineString` geometry for incomplete drawings.
- Updates `ValueJsonConverter` to handle `DrawAreaTaskIncompleteData` during conversion to and from JSON.
- Modifies `DrawAreaTaskViewModel` to load incomplete data if available during initialization.
- Removes validation call in `DataCollectionViewModel to prevent skipping of invalid data


<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

https://github.com/user-attachments/assets/a180c150-a97f-4e0f-8f60-79f58c87e1f6



<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
