### PR TITLE
[Clean Architecture] Refactor 3: Decouples logic for saving and syncing LOI from LoiRepository

### DIFF
--- a/app/src/main/java/org/groundplatform/android/data/repository/LocationOfInterestRepositoryImpl.kt
+++ b/app/src/main/java/org/groundplatform/android/data/repository/LocationOfInterestRepositoryImpl.kt
@@ -89,13 +89,6 @@ class LocationOfInterestRepositoryImpl(
     return locationOfInterest
   }
 
-  /**
-   * Creates a mutation entry for the given parameters, applies it to the local db and schedules a
-   * task for remote sync if the local transaction is successful.
-   *
-   * @param mutation Input [LocationOfInterestMutation]
-   * @return If successful, returns the provided locations of interest wrapped as `Loadable`
-   */
   override suspend fun applyAndEnqueue(mutation: LocationOfInterestMutation) {
     localLoiStore.applyAndEnqueue(mutation)
   }

--- a/app/src/main/java/org/groundplatform/android/data/repository/RepositoryModule.kt
+++ b/app/src/main/java/org/groundplatform/android/data/repository/RepositoryModule.kt
@@ -24,9 +24,6 @@ import org.groundplatform.android.domain.repository.LocationOfInterestRepository
 import org.groundplatform.android.persistence.local.stores.LocalLocationOfInterestStore
 import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.groundplatform.android.persistence.remote.RemoteDataStore
-import org.groundplatform.android.persistence.sync.MutationSyncWorkManager
-import org.groundplatform.android.persistence.uuid.OfflineUuidGenerator
-import org.groundplatform.android.repository.UserRepository
 import org.groundplatform.android.system.auth.AuthenticationManager
 
 @InstallIn(SingletonComponent::class)
@@ -39,19 +36,13 @@ object RepositoryModule {
     authenticationManager: AuthenticationManager,
     localLoiStore: LocalLocationOfInterestStore,
     localSurveyStore: LocalSurveyStore,
-    mutationSyncWorkManager: MutationSyncWorkManager,
     remoteDataStore: RemoteDataStore,
-    userRepository: UserRepository,
-    uuidGenerator: OfflineUuidGenerator,
   ): LocationOfInterestRepository {
     return LocationOfInterestRepositoryImpl(
       authenticationManager,
       localLoiStore,
       localSurveyStore,
-      mutationSyncWorkManager,
       remoteDataStore,
-      userRepository,
-      uuidGenerator,
     )
   }
 }

--- a/app/src/main/java/org/groundplatform/android/domain/repository/LocationOfInterestRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/domain/repository/LocationOfInterestRepository.kt
@@ -17,8 +17,6 @@ package org.groundplatform.android.domain.repository
 
 import kotlinx.coroutines.flow.Flow
 import org.groundplatform.android.model.Survey
-import org.groundplatform.android.model.geometry.Geometry
-import org.groundplatform.android.model.job.Job
 import org.groundplatform.android.model.locationofinterest.LocationOfInterest
 import org.groundplatform.android.model.mutation.LocationOfInterestMutation
 import org.groundplatform.android.ui.map.Bounds
