### PR TITLE
Refactor survey use cases to use SurveyRepository

### DIFF
--- a/app/src/main/java/org/groundplatform/android/repository/LocationOfInterestRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/LocationOfInterestRepository.kt
@@ -94,9 +94,9 @@ constructor(
     val locationOfInterest = survey?.let { localLoiStore.getLocationOfInterest(it, loiId) }
 
     if (survey == null) {
-      Timber.e("LocationOfInterestRepository", "Survey not found: $surveyId")
+      Timber.e("Survey not found: $surveyId")
     } else if (locationOfInterest == null) {
-      Timber.e("LocationRepository", "LOI not found for survey $surveyId: LOI ID $loiId")
+      Timber.e("LOI not found for survey $surveyId: LOI ID $loiId")
     }
     return locationOfInterest
   }

--- a/app/src/main/java/org/groundplatform/android/repository/SurveyRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/SurveyRepository.kt
@@ -61,10 +61,15 @@ constructor(
   val activeSurvey: Survey?
     get() = activeSurveyFlow.value
 
-  /**
-   * Returns the survey with the specified id from the local db, or `null` if not available offline.
-   */
+  suspend fun saveSurvey(survey: Survey) = localSurveyStore.insertOrUpdateSurvey(survey)
+
   suspend fun getOfflineSurvey(surveyId: String): Survey? = localSurveyStore.getSurveyById(surveyId)
+
+  fun getOfflineSurveys(): Flow<List<Survey>> = localSurveyStore.surveys
+
+  suspend fun removeOfflineSurvey(surveyId: String) {
+    getOfflineSurvey(surveyId)?.let { localSurveyStore.deleteSurvey(it) }
+  }
 
   private fun getOfflineSurveyFlow(id: String?): Flow<Survey?> =
     if (id.isNullOrBlank()) flowOf(null) else localSurveyStore.survey(id)

--- a/app/src/main/java/org/groundplatform/android/usecases/survey/ActivateSurveyUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/survey/ActivateSurveyUseCase.kt
@@ -17,7 +17,6 @@
 package org.groundplatform.android.usecases.survey
 
 import javax.inject.Inject
-import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.groundplatform.android.persistence.sync.SurveySyncWorker
 import org.groundplatform.android.repository.SurveyRepository
 
@@ -32,7 +31,6 @@ import org.groundplatform.android.repository.SurveyRepository
 class ActivateSurveyUseCase
 @Inject
 constructor(
-  private val localSurveyStore: LocalSurveyStore,
   private val makeSurveyAvailableOffline: MakeSurveyAvailableOfflineUseCase,
   private val surveyRepository: SurveyRepository,
 ) {
@@ -46,7 +44,7 @@ constructor(
       return true
     }
 
-    localSurveyStore.getSurveyById(surveyId)
+    surveyRepository.getOfflineSurvey(surveyId)
       ?: makeSurveyAvailableOffline(surveyId)
       ?: error("Survey $surveyId not found in remote db")
 

--- a/app/src/main/java/org/groundplatform/android/usecases/survey/ListAvailableSurveysUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/survey/ListAvailableSurveysUseCase.kt
@@ -23,8 +23,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import org.groundplatform.android.model.SurveyListItem
 import org.groundplatform.android.model.toListItem
-import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.groundplatform.android.persistence.remote.RemoteDataStore
+import org.groundplatform.android.repository.SurveyRepository
 import org.groundplatform.android.repository.UserRepository
 import org.groundplatform.android.system.NetworkManager
 import org.groundplatform.android.system.NetworkStatus
@@ -34,9 +34,9 @@ import org.groundplatform.android.system.NetworkStatus
 class ListAvailableSurveysUseCase
 @Inject
 constructor(
-  private val localSurveyStore: LocalSurveyStore,
   private val networkManager: NetworkManager,
   private val remoteDataStore: RemoteDataStore,
+  private val surveyRepository: SurveyRepository,
   private val userRepository: UserRepository,
 ) {
 
@@ -50,7 +50,7 @@ constructor(
     }
 
   private fun getLocalSurveyList(): Flow<List<SurveyListItem>> =
-    localSurveyStore.surveys.map { localSurveys ->
+    surveyRepository.getOfflineSurveys().map { localSurveys ->
       localSurveys.map { localSurvey -> localSurvey.toListItem(true) }
     }
 

--- a/app/src/main/java/org/groundplatform/android/usecases/survey/RemoveOfflineSurveyUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/survey/RemoveOfflineSurveyUseCase.kt
@@ -16,15 +16,11 @@
 package org.groundplatform.android.usecases.survey
 
 import javax.inject.Inject
-import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.groundplatform.android.repository.SurveyRepository
 
 class RemoveOfflineSurveyUseCase
 @Inject
-constructor(
-  private val localSurveyStore: LocalSurveyStore,
-  private val surveyRepository: SurveyRepository,
-) {
+constructor(private val surveyRepository: SurveyRepository) {
 
   /**
    * Attempts to remove the locally synced survey. Also, deactivates it before removing, if it is
@@ -35,7 +31,6 @@ constructor(
       surveyRepository.clearActiveSurvey()
     }
 
-    val survey = localSurveyStore.getSurveyById(surveyId) ?: return
-    localSurveyStore.deleteSurvey(survey)
+    surveyRepository.removeOfflineSurvey(surveyId)
   }
 }

--- a/app/src/main/java/org/groundplatform/android/usecases/survey/SyncSurveyUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/survey/SyncSurveyUseCase.kt
@@ -19,9 +19,9 @@ package org.groundplatform.android.usecases.survey
 import javax.inject.Inject
 import kotlinx.coroutines.withTimeoutOrNull
 import org.groundplatform.android.model.Survey
-import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.groundplatform.android.persistence.remote.RemoteDataStore
 import org.groundplatform.android.repository.LocationOfInterestRepository
+import org.groundplatform.android.repository.SurveyRepository
 import timber.log.Timber
 
 private const val LOAD_REMOTE_SURVEY_TIMEOUT_MILLS: Long = 15 * 1000
@@ -37,9 +37,9 @@ private const val LOAD_REMOTE_SURVEY_TIMEOUT_MILLS: Long = 15 * 1000
 class SyncSurveyUseCase
 @Inject
 constructor(
-  private val localSurveyStore: LocalSurveyStore,
   private val loiRepository: LocationOfInterestRepository,
   private val remoteDataStore: RemoteDataStore,
+  private val surveyRepository: SurveyRepository,
 ) {
 
   suspend operator fun invoke(surveyId: String): Survey? =
@@ -52,7 +52,7 @@ constructor(
     }
 
   private suspend fun syncSurvey(survey: Survey) {
-    localSurveyStore.insertOrUpdateSurvey(survey)
+    surveyRepository.saveSurvey(survey)
     loiRepository.syncLocationsOfInterest(survey)
     Timber.d("Synced survey ${survey.id}")
   }


### PR DESCRIPTION
This commit refactors the following use cases to interact with the `SurveyRepository` instead of directly accessing the `LocalSurveyStore`:

- `ActivateSurveyUseCase`
- `ListAvailableSurveysUseCase`
- `RemoveOfflineSurveyUseCase`
- `SyncSurveyUseCase`

Additionally, it introduces new methods in `SurveyRepository` to support these changes:

- `saveSurvey(survey: Survey)`
- `getOfflineSurveys(): Flow<List<Survey>>`
- `removeOfflineSurvey(surveyId: String)`

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->


<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->


