### PR TITLE
Require approval to run e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
   instrumentation-tests:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/test-e2e.yml
     secrets:
       MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -27,6 +27,7 @@ jobs:
   run-instrumentation-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: e2e-approval
     env:
       FIREBASE_CLI_EXPERIMENTS: webframeworks
 


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #3365 

<!-- PR description. -->
This PR introduces the use of the e2e-approval environment. The test-e2e workflow now pauses on each PR commit and only runs after approval from a user with the appropriate permissions. This improves reliability by ensuring e2e tests run on PRs and catch regressions before changes are merged into master

@gino-m PTAL?
