### PR TITLE
Fix progress bar misaligned on photo task

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionFragment.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionFragment.kt
@@ -22,17 +22,19 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
 import androidx.constraintlayout.widget.Guideline
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnLayout
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.asFlow
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.getValue
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.groundplatform.android.R
 import org.groundplatform.android.databinding.DataCollectionFragBinding
@@ -40,7 +42,9 @@ import org.groundplatform.android.ui.common.AbstractFragment
 import org.groundplatform.android.ui.common.BackPressListener
 import org.groundplatform.android.ui.components.ConfirmationDialog
 import org.groundplatform.android.ui.home.HomeScreenFragmentDirections
+import org.groundplatform.android.ui.main.MainViewModel
 import org.groundplatform.android.util.renderComposableDialog
+import org.groundplatform.android.util.systemInsets
 import org.groundplatform.domain.model.locationofinterest.LoiReport
 import org.groundplatform.domain.model.task.Task
 
@@ -50,6 +54,7 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
   @Inject lateinit var viewPagerAdapterFactory: DataCollectionViewPagerAdapterFactory
 
   val viewModel: DataCollectionViewModel by hiltNavGraphViewModels(R.id.data_collection)
+  private val mainViewModel: MainViewModel by lazy { getViewModel(MainViewModel::class.java) }
 
   private lateinit var binding: DataCollectionFragBinding
   private lateinit var progressBar: ProgressBar
@@ -88,7 +93,14 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
 
     viewLifecycleOwner.lifecycleScope.launch {
       viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-        viewModel.footerVerticalPosition.collect { setProgressBarPosition(it) }
+        combine(mainViewModel.windowInsets.asFlow(), viewModel.footerVerticalPosition) {
+            insets,
+            position ->
+            Pair(insets, position)
+          }
+          .collect { (insets, position) ->
+            setProgressBarPosition(position - insets.systemInsets().top)
+          }
       }
     }
 
@@ -139,11 +151,7 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
   }
 
   private fun setProgressBarPosition(topPosition: Float) {
-    val insets = requireView().rootWindowInsets ?: return
-    val windowInsets = WindowInsetsCompat.toWindowInsetsCompat(insets)
-    val systemBarsInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-
-    val guidelineTop = topPosition.toInt() - systemBarsInsets.top
+    val guidelineTop = topPosition.toInt()
 
     if (guidelineTop > 0) {
       guideline.setGuidelineBegin(guidelineTop)

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/TaskScreen.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/TaskScreen.kt
@@ -21,11 +21,10 @@ import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import org.groundplatform.android.ui.datacollection.components.ButtonActionState
@@ -51,18 +50,16 @@ fun TaskScreen(
   taskBody: @Composable () -> Unit,
 ) {
   val isKeyboardOpen = WindowInsets.isImeVisible
-  var layoutCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+  var footerPositionY by remember { mutableFloatStateOf(0f) }
 
   // Update footer position whenever layout changes or keyboard is toggled.
-  LaunchedEffect(isKeyboardOpen, layoutCoordinates) {
-    layoutCoordinates?.let { onFooterPositionUpdated(it.positionInWindow().y) }
-  }
+  LaunchedEffect(isKeyboardOpen, footerPositionY) { onFooterPositionUpdated(footerPositionY) }
 
   TaskViewLayout(
     header = taskHeader,
     footer = {
       TaskFooter(
-        modifier = Modifier.onGloballyPositioned { layoutCoordinates = it },
+        modifier = Modifier.onGloballyPositioned { footerPositionY = it.positionInWindow().y },
         content = footerContent,
         buttonActionStates = taskActionButtonsStates,
         onButtonClicked = { onAction(TaskScreenAction.OnButtonClicked(it)) },


### PR DESCRIPTION
while testing the latest master to prepare for a new release @jo-spek found that the progress bar was misaligned. This seems to happen after taking a picture in the photo task and it's because, when going back to the app, the fragment collects the latest value from `footerVerticalPosition` and applies it immediately. However, the system window insets are not yet fully re-dispatched after resuming the Activity, which means the top system bar inset may temporarily be reported as 0. This causes the calculated footer position to be incorrect.

In order to fix this, the `windowInsets` from the MainViewModel is now also being combined with `footerVerticalPosition` before applying the final position. This ensures that every time the insets or footer position change, the progress bar updates accordingly.
As an extra precaution, `TaskScreen` was updated to store the Y position as a Float instead of relying on LayoutCoordinates, since its reused reference may not trigger updates in compose

Before

[Screen_recording_20260414_110920.webm](https://github.com/user-attachments/assets/6f932187-6455-46ca-a3b0-5c008190b8b7)


After

[Screen_recording_20260414_110803.webm](https://github.com/user-attachments/assets/4e35c415-923d-4dd1-9498-d3f092d65eae)


@shobhitagarwal1612  PTAL?
