### PR TITLE
Create a config to auto-update gradle and github actions using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See https://docs.github.com/en/code-security/dependabot for more details.
+
+---
+version: 2
+updates:
+  # Enable version updates for Gradle
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    reviewers:
+      - shobhitagarwal1612
+    assignees:
+      - shobhitagarwal1612
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    reviewers:
+      - shobhitagarwal1612
+    assignees:
+      - shobhitagarwal1612


### PR DESCRIPTION
Configured using https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

This was recommended by google.com organization guide.

Currently, the bot is configured to update the `gradle` and `github action` dependencies on a daily basis. Once, the dependencies are stable, then we can move on to a weekly interval.

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->


<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@gino-m  PTAL?
