### PR TITLE
Add UriImage component for displaying images from URIs

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/components/UriImage.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/components/UriImage.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.ui.datacollection.components
+
+import android.net.Uri
+import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.net.toUri
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import coil.size.Scale
+import org.groundplatform.android.R
+import org.groundplatform.android.ui.common.ExcludeFromJacocoGeneratedReport
+import org.groundplatform.android.ui.theme.AppTheme
+
+@VisibleForTesting const val MAX_IMAGE_SIZE = 2048
+
+@Composable
+fun UriImage(uri: Uri?, modifier: Modifier = Modifier) {
+  val context = LocalContext.current
+  val displayMetrics = LocalResources.current.displayMetrics
+
+  // Determine target dimensions to avoid loading very large images into memory.
+  // - Prefer the view’s measured size if available, else fall back to half the screen size.
+  // - Clamp to a maximum of 2048px to keep decoding efficient and prevent OOM on huge images.
+  BoxWithConstraints(modifier = modifier) {
+    val measureW =
+      if (constraints.hasBoundedWidth) constraints.maxWidth else displayMetrics.widthPixels / 2
+    val measureH =
+      if (constraints.hasBoundedHeight) constraints.maxHeight else displayMetrics.heightPixels / 2
+
+    val targetW = measureW.coerceAtMost(MAX_IMAGE_SIZE)
+    val targetH = measureH.coerceAtMost(MAX_IMAGE_SIZE)
+
+    AsyncImage(
+      model =
+        ImageRequest.Builder(context)
+          .data(uri)
+          .size(width = targetW, height = targetH)
+          .scale(Scale.FIT)
+          .placeholder(R.drawable.ic_photo_grey_600_24dp)
+          .error(R.drawable.outline_error_outline_24)
+          .crossfade(true)
+          .build(),
+      contentDescription = stringResource(id = R.string.photo_preview),
+      contentScale = ContentScale.Fit,
+    )
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+@ExcludeFromJacocoGeneratedReport
+private fun UriImagePreview() {
+  AppTheme { UriImage(uri = "content://media/external/images/media/1".toUri()) }
+}

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/components/UriImageTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/components/UriImageTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.ui.datacollection.components
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import coil.Coil
+import coil.ImageLoader
+import coil.decode.DataSource
+import coil.request.ImageRequest
+import coil.request.SuccessResult
+import coil.size.Dimension.Pixels
+import coil.size.Scale
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.groundplatform.android.BaseHiltTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@HiltAndroidTest
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+@Config(qualifiers = "w480dp-h1080dp-mdpi")
+class UriImageTest : BaseHiltTest() {
+
+  private lateinit var context: Context
+  private val capturedRequests = mutableListOf<ImageRequest>()
+
+  @Before
+  override fun setUp() {
+    super.setUp()
+
+    context = ApplicationProvider.getApplicationContext()
+    capturedRequests.clear()
+
+    setupImageLoader()
+  }
+
+  @After
+  fun tearDown() {
+    // Reset ImageLoader to avoid leaking state between tests
+    Coil.setImageLoader(ImageLoader(context))
+  }
+
+  @Test
+  fun uriImage_nullUri_doesNotLoadImage() = runWithTestDispatcher {
+    composeTestRule.setContent { UriImage(uri = null) }
+
+    assertThat(capturedRequests).isEmpty()
+  }
+
+  @Test
+  fun uriImage_loadsImageWithCorrectSpecs() = runWithTestDispatcher {
+    composeTestRule.setContent {
+      UriImage(uri = URI, modifier = Modifier.requiredSize(100.dp, 100.dp))
+    }
+
+    composeTestRule.waitForIdle()
+
+    verifyImageDimensions(100, 100)
+  }
+
+  @Test
+  fun uriImage_largeBoundedSize_isCoercedToMaxImageSize() = runWithTestDispatcher {
+    composeTestRule.setContent {
+      UriImage(uri = URI, modifier = Modifier.requiredSize(3000.dp, 3000.dp))
+    }
+    composeTestRule.waitForIdle()
+
+    verifyImageDimensions(MAX_IMAGE_SIZE, MAX_IMAGE_SIZE)
+  }
+
+  @Test
+  fun uriImage_unboundedSize_usesHalvedDisplayMetrics() = runWithTestDispatcher {
+    composeTestRule.setContent {
+      Layout(content = { UriImage(uri = URI) }) { measurables, _ ->
+        val constraints = Constraints()
+        val placeable = measurables[0].measure(constraints)
+        layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+      }
+    }
+    composeTestRule.waitForIdle()
+
+    verifyImageDimensions(240, 540)
+  }
+
+  private fun setupImageLoader() {
+    val imageLoader =
+      ImageLoader.Builder(context)
+        .components {
+          add { chain ->
+            capturedRequests.add(chain.request)
+            SuccessResult(
+              drawable =
+                BitmapDrawable(
+                  context.resources,
+                  Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
+                ),
+              request = chain.request,
+              dataSource = DataSource.MEMORY_CACHE,
+            )
+          }
+        }
+        .build()
+
+    Coil.setImageLoader(imageLoader)
+  }
+
+  private suspend fun verifyImageDimensions(width: Int, height: Int) {
+    assertThat(capturedRequests).hasSize(1)
+
+    val request = capturedRequests.first()
+    assertThat(request.data).isEqualTo(URI)
+    assertThat(request.scale).isEqualTo(Scale.FIT)
+    assertThat(request.sizeResolver).isNotNull()
+
+    // Check that transitionFactory is set (implies crossfade was called)
+    assertThat(request.transitionFactory).isNotNull()
+
+    val size = request.sizeResolver.size()
+    assertThat((size.width as Pixels).px).isEqualTo(width)
+    assertThat((size.height as Pixels).px).isEqualTo(height)
+  }
+
+  companion object {
+    private val URI = Uri.parse("content://test/image.jpg")
+  }
+}


### PR DESCRIPTION
Towards https://github.com/google/ground-android/issues/3545

- Implement `UriImage` using Coil's `AsyncImage`
- Optimize image loading by calculating target dimensions based on available constraints or display metrics, capped at 2048px to prevent memory issues. This is similar to current implementation in PhotoTaskFragment

<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Split from https://github.com/google/ground-android/pull/3548

<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@andreia-ferreira PTAL?
