### PR TITLE
Re-enable flaky SurveySyncServiceTest

### DIFF
--- a/app/src/test/java/org/groundplatform/android/persistence/sync/SurveySyncServiceTest.kt
+++ b/app/src/test/java/org/groundplatform/android/persistence/sync/SurveySyncServiceTest.kt
@@ -30,6 +30,8 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
+import javax.inject.Inject
+import kotlin.test.assertEquals
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -44,8 +46,6 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
-import javax.inject.Inject
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest

--- a/app/src/test/java/org/groundplatform/android/persistence/sync/SurveySyncServiceTest.kt
+++ b/app/src/test/java/org/groundplatform/android/persistence/sync/SurveySyncServiceTest.kt
@@ -19,16 +19,17 @@ package org.groundplatform.android.persistence.sync
 import android.content.Context
 import android.util.Log
 import androidx.work.Configuration
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
+import androidx.work.await
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.TestDriver
 import androidx.work.testing.WorkManagerTestInitHelper
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -41,7 +42,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
+import javax.inject.Inject
+import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest
@@ -90,10 +94,7 @@ class SurveySyncServiceTest : BaseHiltTest() {
     testDriver.setAllConstraintsMet(requestId)
     advanceUntilIdle()
 
-    // TODO: Re-enable once GCB-specific flake is resolved.
-    // Issue URL: https://github.com/google/ground-android/issues/1787
-    //    verify(syncSurvey).invoke(surveyId)
-    //    assertEquals(WorkInfo.State.SUCCEEDED,
-    // workManager.getWorkInfoById(requestId).await().state)
+    verify(syncSurvey).invoke(surveyId)
+    assertEquals(WorkInfo.State.SUCCEEDED, workManager.getWorkInfoById(requestId).await().state)
   }
 }


### PR DESCRIPTION
The test was previously disabled due to a GCB specific flake.

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #1787 

<!-- PR description. -->
GCB has been deprecated. Re-enabling the previously disabled unit test

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@anandwana001  PTAL?