@@ -67,25 +65,6 @@ interface LocationOfInterestRepository {
    * @return The [LocationOfInterest] if found, otherwise `null`.
    */
   suspend fun getOfflineLoi(surveyId: String, loiId: String): LocationOfInterest?
-
-  /**
-   * Creates and saves a new [LocationOfInterest] locally and schedules it for remote
-   * synchronization.
-   *
-   * @param geometry The geometry of the new LOI.
-   * @param job The job associated with the new LOI.
-   * @param surveyId The ID of the survey this LOI belongs to.
-   * @param loiName An optional name for the LOI.
-   * @param collectionId The ID of the collection this LOI belongs to.
-   * @return The unique ID of the newly created [LocationOfInterest].
-   */
-  suspend fun saveLoi(
-    geometry: Geometry,
-    job: Job,
-    surveyId: String,
-    loiName: String?,
-    collectionId: String,
-  ): String
 
   /**
    * Applies a [LocationOfInterestMutation] to the local data store and enqueues it for

--- a/app/src/main/java/org/groundplatform/android/domain/repository/LocationOfInterestRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/domain/repository/LocationOfInterestRepository.kt
@@ -67,10 +67,11 @@ interface LocationOfInterestRepository {
   suspend fun getOfflineLoi(surveyId: String, loiId: String): LocationOfInterest?
 
   /**
-   * Applies a [LocationOfInterestMutation] to the local data store and enqueues it for
-   * synchronization.
+   * Saves the given [mutation] and generates a corresponding [LocationOfInterest] to persist them
+   * to the local database.
    *
-   * @param mutation The mutation to apply and enqueue.
+   * This allows for optimistic UI updates by using the generated LOI as a local cache until the
+   * [mutation] is successfully synchronized with the remote data store.
    */
   suspend fun applyAndEnqueue(mutation: LocationOfInterestMutation)
 

--- a/app/src/main/java/org/groundplatform/android/domain/usecase/loi/SaveLoiUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/domain/usecase/loi/SaveLoiUseCase.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.domain.usecase.loi
+
+import javax.inject.Inject
+import org.groundplatform.android.domain.repository.LocationOfInterestRepository
+import org.groundplatform.android.model.geometry.Geometry
+import org.groundplatform.android.model.job.Job
+import org.groundplatform.android.model.locationofinterest.LocationOfInterest
+import org.groundplatform.android.model.locationofinterest.generateProperties
+import org.groundplatform.android.model.mutation.LocationOfInterestMutation
+import org.groundplatform.android.model.mutation.Mutation
+import org.groundplatform.android.persistence.sync.MutationSyncWorkManager
+import org.groundplatform.android.persistence.uuid.OfflineUuidGenerator
+import org.groundplatform.android.repository.UserRepository
+
+class SaveLoiUseCase
+@Inject
+constructor(
+  private val locationOfInterestRepository: LocationOfInterestRepository,
+  private val mutationSyncWorkManager: MutationSyncWorkManager,
+  private val userRepository: UserRepository,
+  private val uuidGenerator: OfflineUuidGenerator,
+) {
+
+  /**
+   * Creates and saves a new [LocationOfInterest] locally and schedules it for remote
+   * synchronization.
+   *
+   * @param collectionId The ID of the collection this LOI belongs to.
+   * @param geometry The geometry of the new LOI.
+   * @param job The job associated with the new LOI.
+   * @param loiName An optional name for the LOI.
+   * @param surveyId The ID of the survey this LOI belongs to.
+   * @return The unique ID of the newly created [LocationOfInterest].
+   */
+  suspend operator fun invoke(
+    collectionId: String,
+    geometry: Geometry,
+    job: Job,
+    loiName: String?,
+    surveyId: String,
+  ): String {
+    val newId = uuidGenerator.generateUuid()
+    val mutation =
+      LocationOfInterestMutation(
+        jobId = job.id,
+        type = Mutation.Type.CREATE,
+        syncStatus = Mutation.SyncStatus.PENDING,
+        surveyId = surveyId,
+        locationOfInterestId = newId,
+        userId = userRepository.getAuthenticatedUser().id,
+        geometry = geometry,
+        properties = generateProperties(loiName),
+        isPredefined = false,
+        collectionId = collectionId,
+      )
+    locationOfInterestRepository.applyAndEnqueue(mutation)
+    mutationSyncWorkManager.enqueueSyncWorker()
+    return newId
+  }
+}

--- a/app/src/main/java/org/groundplatform/android/usecases/submission/SubmitDataUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/submission/SubmitDataUseCase.kt
@@ -17,7 +17,7 @@ package org.groundplatform.android.usecases.submission
 
 import androidx.room.Transaction
 import javax.inject.Inject
-import org.groundplatform.android.domain.repository.LocationOfInterestRepository
+import org.groundplatform.android.domain.usecase.loi.SaveLoiUseCase
 import org.groundplatform.android.model.job.Job
 import org.groundplatform.android.model.submission.DrawAreaTaskData
 import org.groundplatform.android.model.submission.DropPinTaskData
@@ -29,7 +29,7 @@ import timber.log.Timber
 class SubmitDataUseCase
 @Inject
 constructor(
-  private val locationOfInterestRepository: LocationOfInterestRepository,
+  private val saveLoiUseCase: SaveLoiUseCase,
   private val submissionRepository: SubmissionRepository,
 ) {
 
@@ -76,6 +76,6 @@ constructor(
         Task.Type.DRAW_AREA -> (addLoiTaskValue as (DrawAreaTaskData)).geometry
         else -> error("Invalid AddLoi task")
       }
-    return locationOfInterestRepository.saveLoi(geometry, job, surveyId, loiName, collectionId)
+    return saveLoiUseCase(collectionId, geometry, job, loiName, surveyId)
   }
 }

