### PR TITLE
Fix not possible to join unlisted surveys

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModel.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -90,9 +89,7 @@ internal constructor(
 
   init {
     if (!surveyIdToActivate.isNullOrBlank()) {
-      viewModelScope.launch {
-        activateSurvey(surveyIdToActivate)
-      }
+      viewModelScope.launch { activateSurvey(surveyIdToActivate) }
     }
   }
 

--- a/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModel.kt
@@ -91,9 +91,6 @@ internal constructor(
   init {
     if (!surveyIdToActivate.isNullOrBlank()) {
       viewModelScope.launch {
-        // Wait for the survey list to contain the target survey
-        surveyList.first { surveys -> surveys.any { it.id == surveyIdToActivate } }
-        // Once found, activate it
         activateSurvey(surveyIdToActivate)
       }
     }

--- a/app/src/test/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModelTest.kt
@@ -59,6 +59,9 @@ class SurveySelectorViewModelTest : BaseHiltTest() {
     externalScope = TestScope(testDispatcher)
     ioDispatcher = testDispatcher
     whenever(listAvailableSurveysUseCase()).thenReturn(flowOf(listOf(TEST_SURVEY)))
+  }
+
+  private fun createViewModel(savedStateHandle: SavedStateHandle = SavedStateHandle()) {
     viewModel =
       SurveySelectorViewModel(
         activateSurveyUseCase,
@@ -67,12 +70,14 @@ class SurveySelectorViewModelTest : BaseHiltTest() {
         listAvailableSurveysUseCase,
         removeOfflineSurveyUseCase,
         userRepository,
-        SavedStateHandle(),
+        savedStateHandle,
       )
   }
 
   @Test
   fun `uiState loads surveys`() = runWithTestDispatcher {
+    createViewModel()
+
     viewModel.uiState.test {
       val state = awaitItem()
       assertThat(state.isLoading).isFalse()
@@ -82,6 +87,7 @@ class SurveySelectorViewModelTest : BaseHiltTest() {
 
   @Test
   fun `activateSurvey navigates on success`() = runWithTestDispatcher {
+    createViewModel()
     whenever(activateSurveyUseCase("1")).thenReturn(true)
 
     viewModel.events.test {
@@ -92,11 +98,33 @@ class SurveySelectorViewModelTest : BaseHiltTest() {
 
   @Test
   fun `activateSurvey shows error on failure`() = runWithTestDispatcher {
+    createViewModel()
     val error = RuntimeException("Oops")
     whenever(activateSurveyUseCase("1")).thenThrow(error)
 
     viewModel.events.test {
       viewModel.activateSurvey("1")
+      assertThat(awaitItem()).isEqualTo(SurveySelectorEvent.ShowError(error))
+    }
+  }
+
+  @Test
+  fun `activateSurvey from deeplink works correctly`() = runWithTestDispatcher {
+    val savedState = SavedStateHandle(mapOf("surveyId" to "deeplink-id"))
+    whenever(activateSurveyUseCase("deeplink-id")).thenReturn(true)
+    createViewModel(savedStateHandle = savedState)
+
+    viewModel.events.test { assertThat(awaitItem()).isEqualTo(SurveySelectorEvent.NavigateToHome) }
+  }
+
+  @Test
+  fun `activateSurvey from deeplink shows error on failure`() = runWithTestDispatcher {
+    val savedState = SavedStateHandle(mapOf("surveyId" to "bad-id"))
+    val error = RuntimeException("activation failed")
+    whenever(activateSurveyUseCase("bad-id")).thenThrow(error)
+    createViewModel(savedStateHandle = savedState)
+
+    viewModel.events.test {
       assertThat(awaitItem()).isEqualTo(SurveySelectorEvent.ShowError(error))
     }
   }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3674

After the Compose refactor of the survey selector, the VM was updated to wait until the `surveyList` contained the deeplink survey id (when provided) before activating it.

However, this broke support for unlisted surveys, where any user with the URL should be able to join, even if the survey is not present in their survey list.

This PR restores the previous behavior by triggering activation immediately when a surveyId is provided via deeplink.

@shobhitagarwal1612  PTAL?
