### PR TITLE
Replace chained shared preferences edits with kotlin KTX extension function

### DIFF
--- a/app/src/main/java/org/groundplatform/android/persistence/local/LocalValueStore.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/local/LocalValueStore.kt
@@ -16,6 +16,7 @@
 package org.groundplatform.android.persistence.local
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -48,9 +49,7 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
    */
   var lastActiveSurveyId: String
     get() = allowThreadDiskReads { preferences.getString(ACTIVE_SURVEY_ID_KEY, "").orEmpty() }
-    set(id) = allowThreadDiskWrites {
-      preferences.edit().putString(ACTIVE_SURVEY_ID_KEY, id).apply()
-    }
+    set(id) = allowThreadDiskWrites { preferences.edit { putString(ACTIVE_SURVEY_ID_KEY, id) } }
 
   /** The last map type selected. */
   var mapType: MapType
@@ -59,7 +58,7 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
       MapType.entries[mapTypeIdx]
     }
     set(value) = allowThreadDiskWrites {
-      preferences.edit().putInt(MAP_TYPE, value.ordinal).apply()
+      preferences.edit { putInt(MAP_TYPE, value.ordinal) }
       _mapType.update { value }
     }
 
@@ -67,21 +66,19 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
   var isLocationLockEnabled: Boolean
     get() = allowThreadDiskReads { preferences.getBoolean(LOCATION_LOCK_ENABLED, false) }
     set(value) = allowThreadDiskWrites {
-      preferences.edit().putBoolean(LOCATION_LOCK_ENABLED, value).apply()
+      preferences.edit { putBoolean(LOCATION_LOCK_ENABLED, value) }
     }
 
   /** Terms of service acceptance state for the currently signed in user. */
   var isTermsOfServiceAccepted: Boolean
     get() = allowThreadDiskReads { preferences.getBoolean(TOS_ACCEPTED, false) }
-    set(value) = allowThreadDiskWrites {
-      preferences.edit().putBoolean(TOS_ACCEPTED, value).apply()
-    }
+    set(value) = allowThreadDiskWrites { preferences.edit { putBoolean(TOS_ACCEPTED, value) } }
 
   /** Whether to overlay offline map imagery. */
   var isOfflineImageryEnabled: Boolean
     get() = allowThreadDiskReads { preferences.getBoolean(OFFLINE_MAP_IMAGERY, true) }
     set(value) = allowThreadDiskReads {
-      preferences.edit().putBoolean(OFFLINE_MAP_IMAGERY, value).apply()
+      preferences.edit { putBoolean(OFFLINE_MAP_IMAGERY, value) }
       _offlineImageryEnabled.update { value }
     }
 
@@ -89,24 +86,22 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
   var drawAreaInstructionsShown: Boolean
     get() = allowThreadDiskReads { preferences.getBoolean(DRAW_AREA_INSTRUCTIONS_SHOWN, false) }
     set(value) = allowThreadDiskReads {
-      preferences.edit().putBoolean(DRAW_AREA_INSTRUCTIONS_SHOWN, value).apply()
+      preferences.edit { putBoolean(DRAW_AREA_INSTRUCTIONS_SHOWN, value) }
     }
 
   /** Whether to display instructions when loading a drop pin task. */
   var dropPinInstructionsShown: Boolean
     get() = allowThreadDiskReads { preferences.getBoolean(DROP_PIN_INSTRUCTIONS_SHOWN, false) }
     set(value) = allowThreadDiskReads {
-      preferences.edit().putBoolean(DROP_PIN_INSTRUCTIONS_SHOWN, value).apply()
+      preferences.edit { putBoolean(DROP_PIN_INSTRUCTIONS_SHOWN, value) }
     }
 
   var draftSubmissionId: String?
     get() = allowThreadDiskReads { preferences.getString(DRAFT_SUBMISSION_ID, null) }
-    set(value) = allowThreadDiskReads {
-      preferences.edit().putString(DRAFT_SUBMISSION_ID, value).apply()
-    }
+    set(value) = allowThreadDiskReads { preferences.edit { putString(DRAFT_SUBMISSION_ID, value) } }
 
   /** Removes all values stored in the local store. */
-  fun clear() = allowThreadDiskWrites { preferences.edit().clear().apply() }
+  fun clear() = allowThreadDiskWrites { preferences.edit { clear() } }
 
   fun shouldUploadMediaOverUnmeteredConnectionOnly(): Boolean = allowThreadDiskReads {
     preferences.getBoolean(Keys.UPLOAD_MEDIA, false)
@@ -114,10 +109,7 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
 
   fun setLastCameraPosition(surveyId: String, cameraPosition: CameraPosition) =
     allowThreadDiskReads {
-      preferences
-        .edit()
-        .putString(LAST_VIEWPORT_PREFIX + surveyId, cameraPosition.serialize())
-        .apply()
+      preferences.edit { putString(LAST_VIEWPORT_PREFIX + surveyId, cameraPosition.serialize()) }
     }
 
   fun getLastCameraPosition(surveyId: String): CameraPosition? = allowThreadDiskReads {
@@ -134,7 +126,7 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
   }
 
   fun setDataSharingConsent(surveyId: String, consent: Boolean) {
-    preferences.edit().putBoolean(DATA_SHARING_CONSENT_PREFIX + surveyId, consent).apply()
+    preferences.edit { putBoolean(DATA_SHARING_CONSENT_PREFIX + surveyId, consent) }
   }
 
   fun getDataSharingConsent(surveyId: String): Boolean = allowThreadDiskReads {

--- a/app/src/test/java/org/groundplatform/android/MainViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/MainViewModelTest.kt
@@ -16,6 +16,7 @@
 package org.groundplatform.android
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.firestore.FirebaseFirestoreException
@@ -55,7 +56,7 @@ class MainViewModelTest : BaseHiltTest() {
   }
 
   private fun setupUserPreferences() {
-    sharedPreferences.edit().putString("foo", "bar").apply()
+    sharedPreferences.edit { putString("foo", "bar") }
   }
 
   private fun verifyUserPreferencesCleared() {


### PR DESCRIPTION

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Doesn't change any behavior. Replaces current usages of .edit() with a more idiomatic method.

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
