### PR TITLE
[Code health] Remove duplicate test for sign-in progress dialog

### DIFF
--- a/app/src/test/java/org/groundplatform/android/ui/main/MainActivityTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/main/MainActivityTest.kt
@@ -17,10 +17,8 @@ package org.groundplatform.android.ui.main
 
 import android.content.Intent
 import android.net.Uri
-import android.os.Looper
 import androidx.navigation.fragment.NavHostFragment
 import com.google.common.truth.Truth.assertThat
-import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
@@ -36,8 +34,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows
-import org.robolectric.shadows.ShadowProgressDialog
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest
@@ -50,35 +46,6 @@ class MainActivityTest : BaseHiltTest() {
   @Inject lateinit var tosRepository: TermsOfServiceRepository
 
   @Inject lateinit var remoteConfig: FirebaseRemoteConfig
-
-  override fun setUp() {
-    super.setUp()
-    ShadowProgressDialog.reset()
-    Shadows.shadowOf(Looper.getMainLooper()).idle()
-  }
-
-  override fun closeDb() {
-    super.closeDb()
-    Shadows.shadowOf(Looper.getMainLooper()).idle()
-  }
-
-  @Test
-  fun `Sign in error dialog is displayed when sign in fails`() = runWithTestDispatcher {
-    Robolectric.buildActivity(MainActivity::class.java).use { controller ->
-      controller.setup() // Moves Activity to RESUMED state
-      activity = controller.get()
-
-      fakeAuthenticationManager.setState(
-        SignInState.Error(
-          error =
-            FirebaseFirestoreException("error", FirebaseFirestoreException.Code.PERMISSION_DENIED)
-        )
-      )
-      advanceUntilIdle()
-
-      assertThat(ShadowProgressDialog.getLatestDialog().isShowing).isTrue()
-    }
-  }
 
   @Test
   fun `Launch app with survey ID navigates to survey selector when user is logged in`() =


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
This test is already covered in SignInScreenTest. Removing from MainActivityTest to reduce flakiness in https://github.com/google/ground-android/pull/3548

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@andreia-ferreira PTAL?
