### PR TITLE
Request focus when "Other" option is selected

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
@@ -109,7 +109,7 @@ fun MultipleChoiceItemView(
 
     if (item.isOtherOption) {
       Row(modifier = modifier.padding(horizontal = 48.dp)) {
-        RenderOtherTextField(modifier, item, focusRequester, otherValueChanged)
+        OtherTextField(modifier, item, focusRequester, otherValueChanged)
       }
     }
 
@@ -120,7 +120,7 @@ fun MultipleChoiceItemView(
 }
 
 @Composable
-private fun RenderOtherTextField(
+private fun OtherTextField(
   modifier: Modifier,
   item: MultipleChoiceItem,
   focusRequester: FocusRequester,

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
@@ -109,22 +109,7 @@ fun MultipleChoiceItemView(
 
     if (item.isOtherOption) {
       Row(modifier = modifier.padding(horizontal = 48.dp)) {
-        OutlinedTextField(
-          supportingText = {
-            Row(modifier = modifier.fillMaxWidth()) {
-              Spacer(modifier = modifier.weight(1f))
-              Text(
-                "${item.otherText.length} / ${Config.TEXT_DATA_CHAR_LIMIT}",
-                textAlign = TextAlign.End,
-              )
-            }
-          },
-          isError = item.otherText.length > Config.TEXT_DATA_CHAR_LIMIT,
-          value = item.otherText,
-          textStyle = MaterialTheme.typography.bodyLarge,
-          onValueChange = { otherValueChanged(it) },
-          modifier = Modifier.testTag(OTHER_INPUT_TEXT_TEST_TAG).focusRequester(focusRequester),
-        )
+        RenderOtherTextField(modifier, item, focusRequester, otherValueChanged)
       }
     }
 
@@ -132,6 +117,28 @@ fun MultipleChoiceItemView(
       HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
     }
   }
+}
+
+@Composable
+private fun RenderOtherTextField(
+  modifier: Modifier,
+  item: MultipleChoiceItem,
+  focusRequester: FocusRequester,
+  otherValueChanged: (text: String) -> Unit,
+) {
+  OutlinedTextField(
+    supportingText = {
+      Row(modifier = modifier.fillMaxWidth()) {
+        Spacer(modifier = modifier.weight(1f))
+        Text("${item.otherText.length} / ${Config.TEXT_DATA_CHAR_LIMIT}", textAlign = TextAlign.End)
+      }
+    },
+    isError = item.otherText.length > Config.TEXT_DATA_CHAR_LIMIT,
+    value = item.otherText,
+    textStyle = MaterialTheme.typography.bodyLarge,
+    onValueChange = { otherValueChanged(it) },
+    modifier = Modifier.testTag(OTHER_INPUT_TEXT_TEST_TAG).focusRequester(focusRequester),
+  )
 }
 
 @Composable

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/multiplechoice/MultipleChoiceItemView.kt
@@ -29,8 +29,11 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -67,11 +70,16 @@ fun MultipleChoiceItemView(
 ) {
   val focusManager = LocalFocusManager.current
   val keyboardController = LocalSoftwareKeyboardController.current
+  val focusRequester = remember { FocusRequester() }
 
   LaunchedEffect(item.isSelected) {
-    if (item.isOtherOption && !item.isSelected) {
-      keyboardController?.hide()
-      focusManager.clearFocus()
+    if (item.isOtherOption) {
+      if (item.isSelected) {
+        focusRequester.requestFocus()
+      } else {
+        keyboardController?.hide()
+        focusManager.clearFocus()
+      }
     }
   }
 
@@ -115,7 +123,7 @@ fun MultipleChoiceItemView(
           value = item.otherText,
           textStyle = MaterialTheme.typography.bodyLarge,
           onValueChange = { otherValueChanged(it) },
-          modifier = Modifier.testTag(OTHER_INPUT_TEXT_TEST_TAG),
+          modifier = Modifier.testTag(OTHER_INPUT_TEXT_TEST_TAG).focusRequester(focusRequester),
         )
       }
     }


### PR DESCRIPTION

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2403

<!-- PR description. -->
This ensures that the text field for "Other" automatically gains focus, allowing the user to start typing immediately after selecting the option.


<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->
[other field focus.webm](https://github.com/user-attachments/assets/d7f747be-1b76-4f50-b674-78b098150b5a)


<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
