### PR TITLE
Auto-enable location lock when activating a survey without any LOIs or last saved camera position

### DIFF
--- a/app/src/main/java/org/groundplatform/android/persistence/local/LocalValueStore.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/local/LocalValueStore.kt
@@ -107,6 +107,10 @@ class LocalValueStore @Inject constructor(private val preferences: SharedPrefere
     preferences.getBoolean(Keys.UPLOAD_MEDIA, false)
   }
 
+  fun clearLastCameraPosition(surveyId: String) = allowThreadDiskReads {
+    preferences.edit { remove(LAST_VIEWPORT_PREFIX + surveyId) }
+  }
+
   fun setLastCameraPosition(surveyId: String, cameraPosition: CameraPosition) =
     allowThreadDiskReads {
       preferences.edit { putString(LAST_VIEWPORT_PREFIX + surveyId, cameraPosition.serialize()) }

--- a/app/src/main/java/org/groundplatform/android/persistence/local/room/dao/LocationOfInterestDao.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/local/room/dao/LocationOfInterestDao.kt
@@ -33,6 +33,11 @@ interface LocationOfInterestDao : BaseDao<LocationOfInterestEntity> {
     deletionState: EntityDeletionState,
   ): Flow<List<LocationOfInterestEntity>>
 
+  @Query(
+    "SELECT COUNT(*) from location_of_interest WHERE survey_id = :surveyId AND state = :deletionState"
+  )
+  suspend fun countByDeletionState(surveyId: String, deletionState: EntityDeletionState): Int
+
   @Query("SELECT * FROM location_of_interest WHERE id = :id")
   suspend fun findById(id: String): LocationOfInterestEntity?
 

--- a/app/src/main/java/org/groundplatform/android/persistence/local/room/stores/RoomLocationOfInterestStore.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/local/room/stores/RoomLocationOfInterestStore.kt
@@ -44,6 +44,9 @@ class RoomLocationOfInterestStore @Inject internal constructor() : LocalLocation
   @Inject lateinit var locationOfInterestMutationDao: LocationOfInterestMutationDao
   @Inject lateinit var userStore: RoomUserStore
 
+  override suspend fun getLoiCount(surveyId: String): Int =
+    locationOfInterestDao.countByDeletionState(surveyId, EntityDeletionState.DEFAULT)
+
   override fun getValidLois(survey: Survey): Flow<Set<LocationOfInterest>> =
     locationOfInterestDao.getByDeletionState(survey.id, EntityDeletionState.DEFAULT).map {
       toLocationsOfInterest(survey, it)

--- a/app/src/main/java/org/groundplatform/android/persistence/local/stores/LocalLocationOfInterestStore.kt
+++ b/app/src/main/java/org/groundplatform/android/persistence/local/stores/LocalLocationOfInterestStore.kt
@@ -24,6 +24,12 @@ import org.groundplatform.android.persistence.local.room.fields.MutationEntitySy
 
 interface LocalLocationOfInterestStore :
   LocalMutationStore<LocationOfInterestMutation, LocationOfInterest> {
+
+  /**
+   * Returns the count of [LocationOfInterest] in the local db associated with the given [Survey].
+   */
+  suspend fun getLoiCount(surveyId: String): Int
+
   /**
    * Retrieves the complete set of [LocationOfInterest] associated with the given [Survey] from the
    * local database and returns a [Flow] that continually emits the complete set anew any time the

--- a/app/src/main/java/org/groundplatform/android/repository/LocationOfInterestRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/LocationOfInterestRepository.kt
@@ -140,6 +140,12 @@ constructor(
     mutationSyncWorkManager.enqueueSyncWorker()
   }
 
+  /**
+   * Returns true if [Survey] for the given [surveyId] has at least one valid [LocationOfInterest]
+   * in the local storage.
+   */
+  suspend fun hasValidLois(surveyId: String): Boolean = localLoiStore.getLoiCount(surveyId) > 0
+
   /** Returns a flow of all valid (not deleted) [LocationOfInterest] in the given [Survey]. */
   fun getValidLois(survey: Survey): Flow<Set<LocationOfInterest>> =
     localLoiStore.getValidLois(survey)

--- a/app/src/main/java/org/groundplatform/android/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/home/mapcontainer/HomeScreenMapContainerFragment.kt
@@ -175,6 +175,7 @@ class HomeScreenMapContainerFragment : AbstractMapContainerFragment() {
     )
     binding.bottomContainer.bringToFront()
     showDataCollectionHint()
+    mapContainerViewModel.maybeEnableLocationLock()
   }
 
   /**

--- a/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModel.kt
@@ -44,7 +44,7 @@ internal constructor(
   @ApplicationScope private val externalScope: CoroutineScope,
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
   private val listAvailableSurveysUseCase: ListAvailableSurveysUseCase,
-  private val remoteOfflineSurveyUseCase: RemoveOfflineSurveyUseCase,
+  private val removeOfflineSurveyUseCase: RemoveOfflineSurveyUseCase,
   private val userRepository: UserRepository,
 ) : AbstractViewModel() {
 
@@ -108,7 +108,7 @@ internal constructor(
   }
 
   fun deleteSurvey(surveyId: String) {
-    externalScope.launch(ioDispatcher) { remoteOfflineSurveyUseCase(surveyId) }
+    externalScope.launch(ioDispatcher) { removeOfflineSurveyUseCase(surveyId) }
   }
 
   fun signOut() {

--- a/app/src/main/java/org/groundplatform/android/usecases/location/ShouldEnableLocationLockUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/location/ShouldEnableLocationLockUseCase.kt
@@ -15,9 +15,9 @@
  */
 package org.groundplatform.android.usecases.location
 
+import javax.inject.Inject
 import org.groundplatform.android.repository.LocationOfInterestRepository
 import org.groundplatform.android.repository.MapStateRepository
-import javax.inject.Inject
 
 /** Use case to determine if location lock should be enabled for a survey. */
 class ShouldEnableLocationLockUseCase

--- a/app/src/main/java/org/groundplatform/android/usecases/location/ShouldEnableLocationLockUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/location/ShouldEnableLocationLockUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.usecases.location
+
+import org.groundplatform.android.repository.LocationOfInterestRepository
+import org.groundplatform.android.repository.MapStateRepository
+import javax.inject.Inject
+
+/** Use case to determine if location lock should be enabled for a survey. */
+class ShouldEnableLocationLockUseCase
+@Inject
+constructor(
+  private val loiRepository: LocationOfInterestRepository,
+  private val mapStateRepository: MapStateRepository,
+) {
+
+  /** Returns true if location lock should be enabled for the survey. */
+  suspend operator fun invoke(surveyId: String): Boolean {
+    if (loiRepository.hasValidLois(surveyId)) return false
+    if (mapStateRepository.getCameraPosition(surveyId) != null) return false
+    return true
+  }
+}

--- a/app/src/main/java/org/groundplatform/android/usecases/survey/RemoveOfflineSurveyUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/survey/RemoveOfflineSurveyUseCase.kt
@@ -16,6 +16,7 @@
 package org.groundplatform.android.usecases.survey
 
 import javax.inject.Inject
+import org.groundplatform.android.persistence.local.LocalValueStore
 import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.groundplatform.android.repository.SurveyRepository
 
@@ -23,6 +24,7 @@ class RemoveOfflineSurveyUseCase
 @Inject
 constructor(
   private val localSurveyStore: LocalSurveyStore,
+  private val localValueStore: LocalValueStore,
   private val surveyRepository: SurveyRepository,
 ) {
 
@@ -34,6 +36,8 @@ constructor(
     if (surveyRepository.isSurveyActive(surveyId)) {
       surveyRepository.clearActiveSurvey()
     }
+
+    localValueStore.clearLastCameraPosition(surveyId)
 
     val survey = localSurveyStore.getSurveyById(surveyId) ?: return
     localSurveyStore.deleteSurvey(survey)

--- a/app/src/test/java/org/groundplatform/android/persistence/local/LocalLocationOfInterestStoreTest.kt
+++ b/app/src/test/java/org/groundplatform/android/persistence/local/LocalLocationOfInterestStoreTest.kt
@@ -131,6 +131,20 @@ class LocalLocationOfInterestStoreTest : BaseHiltTest() {
   }
 
   @Test
+  fun `getLoiCount returns 0 when no LOIs exist`() = runWithTestDispatcher {
+    assertThat(localLoiStore.getLoiCount(TEST_SURVEY.id)).isEqualTo(0)
+  }
+
+  @Test
+  fun `getLoiCount returns count when LOIs exist`() = runWithTestDispatcher {
+    localUserStore.insertOrUpdateUser(TEST_USER)
+    localSurveyStore.insertOrUpdateSurvey(TEST_SURVEY)
+    localLoiStore.applyAndEnqueue(TEST_LOI_MUTATION)
+
+    assertThat(localLoiStore.getLoiCount(TEST_SURVEY.id)).isEqualTo(1)
+  }
+
+  @Test
   fun testMergeLoi() = runWithTestDispatcher {
     localUserStore.insertOrUpdateUser(TEST_USER)
     localSurveyStore.insertOrUpdateSurvey(TEST_SURVEY)

--- a/app/src/test/java/org/groundplatform/android/repository/LocationOfInterestRepositoryTest.kt
+++ b/app/src/test/java/org/groundplatform/android/repository/LocationOfInterestRepositoryTest.kt
@@ -30,6 +30,7 @@ import org.groundplatform.android.model.geometry.LinearRing
 import org.groundplatform.android.model.geometry.Point
 import org.groundplatform.android.model.geometry.Polygon
 import org.groundplatform.android.model.mutation.Mutation.Type.CREATE
+import org.groundplatform.android.persistence.local.stores.LocalLocationOfInterestStore
 import org.groundplatform.android.persistence.remote.FakeRemoteDataStore
 import org.groundplatform.android.persistence.sync.MutationSyncWorkManager
 import org.groundplatform.android.system.auth.FakeAuthenticationManager
@@ -53,6 +54,7 @@ class LocationOfInterestRepositoryTest : BaseHiltTest() {
   @Inject lateinit var fakeAuthenticationManager: FakeAuthenticationManager
   @Inject lateinit var fakeRemoteDataStore: FakeRemoteDataStore
   @Inject lateinit var locationOfInterestRepository: LocationOfInterestRepository
+  @Inject lateinit var localLoiStore: LocalLocationOfInterestStore
   @Inject lateinit var mutationRepository: MutationRepository
   @Inject lateinit var userRepository: UserRepository
   @Inject lateinit var activateSurvey: ActivateSurveyUseCase
@@ -164,6 +166,27 @@ class LocationOfInterestRepositoryTest : BaseHiltTest() {
           )
         )
     }
+  }
+
+  @Test
+  fun `hasValidLois when survey has no lois returns false`() = runWithTestDispatcher {
+    // Remove all LOIs from local db inserted during setup()
+    localLoiStore.deleteNotIn(TEST_SURVEY.id, emptyList())
+
+    assertThat(locationOfInterestRepository.hasValidLois(TEST_SURVEY.id)).isFalse()
+  }
+
+  @Test
+  fun `hasValidLois when survey has lois returns true`() = runWithTestDispatcher {
+    // Remove all LOIs from local db inserted during setup()
+    localLoiStore.deleteNotIn(TEST_SURVEY.id, emptyList())
+
+    // Insert a new LOI
+    locationOfInterestRepository.applyAndEnqueue(
+      LOCATION_OF_INTEREST.toMutation(CREATE, TEST_USER.id)
+    )
+
+    assertThat(locationOfInterestRepository.hasValidLois(TEST_SURVEY.id)).isTrue()
   }
 
   companion object {

--- a/app/src/test/java/org/groundplatform/android/usecases/location/ShouldEnableLocationLockUseCaseTest.kt
+++ b/app/src/test/java/org/groundplatform/android/usecases/location/ShouldEnableLocationLockUseCaseTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.usecases.location
+
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.BindValue
+import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
+import org.groundplatform.android.BaseHiltTest
+import org.groundplatform.android.model.geometry.Coordinates
+import org.groundplatform.android.repository.LocationOfInterestRepository
+import org.groundplatform.android.repository.MapStateRepository
+import org.groundplatform.android.ui.map.CameraPosition
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@HiltAndroidTest
+@RunWith(RobolectricTestRunner::class)
+class ShouldEnableLocationLockUseCaseTest : BaseHiltTest() {
+
+  @BindValue @Mock lateinit var loiRepository: LocationOfInterestRepository
+  @BindValue @Mock lateinit var mapStateRepository: MapStateRepository
+
+  @Inject lateinit var shouldEnableLocationLockUseCase: ShouldEnableLocationLockUseCase
+
+  @Test
+  fun `returns false when survey has valid lois`() = runWithTestDispatcher {
+    whenever(loiRepository.hasValidLois("survey")).thenReturn(true)
+
+    assertThat(shouldEnableLocationLockUseCase("survey")).isFalse()
+  }
+
+  @Test
+  fun `returns false when survey has valid lois and last saved camera position`() =
+    runWithTestDispatcher {
+      whenever(loiRepository.hasValidLois("survey")).thenReturn(true)
+      whenever(mapStateRepository.getCameraPosition("survey"))
+        .thenReturn(CameraPosition(Coordinates(0.0, 0.0)))
+
+      assertThat(shouldEnableLocationLockUseCase("survey")).isFalse()
+    }
+
+  @Test
+  fun `returns false when survey has no valid lois but has last saved camera position`() =
+    runWithTestDispatcher {
+      whenever(loiRepository.hasValidLois("survey")).thenReturn(false)
+      whenever(mapStateRepository.getCameraPosition("survey"))
+        .thenReturn(CameraPosition(Coordinates(0.0, 0.0)))
+
+      assertThat(shouldEnableLocationLockUseCase("survey")).isFalse()
+    }
+
+  @Test
+  fun `returns false when survey has no valid lois and no last saved camera position`() =
+    runWithTestDispatcher {
+      whenever(loiRepository.hasValidLois("survey")).thenReturn(false)
+      whenever(mapStateRepository.getCameraPosition("survey")).thenReturn(null)
+
+      assertThat(shouldEnableLocationLockUseCase("survey")).isTrue()
+    }
+}

--- a/app/src/test/java/org/groundplatform/android/usecases/survey/RemoveOfflineSurveyUseCaseTest.kt
+++ b/app/src/test/java/org/groundplatform/android/usecases/survey/RemoveOfflineSurveyUseCaseTest.kt
@@ -23,8 +23,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.groundplatform.android.BaseHiltTest
 import org.groundplatform.android.FakeData.SURVEY
+import org.groundplatform.android.model.geometry.Coordinates
+import org.groundplatform.android.persistence.local.LocalValueStore
 import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.groundplatform.android.repository.SurveyRepository
+import org.groundplatform.android.ui.map.CameraPosition
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -35,6 +38,7 @@ import org.robolectric.RobolectricTestRunner
 class RemoveOfflineSurveyUseCaseTest : BaseHiltTest() {
   @Inject lateinit var activateSurvey: ActivateSurveyUseCase
   @Inject lateinit var localSurveyStore: LocalSurveyStore
+  @Inject lateinit var localValueStore: LocalValueStore
   @Inject lateinit var removeOfflineSurveyUseCase: RemoveOfflineSurveyUseCase
   @Inject lateinit var surveyRepository: SurveyRepository
 
@@ -45,6 +49,16 @@ class RemoveOfflineSurveyUseCaseTest : BaseHiltTest() {
     removeOfflineSurveyUseCase(SURVEY.id)
 
     localSurveyStore.surveys.test { assertThat(expectMostRecentItem()).isEmpty() }
+  }
+
+  @Test
+  fun `should remove last camera position`() = runWithTestDispatcher {
+    localValueStore.setLastCameraPosition(SURVEY.id, CameraPosition(Coordinates(0.0, 0.0)))
+    localSurveyStore.insertOrUpdateSurvey(SURVEY)
+
+    removeOfflineSurveyUseCase(SURVEY.id)
+
+    assertThat(localValueStore.getLastCameraPosition(SURVEY.id)).isNull()
   }
 
   @Test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2130

<!-- PR description. -->
This PR auto-enables the location lock button iff:
 * There are no LOIs to move the camera position to
 * There is no last saved camera position

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
Verified locally using unit tests and testing on emulator

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