--- a/app/src/test/java/org/groundplatform/android/domain/usecase/loi/SaveLoiUseCaseTest.kt
+++ b/app/src/test/java/org/groundplatform/android/domain/usecase/loi/SaveLoiUseCaseTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.domain.usecase.loi
+
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.BindValue
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import java.util.Date
+import javax.inject.Inject
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.groundplatform.android.BaseHiltTest
+import org.groundplatform.android.FakeData
+import org.groundplatform.android.data.repository.RepositoryModule
+import org.groundplatform.android.domain.repository.LocationOfInterestRepository
+import org.groundplatform.android.model.geometry.Coordinates
+import org.groundplatform.android.model.geometry.Point
+import org.groundplatform.android.model.mutation.LocationOfInterestMutation
+import org.groundplatform.android.model.mutation.Mutation
+import org.groundplatform.android.persistence.sync.MutationSyncWorkManager
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltAndroidTest
+@RunWith(RobolectricTestRunner::class)
+@UninstallModules(RepositoryModule::class)
+class SaveLoiUseCaseTest : BaseHiltTest() {
+  @BindValue @Mock lateinit var mockLoiRepository: LocationOfInterestRepository
+  @BindValue @Mock lateinit var mockWorkManager: MutationSyncWorkManager
+
+  @Inject lateinit var saveLoiUseCase: SaveLoiUseCase
+
+  @Test
+  fun testApplyAndEnqueue_enqueuesWorker() = runWithTestDispatcher {
+    saveLoi()
+
+    argumentCaptor<LocationOfInterestMutation> {
+      verify(mockLoiRepository).applyAndEnqueue(capture())
+
+      val date = Date()
+      val mutation = firstValue.copy(clientTimestamp = date) // replace timestamp
+      assertThat(mutation)
+        .isEqualTo(
+          LocationOfInterestMutation(
+            jobId = "job id",
+            type = Mutation.Type.CREATE,
+            syncStatus = Mutation.SyncStatus.PENDING,
+            surveyId = "survey id",
+            locationOfInterestId = "TEST UUID",
+            userId = "user id",
+            geometry = POINT_GEOMETRY,
+            collectionId = "loiId",
+            properties = mapOf(),
+            isPredefined = false,
+            clientTimestamp = date,
+          )
+        )
+    }
+
+    verify(mockWorkManager).enqueueSyncWorker()
+  }
+
+  @Test
+  fun testApplyAndEnqueue_returnsErrorOnWorkerSyncFailure() = runWithTestDispatcher {
+    whenever(mockWorkManager.enqueueSyncWorker()).thenThrow(Error())
+
+    assertFailsWith<Error> { saveLoi() }
+
+    verify(mockWorkManager, times(1)).enqueueSyncWorker()
+  }
+
+  private suspend fun saveLoi() {
+    saveLoiUseCase(
+      collectionId = "loiId",
+      geometry = POINT_GEOMETRY,
+      job = TEST_SURVEY.jobs.first(),
+      loiName = null,
+      surveyId = TEST_SURVEY.id,
+    )
+  }
+
+  // TODO: Add tests for new LOI sync once implemented (create, update, delete, error).
+  // Issue URL: https://github.com/google/ground-android/issues/1373
+
+  // TODO: Add tests for getLocationsOfInterest once new LOI sync implemented.
+  // Issue URL: https://github.com/google/ground-android/issues/1373
+
+  companion object {
+    private val COORDINATE = Coordinates(-20.0, -20.0)
+    private val POINT_GEOMETRY = Point(COORDINATE)
+    private val TEST_SURVEY = FakeData.SURVEY
+  }
+}

--- a/app/src/test/java/org/groundplatform/android/usecases/survey/SyncSurveyUseCaseTest.kt
+++ b/app/src/test/java/org/groundplatform/android/usecases/survey/SyncSurveyUseCaseTest.kt
@@ -29,7 +29,6 @@ import org.groundplatform.android.data.repository.RepositoryModule
 import org.groundplatform.android.domain.repository.LocationOfInterestRepository
 import org.groundplatform.android.persistence.local.stores.LocalSurveyStore
 import org.groundplatform.android.persistence.remote.FakeRemoteDataStore
-import org.groundplatform.android.system.SystemModule
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards https://github.com/google/ground-android/issues/3192

"DO NOT SUBMIT" until `part-2` branch is merged.

<!-- PR description. -->
Creates `SaveLoiUseCase` to decouple logic for applying mutation to local db and enqueuing worker. 

This is a pure refactor and doesn't modify any behavior. 

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
