### PR TITLE
[Draw polygon task] Don't disable redo button after removing all points

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
@@ -57,7 +57,6 @@ import org.groundplatform.domain.model.settings.MeasurementUnits
 import org.groundplatform.domain.model.submission.DrawAreaTaskData
 import org.groundplatform.domain.model.submission.DrawAreaTaskIncompleteData
 import org.groundplatform.domain.model.submission.TaskData
-import org.groundplatform.domain.model.submission.isNotNullOrEmpty
 import org.groundplatform.domain.model.task.Task
 import org.groundplatform.domain.usecases.user.GetUserSettingsUseCase
 import org.groundplatform.domain.util.calculateShoelacePolygonArea
@@ -140,7 +139,7 @@ internal constructor(
           getPreviousButton(),
           getSkipButton(taskData),
           getUndoButton(taskData, true),
-          getRedoButton(taskData),
+          getRedoButton(),
           getAddPointButton(isClosed, sessionState.isTooClose),
           getCompleteButton(isClosed, sessionState.isMarkedComplete),
           getNextButton(taskData).takeIf { sessionState.isMarkedComplete },
@@ -358,10 +357,10 @@ internal constructor(
     vibrationHelper.vibrate()
   }
 
-  private fun getRedoButton(taskData: TaskData?): ButtonActionState =
+  private fun getRedoButton(): ButtonActionState =
     ButtonActionState(
       action = ButtonAction.REDO,
-      isEnabled = session.canRedo() && taskData.isNotNullOrEmpty(),
+      isEnabled = session.canRedo(),
       isVisible = true,
     )
 

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/PolygonDrawingSessionImpl.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/PolygonDrawingSessionImpl.kt
@@ -111,11 +111,6 @@ class PolygonDrawingSessionImpl : PolygonDrawingSession {
     _isMarkedComplete = false
     redoVertexStack.add(_vertices.last())
     _vertices = _vertices.dropLast(1).toImmutableList()
-
-    if (_vertices.isEmpty()) {
-      redoVertexStack.clear()
-    }
-
     return true
   }
 

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskFragmentTest.kt
@@ -198,21 +198,22 @@ class DrawAreaTaskFragmentTest :
   }
 
   @Test
-  fun `redo button when is disabled empty redo vertex stack`() = runWithTestDispatcher {
-    setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
+  fun `redo button is enabled when redo stack is not empty even if vertices become empty`() =
+    runWithTestDispatcher {
+      setupTaskFragment<DrawAreaTaskFragment>(job, task.copy(isRequired = false))
 
-    runner().assertButtonIsDisabled(REDO_POINT_BUTTON_TEXT, true)
+      runner().assertButtonIsDisabled(REDO_POINT_BUTTON_TEXT, true)
 
-    updateLastVertexAndAddPoint(COORDINATE_1)
-    updateLastVertexAndAddPoint(COORDINATE_2)
+      updateLastVertexAndAddPoint(COORDINATE_1)
+      updateLastVertexAndAddPoint(COORDINATE_2)
 
-    viewModel.removeLastVertex()
-    runner().assertButtonIsEnabled(REDO_POINT_BUTTON_TEXT, true)
+      viewModel.removeLastVertex()
+      runner().assertButtonIsEnabled(REDO_POINT_BUTTON_TEXT, true)
 
-    viewModel.removeLastVertex()
-    viewModel.removeLastVertex()
-    runner().assertButtonIsDisabled(REDO_POINT_BUTTON_TEXT, true)
-  }
+      viewModel.removeLastVertex()
+      viewModel.removeLastVertex()
+      runner().assertButtonIsEnabled(REDO_POINT_BUTTON_TEXT, true)
+    }
 
   @Test
   fun `Instructions dialog is shown`() = runWithTestDispatcher {

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModelTest.kt
@@ -456,6 +456,22 @@ class DrawAreaTaskViewModelTest : BaseHiltTest() {
     }
 
   @Test
+  fun `REDO button is visible and enabled when there is something to redo even if vertices become empty`() =
+    runWithTestDispatcher {
+      setupViewModel()
+      updateLastVertexAndAdd(COORDINATE_1)
+      viewModel.removeLastVertex()
+      advanceUntilIdle()
+
+      val states = viewModel.taskActionButtonStates.first()
+
+      with(requireNotNull(states.find { it.action == ButtonAction.REDO })) {
+        assertTrue(isVisible)
+        assertTrue(isEnabled)
+      }
+    }
+
+  @Test
   fun `ADD_POINT is visible and enabled when polygon is not finished yet`() =
     runWithTestDispatcher {
       setupViewModel()

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/PolygonDrawingSessionTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/PolygonDrawingSessionTest.kt
@@ -134,12 +134,12 @@ class PolygonDrawingSessionTest {
   }
 
   @Test
-  fun `removeLastVertex clears redo stack when vertices become empty`() {
+  fun `removeLastVertex does not clear redo stack when vertices become empty`() {
     session.setVertices(listOf(COORDINATE_1))
 
     assertThat(session.removeLastVertex()).isTrue()
     assertThat(session.vertices).isEmpty()
-    assertThat(session.redoVertexStack).isEmpty()
+    assertThat(session.redoVertexStack).containsExactly(COORDINATE_1)
   }
 
   @Test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #3679

<!-- PR description. -->
Key changes:
 * Don't clear the redo stack after removing all vertices
 * Remove check to disable the REDO button is `taskData` is null

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

Before:

[Screen_recording_20260421_195612.webm](https://github.com/user-attachments/assets/319d6c5e-1507-41b8-9eea-a1cb9a9940fc)


<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
After:

[Screen_recording_20260421_194954.webm](https://github.com/user-attachments/assets/f1ad06ec-3c77-4410-9c39-be28932f4631)


@andreia-ferreira  PTAL?
