### PR TITLE
Fix the ExcludeFromJacocoGeneratedReport annotation to exclude preview compose methods from test coverage

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/common/ExcludeFromJacocoGeneratedReport.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/common/ExcludeFromJacocoGeneratedReport.kt
@@ -17,5 +17,12 @@ package org.groundplatform.android.ui.common
 
 // https://stackoverflow.com/questions/47824761/how-would-i-add-an-annotation-to-exclude-a-method-from-a-jacoco-code-coverage-re
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
+@Target(
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.CLASS,
+  AnnotationTarget.FILE,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.PROPERTY_GETTER,
+  AnnotationTarget.CONSTRUCTOR,
+)
 annotation class ExcludeFromJacocoGeneratedReport


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->


<!-- PR description. -->

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@... PTAL?
