### PR TITLE
Fix codecov failing dependabot CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,13 @@ jobs:
         run: ./gradlew jacocoLocalDebugUnitTestReport
 
       - name: Upload coverage to Codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "**/build/reports/jacoco/**/*.xml"
           flags: service
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   instrumentation-tests:
     needs: build


### PR DESCRIPTION
Dependabot PRs do not have access to the CODECOV_TOKEN so the Codecov step can't run. After https://github.com/google/ground-android/pull/3607 the ci workflow has `fail_ci_if_error: true` in the codecov step, which makes the entire job fail.

This PR updates that to skip that step in case it's just a dependabot PR. Also it sets `fail_ci_if_error: false` to ensure that coverage upload issues never fail the entire pipeline

@shobhitagarwal1612  PTAL?
