### PR TITLE
Fix incorrect state for mutations

### DIFF
--- a/app/schemas/org.groundplatform.android.data.local.room.LocalDatabase/127.json
+++ b/app/schemas/org.groundplatform.android.data.local.room.LocalDatabase/127.json
@@ -1,0 +1,1121 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 127,
+    "identityHash": "6a392f7f45a0198f806ed87429d6256a",
+    "entities": [
+      {
+        "tableName": "draft_submission",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `job_id` TEXT NOT NULL, `loi_id` TEXT, `survey_id` TEXT NOT NULL, `deltas` TEXT, `loi_name` TEXT, `current_task_id` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "job_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loiId",
+            "columnName": "loi_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deltas",
+            "columnName": "deltas",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "loiName",
+            "columnName": "loi_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "currentTaskId",
+            "columnName": "current_task_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_draft_submission_loi_id_job_id_survey_id",
+            "unique": false,
+            "columnNames": [
+              "loi_id",
+              "job_id",
+              "survey_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_submission_loi_id_job_id_survey_id` ON `${TABLE_NAME}` (`loi_id`, `job_id`, `survey_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "location_of_interest",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `survey_id` TEXT NOT NULL, `job_id` TEXT NOT NULL, `state` INTEGER NOT NULL, `geometry` BLOB, `customId` TEXT NOT NULL, `submissionCount` INTEGER NOT NULL, `properties` TEXT NOT NULL, `isPredefined` INTEGER, `created_clientTimestamp` INTEGER NOT NULL, `created_serverTimestamp` INTEGER, `created_user_id` TEXT NOT NULL, `created_user_email` TEXT NOT NULL, `created_user_display_name` TEXT NOT NULL, `modified_clientTimestamp` INTEGER NOT NULL, `modified_serverTimestamp` INTEGER, `modified_user_id` TEXT NOT NULL, `modified_user_email` TEXT NOT NULL, `modified_user_display_name` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`job_id`) REFERENCES `job`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "job_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletionState",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "geometry",
+            "columnName": "geometry",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "customId",
+            "columnName": "customId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submissionCount",
+            "columnName": "submissionCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "properties",
+            "columnName": "properties",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPredefined",
+            "columnName": "isPredefined",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "created.clientTimestamp",
+            "columnName": "created_clientTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created.serverTimestamp",
+            "columnName": "created_serverTimestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "created.user.id",
+            "columnName": "created_user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created.user.email",
+            "columnName": "created_user_email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created.user.displayName",
+            "columnName": "created_user_display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified.clientTimestamp",
+            "columnName": "modified_clientTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified.serverTimestamp",
+            "columnName": "modified_serverTimestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastModified.user.id",
+            "columnName": "modified_user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified.user.email",
+            "columnName": "modified_user_email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified.user.displayName",
+            "columnName": "modified_user_display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_location_of_interest_survey_id",
+            "unique": false,
+            "columnNames": [
+              "survey_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_of_interest_survey_id` ON `${TABLE_NAME}` (`survey_id`)"
+          },
+          {
+            "name": "index_location_of_interest_job_id",
+            "unique": false,
+            "columnNames": [
+              "job_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_of_interest_job_id` ON `${TABLE_NAME}` (`job_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "job",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "job_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "location_of_interest_mutation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `survey_id` TEXT NOT NULL, `type` INTEGER NOT NULL, `state` INTEGER NOT NULL, `retry_count` INTEGER NOT NULL, `last_error` TEXT NOT NULL, `user_id` TEXT NOT NULL, `client_timestamp` INTEGER NOT NULL, `location_of_interest_id` TEXT NOT NULL, `job_id` TEXT NOT NULL, `is_predefined` INTEGER, `collection_id` TEXT NOT NULL, `newGeometry` BLOB, `newProperties` TEXT NOT NULL, `newCustomId` TEXT NOT NULL, FOREIGN KEY(`location_of_interest_id`) REFERENCES `location_of_interest`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retry_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "last_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientTimestamp",
+            "columnName": "client_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationOfInterestId",
+            "columnName": "location_of_interest_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "job_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPredefined",
+            "columnName": "is_predefined",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collection_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newGeometry",
+            "columnName": "newGeometry",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "newProperties",
+            "columnName": "newProperties",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newCustomId",
+            "columnName": "newCustomId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_location_of_interest_mutation_location_of_interest_id",
+            "unique": false,
+            "columnNames": [
+              "location_of_interest_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_of_interest_mutation_location_of_interest_id` ON `${TABLE_NAME}` (`location_of_interest_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "location_of_interest",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "location_of_interest_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "task",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `index` INTEGER NOT NULL, `task_type` INTEGER NOT NULL, `label` TEXT, `is_required` INTEGER NOT NULL, `job_id` TEXT, `is_add_loi_task` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`job_id`) REFERENCES `job`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskType",
+            "columnName": "task_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isRequired",
+            "columnName": "is_required",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "job_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAddLoiTask",
+            "columnName": "is_add_loi_task",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_task_job_id",
+            "unique": false,
+            "columnNames": [
+              "job_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_task_job_id` ON `${TABLE_NAME}` (`job_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "job",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "job_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "job",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT, `survey_id` TEXT, `strategy` TEXT NOT NULL, `style_color` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`survey_id`) REFERENCES `survey`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "strategy",
+            "columnName": "strategy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "style.color",
+            "columnName": "style_color",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_job_survey_id",
+            "unique": false,
+            "columnNames": [
+              "survey_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_job_survey_id` ON `${TABLE_NAME}` (`survey_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "survey",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "survey_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "multiple_choice",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`task_id` TEXT NOT NULL, `type` INTEGER NOT NULL, `has_other_option` INTEGER NOT NULL, PRIMARY KEY(`task_id`), FOREIGN KEY(`task_id`) REFERENCES `task`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "taskId",
+            "columnName": "task_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasOtherOption",
+            "columnName": "has_other_option",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "task_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_multiple_choice_task_id",
+            "unique": false,
+            "columnNames": [
+              "task_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_multiple_choice_task_id` ON `${TABLE_NAME}` (`task_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "task",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "task_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "option",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `code` TEXT NOT NULL, `label` TEXT NOT NULL, `task_id` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`task_id`) REFERENCES `task`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "task_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_option_task_id",
+            "unique": false,
+            "columnNames": [
+              "task_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_option_task_id` ON `${TABLE_NAME}` (`task_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "task",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "task_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "survey",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT, `description` TEXT, `acl` TEXT, `data_sharing_terms` BLOB, `general_access` INTEGER NOT NULL, `data_visibility` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "acl",
+            "columnName": "acl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dataSharingTerms",
+            "columnName": "data_sharing_terms",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "generalAccess",
+            "columnName": "general_access",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataVisibility",
+            "columnName": "data_visibility",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "submission",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `location_of_interest_id` TEXT NOT NULL, `job_id` TEXT NOT NULL, `state` INTEGER NOT NULL, `data` TEXT, `created_clientTimestamp` INTEGER NOT NULL, `created_serverTimestamp` INTEGER, `created_user_id` TEXT NOT NULL, `created_user_email` TEXT NOT NULL, `created_user_display_name` TEXT NOT NULL, `modified_clientTimestamp` INTEGER NOT NULL, `modified_serverTimestamp` INTEGER, `modified_user_id` TEXT NOT NULL, `modified_user_email` TEXT NOT NULL, `modified_user_display_name` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`location_of_interest_id`) REFERENCES `location_of_interest`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationOfInterestId",
+            "columnName": "location_of_interest_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "job_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletionState",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created.clientTimestamp",
+            "columnName": "created_clientTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created.serverTimestamp",
+            "columnName": "created_serverTimestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "created.user.id",
+            "columnName": "created_user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created.user.email",
+            "columnName": "created_user_email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created.user.displayName",
+            "columnName": "created_user_display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified.clientTimestamp",
+            "columnName": "modified_clientTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified.serverTimestamp",
+            "columnName": "modified_serverTimestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastModified.user.id",
+            "columnName": "modified_user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified.user.email",
+            "columnName": "modified_user_email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified.user.displayName",
+            "columnName": "modified_user_display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_submission_location_of_interest_id_job_id_state",
+            "unique": false,
+            "columnNames": [
+              "location_of_interest_id",
+              "job_id",
+              "state"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_submission_location_of_interest_id_job_id_state` ON `${TABLE_NAME}` (`location_of_interest_id`, `job_id`, `state`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "location_of_interest",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "location_of_interest_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "submission_mutation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `survey_id` TEXT NOT NULL, `type` INTEGER NOT NULL, `state` INTEGER NOT NULL, `retry_count` INTEGER NOT NULL, `last_error` TEXT NOT NULL, `user_id` TEXT NOT NULL, `client_timestamp` INTEGER NOT NULL, `location_of_interest_id` TEXT NOT NULL, `job_id` TEXT NOT NULL, `submission_id` TEXT NOT NULL, `collection_id` TEXT NOT NULL, `deltas` TEXT, FOREIGN KEY(`location_of_interest_id`) REFERENCES `location_of_interest`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`submission_id`) REFERENCES `submission`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "surveyId",
+            "columnName": "survey_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retry_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "last_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientTimestamp",
+            "columnName": "client_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationOfInterestId",
+            "columnName": "location_of_interest_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "job_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submissionId",
+            "columnName": "submission_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collection_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deltas",
+            "columnName": "deltas",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_submission_mutation_location_of_interest_id",
+            "unique": false,
+            "columnNames": [
+              "location_of_interest_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_submission_mutation_location_of_interest_id` ON `${TABLE_NAME}` (`location_of_interest_id`)"
+          },
+          {
+            "name": "index_submission_mutation_submission_id",
+            "unique": false,
+            "columnNames": [
+              "submission_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_submission_mutation_submission_id` ON `${TABLE_NAME}` (`submission_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "location_of_interest",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "location_of_interest_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "submission",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "submission_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "offline_area",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `state` INTEGER NOT NULL, `north` REAL NOT NULL, `south` REAL NOT NULL, `east` REAL NOT NULL, `west` REAL NOT NULL, `min_zoom` INTEGER NOT NULL, `max_zoom` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "north",
+            "columnName": "north",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "south",
+            "columnName": "south",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "east",
+            "columnName": "east",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "west",
+            "columnName": "west",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minZoom",
+            "columnName": "min_zoom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxZoom",
+            "columnName": "max_zoom",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `email` TEXT NOT NULL, `display_name` TEXT NOT NULL, `photo_url` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parent_task_id` TEXT NOT NULL, `match_type` INTEGER NOT NULL, PRIMARY KEY(`parent_task_id`), FOREIGN KEY(`parent_task_id`) REFERENCES `task`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "parentTaskId",
+            "columnName": "parent_task_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchType",
+            "columnName": "match_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parent_task_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_condition_parent_task_id",
+            "unique": false,
+            "columnNames": [
+              "parent_task_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_condition_parent_task_id` ON `${TABLE_NAME}` (`parent_task_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "task",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "parent_task_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "expression",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`parent_task_id` TEXT NOT NULL, `task_id` TEXT NOT NULL, `expression_type` INTEGER NOT NULL, `option_ids` TEXT, PRIMARY KEY(`parent_task_id`), FOREIGN KEY(`parent_task_id`) REFERENCES `condition`(`parent_task_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "parentTaskId",
+            "columnName": "parent_task_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "task_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expressionType",
+            "columnName": "expression_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionIds",
+            "columnName": "option_ids",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parent_task_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_expression_parent_task_id",
+            "unique": false,
+            "columnNames": [
+              "parent_task_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_expression_parent_task_id` ON `${TABLE_NAME}` (`parent_task_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "condition",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "parent_task_id"
+            ],
+            "referencedColumns": [
+              "parent_task_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6a392f7f45a0198f806ed87429d6256a')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/groundplatform/android/data/local/room/migration/MigrationTest.kt
+++ b/app/src/androidTest/java/org/groundplatform/android/data/local/room/migration/MigrationTest.kt
@@ -19,7 +19,6 @@ import android.database.sqlite.SQLiteDatabase
 import androidx.room.Room
 import androidx.room.migration.Migration
 import androidx.room.testing.MigrationTestHelper
-import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import java.io.IOException
@@ -29,9 +28,9 @@ import org.groundplatform.android.data.local.room.LocalDatabase
 import org.groundplatform.android.data.local.room.migration.MigrationTestDataGenerator.getConditionContentValues
 import org.groundplatform.android.data.local.room.migration.MigrationTestDataGenerator.getExpressionContentValues
 import org.groundplatform.android.data.local.room.migration.MigrationTestDataGenerator.getJobContentValues
+import org.groundplatform.android.data.local.room.migration.MigrationTestDataGenerator.getLocationOfInterestMutationContentValues
 import org.groundplatform.android.data.local.room.migration.MigrationTestDataGenerator.getSurveyContentValues
 import org.groundplatform.android.data.local.room.migration.MigrationTestDataGenerator.getTaskContentValues
-import org.groundplatform.domain.model.Survey
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -40,15 +39,10 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class MigrationTest {
   private val testDatabase = "test.db"
-  private val migrations = arrayOf(Migration_124_125, Migration_125_126)
+  private val migrations = arrayOf(Migration_124_125, Migration_125_126, Migration_126_127)
 
   @get:Rule
-  val helper =
-    MigrationTestHelper(
-      instrumentation = InstrumentationRegistry.getInstrumentation(),
-      assetsFolder = LocalDatabase::class.java.canonicalName!!,
-      openFactory = FrameworkSQLiteOpenHelperFactory(),
-    )
+  val helper = MigrationTestHelper(InstrumentationRegistry.getInstrumentation(), LocalDatabase::class.java)
 
   @Test
   @Throws(IOException::class)
@@ -116,6 +110,52 @@ class MigrationTest {
 
       val deletedSurvey = surveyDao().findSurveyById(faultySurvey)
       assertEquals(null, deletedSurvey)
+
+      close()
+    }
+  }
+
+  @Test
+  @Throws(IOException::class)
+  fun migrate126To127() = runBlocking {
+    val completedState = 3
+    val failedState = 2
+    val mediaPendingState = 5
+
+    helper.createDatabase(testDatabase, 126).apply {
+      // Insert LOI mutation with MEDIA_UPLOAD_PENDING status (should be rewritten to COMPLETED)
+      insert(
+        "location_of_interest_mutation",
+        SQLiteDatabase.CONFLICT_REPLACE,
+        getLocationOfInterestMutationContentValues(id = 1L, state = mediaPendingState),
+      )
+      // Insert LOI mutation already COMPLETED (should remain unchanged)
+      insert(
+        "location_of_interest_mutation",
+        SQLiteDatabase.CONFLICT_REPLACE,
+        getLocationOfInterestMutationContentValues(id = 2L, state = completedState),
+      )
+      // Insert LOI mutation with FAILED status (should remain unchanged)
+      insert(
+        "location_of_interest_mutation",
+        SQLiteDatabase.CONFLICT_REPLACE,
+        getLocationOfInterestMutationContentValues(id = 3L, state = failedState),
+      )
+      close()
+    }
+
+    helper.runMigrationsAndValidate(testDatabase, 127, true, *migrations)
+
+    with(getMigratedRoomDatabase(migrations)) {
+      val mutations = locationOfInterestMutationDao().getAllMutationsFlow().first()
+      assertEquals(3, mutations.size)
+
+      // Verify MEDIA_UPLOAD_PENDING was rewritten to COMPLETED
+      assertEquals(completedState, mutations.find { it.id == 1L }?.syncStatus?.intValue())
+      // Verify already COMPLETED remains unchanged
+      assertEquals(completedState, mutations.find { it.id == 2L }?.syncStatus?.intValue())
+      // Verify FAILED remains unchanged
+      assertEquals(failedState, mutations.find { it.id == 3L }?.syncStatus?.intValue())
 
       close()
     }

--- a/app/src/androidTest/java/org/groundplatform/android/data/local/room/migration/MigrationTestDataGenerator.kt
+++ b/app/src/androidTest/java/org/groundplatform/android/data/local/room/migration/MigrationTestDataGenerator.kt
@@ -62,4 +62,29 @@ object MigrationTestDataGenerator {
       put("task_id", "someOtherTask")
       put("expression_type", 1)
     }
+
+  fun getLocationOfInterestMutationContentValues(
+    id: Long,
+    state: Int,
+    surveyId: String = "survey",
+    loiId: String = "loi",
+    jobId: String = "job",
+    userId: String = "user",
+    collectionId: String = "collection",
+  ): ContentValues =
+    ContentValues().apply {
+      put("id", id)
+      put("survey_id", surveyId)
+      put("type", 1) // CREATE
+      put("state", state)
+      put("retry_count", 0L)
+      put("last_error", "")
+      put("user_id", userId)
+      put("client_timestamp", 0L)
+      put("location_of_interest_id", loiId)
+      put("job_id", jobId)
+      put("collection_id", collectionId)
+      put("newProperties", "{}")
+      put("newCustomId", "")
+    }
 }

--- a/app/src/main/java/org/groundplatform/android/common/Constants.kt
+++ b/app/src/main/java/org/groundplatform/android/common/Constants.kt
@@ -26,7 +26,7 @@ object Constants {
   const val SHARED_PREFS_MODE = Context.MODE_PRIVATE
 
   // Local db settings.
-  const val DB_VERSION = 126
+  const val DB_VERSION = 127
   const val DB_NAME = "ground.db"
 
   // Firebase Cloud Firestore settings.

--- a/app/src/main/java/org/groundplatform/android/data/local/room/migration/Migration_126_127.kt
+++ b/app/src/main/java/org/groundplatform/android/data/local/room/migration/Migration_126_127.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.data.local.room.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * LOIs never carry media, so MEDIA_UPLOAD_PENDING (5) is not a valid state for them. It was written
+ * by an earlier version of the LocalMutationSyncWorker that tagged every synced mutation as pending
+ * media upload. Those rows should be set to COMPLETED (3).
+ */
+val Migration_126_127 =
+  object : Migration(126, 127) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+      db.execSQL("UPDATE location_of_interest_mutation SET state = 3 WHERE state = 5")
+    }
+  }

--- a/app/src/main/java/org/groundplatform/android/data/sync/LocalMutationSyncWorker.kt
+++ b/app/src/main/java/org/groundplatform/android/data/sync/LocalMutationSyncWorker.kt
@@ -25,10 +25,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import org.groundplatform.android.data.remote.RemoteDataStore
 import org.groundplatform.android.di.coroutines.IoDispatcher
-import org.groundplatform.android.util.priority
-import org.groundplatform.domain.model.mutation.Mutation
 import org.groundplatform.domain.repository.MutationRepositoryInterface
 import timber.log.Timber
 
@@ -51,31 +48,15 @@ constructor(
     withContext(ioDispatcher) {
       val queue = mutationRepository.getIncompleteUploads()
       Timber.d("Uploading ${queue.size} additions / changes")
-      val results = queue.map { processMutations(it.mutations()) }
-      if (results.any { it }) mediaUploadWorkManager.enqueueSyncWorker()
-      if (results.all { it }) success() else retry()
-    }
+      val results = queue.map { mutationRepository.processMutations(it.mutations()) }
 
-  /**
-   * Applies mutations to remote data store, updating their status in the queue accordingly. Catches
-   * and handles all exceptions.
-   *
-   * @return `true` if all mutations were successfully synced with [RemoteDataStore], `false` if at
-   *   least one failed.
-   */
-  private suspend fun processMutations(mutations: List<Mutation>): Boolean {
-    if (mutations.isEmpty()) return true
-    try {
-      mutationRepository.markAsInProgress(mutations)
-      mutationRepository.uploadMutations(mutations)
-      mutationRepository.finalizePendingMutationsForMediaUpload(mutations)
-      return true
-    } catch (t: Throwable) {
-      // Mark all mutations as having failed since the remote datastore only commits when all
-      // mutations have succeeded.
-      mutationRepository.markAsFailed(mutations, t)
-      Timber.log(t.priority(), t, "Failed to sync local data")
-      return false
+      val successfulMutations =
+        results.filterIsInstance<MutationRepositoryInterface.MutationResult.Success>()
+
+      if (successfulMutations.any { it.hasPendingMediaUploads }) {
+        mediaUploadWorkManager.enqueueSyncWorker()
+      }
+
+      if (results.size == successfulMutations.size) success() else retry()
     }
-  }
 }

--- a/app/src/main/java/org/groundplatform/android/di/LocalDatabaseModule.kt
+++ b/app/src/main/java/org/groundplatform/android/di/LocalDatabaseModule.kt
@@ -30,6 +30,7 @@ import org.groundplatform.android.common.Constants
 import org.groundplatform.android.data.local.room.LocalDatabase
 import org.groundplatform.android.data.local.room.migration.Migration_124_125
 import org.groundplatform.android.data.local.room.migration.Migration_125_126
+import org.groundplatform.android.data.local.room.migration.Migration_126_127
 import org.groundplatform.android.di.coroutines.IoDispatcher
 
 @InstallIn(SingletonComponent::class)
@@ -53,7 +54,7 @@ object LocalDatabaseModule {
         .setTransactionExecutor(Executors.newSingleThreadExecutor())
         // Run queries and transactions on background I/O thread.
         .setQueryExecutor(ioDispatcher.asExecutor())
-        .addMigrations(Migration_124_125, Migration_125_126)
+        .addMigrations(Migration_124_125, Migration_125_126, Migration_126_127)
         .build()
         .also { INSTANCE = it }
   }

--- a/app/src/main/java/org/groundplatform/android/repository/MutationRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/MutationRepository.kt
@@ -25,6 +25,7 @@ import org.groundplatform.android.data.local.stores.LocalLocationOfInterestStore
 import org.groundplatform.android.data.local.stores.LocalSubmissionStore
 import org.groundplatform.android.data.remote.RemoteDataStore
 import org.groundplatform.android.system.auth.AuthenticationManager
+import org.groundplatform.android.util.priority
 import org.groundplatform.domain.model.User
 import org.groundplatform.domain.model.mutation.LocationOfInterestMutation
 import org.groundplatform.domain.model.mutation.Mutation
@@ -111,23 +112,36 @@ constructor(
    */
   private suspend fun saveMutationsLocally(mutations: List<Mutation>) {
     val loiMutations = mutations.filterIsInstance<LocationOfInterestMutation>()
-    localLocationOfInterestStore.updateAll(loiMutations)
+    if (loiMutations.isNotEmpty()) localLocationOfInterestStore.updateAll(loiMutations)
 
     val submissionMutations = mutations.filterIsInstance<SubmissionMutation>()
-    localSubmissionStore.updateAll(submissionMutations)
+    if (submissionMutations.isNotEmpty()) localSubmissionStore.updateAll(submissionMutations)
   }
 
-  override suspend fun finalizePendingMutationsForMediaUpload(mutations: List<Mutation>) {
+  override suspend fun processMutations(
+    mutations: List<Mutation>
+  ): MutationRepositoryInterface.MutationResult =
+    try {
+    markAsInProgress(mutations)
+    uploadMutations(mutations)
     finalizeDeletions(mutations)
-    // TODO: Only do this is there are actually photos to upload.
-    // Issue URL: https://github.com/google/ground-android/issues/2873
-    markForMediaUpload(mutations)
-  }
+    val (hasMediaToUpload, hasNoMedia) =
+      mutations.partition { it is SubmissionMutation && it.getPhotoData().isNotEmpty() }
+    if (hasNoMedia.isNotEmpty()) markAsComplete(hasNoMedia)
+    if (hasMediaToUpload.isNotEmpty()) markForMediaUpload(hasMediaToUpload)
+    MutationRepositoryInterface.MutationResult.Success(hasMediaToUpload.isNotEmpty())
+    } catch (t: Throwable) {
+      // Mark all mutations as having failed since the remote datastore only commits when all
+      // mutations have succeeded.
+      markAsFailed(mutations, t)
+      Timber.log(t.priority(), t, "Failed to sync local data")
+      return MutationRepositoryInterface.MutationResult.Failure
+    }
 
   private suspend fun finalizeDeletions(mutations: List<Mutation>) =
     mutations
       .filter { it.type === Mutation.Type.DELETE }
-      .map { mutation ->
+      .forEach { mutation ->
         when (mutation) {
           is SubmissionMutation -> {
             localSubmissionStore.deleteSubmission(mutation.submissionId)
@@ -138,11 +152,11 @@ constructor(
         }
       }
 
-  override suspend fun markAsInProgress(mutations: List<Mutation>) {
+  private suspend fun markAsInProgress(mutations: List<Mutation>) {
     saveMutationsLocally(mutations.updateMutationStatus(IN_PROGRESS))
   }
 
-  override suspend fun uploadMutations(mutations: List<Mutation>) {
+  private suspend fun uploadMutations(mutations: List<Mutation>) {
     val user = userRepository.getAuthenticatedUser()
     remoteDataStore.applyMutations(mutations, user)
   }

--- a/app/src/main/java/org/groundplatform/android/repository/MutationRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/MutationRepository.kt
@@ -135,7 +135,7 @@ constructor(
       // mutations have succeeded.
       markAsFailed(mutations, t)
       Timber.log(t.priority(), t, "Failed to sync local data")
-      return MutationRepositoryInterface.MutationResult.Failure
+      MutationRepositoryInterface.MutationResult.Failure
     }
 
   private suspend fun finalizeDeletions(mutations: List<Mutation>) =

--- a/app/src/test/java/org/groundplatform/android/data/sync/LocalMutationSyncWorkerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/data/sync/LocalMutationSyncWorkerTest.kt
@@ -40,20 +40,25 @@ import org.groundplatform.android.data.remote.FakeRemoteDataStore
 import org.groundplatform.android.di.coroutines.IoDispatcher
 import org.groundplatform.android.system.auth.FakeAuthenticationManager
 import org.groundplatform.domain.model.geometry.Point
-import org.groundplatform.domain.model.mutation.LocationOfInterestMutation
 import org.groundplatform.domain.model.mutation.Mutation
+import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.COMPLETED
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.FAILED
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.IN_PROGRESS
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.MEDIA_UPLOAD_PENDING
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.PENDING
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.UNKNOWN
-import org.groundplatform.domain.model.mutation.SubmissionMutation
+import org.groundplatform.domain.model.submission.ValueDelta
+import org.groundplatform.domain.model.task.PhotoTaskData
+import org.groundplatform.domain.model.task.Task
 import org.groundplatform.domain.repository.MutationRepositoryInterface
 import org.groundplatform.domain.repository.UserRepositoryInterface
+import org.groundplatform.testing.FakeDataGenerator
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
 @HiltAndroidTest
@@ -98,22 +103,20 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
         )
     }
 
-  private val testSurvey = FakeData.SURVEY.copy(id = TEST_SURVEY_ID)
-
   @Before
   override fun setUp() {
     super.setUp()
     context = ApplicationProvider.getApplicationContext()
     runBlocking {
-      fakeAuthenticationManager.setUser(FakeData.USER.copy(id = TEST_USER_ID))
-      localUserStore.insertOrUpdateUser(FakeData.USER.copy(id = TEST_USER_ID))
-      localSurveyStore.insertOrUpdateSurvey(testSurvey)
+      fakeAuthenticationManager.setUser(TEST_USER)
+      localUserStore.insertOrUpdateUser(TEST_USER)
+      localSurveyStore.insertOrUpdateSurvey(TEST_SURVEY)
     }
   }
 
   @Test
   fun `Ignores mutations not belonging to current user`() = runWithTestDispatcher {
-    fakeAuthenticationManager.setUser(FakeData.USER.copy(id = "random user id"))
+    fakeAuthenticationManager.setUser(TEST_USER.copy(id = "random user id"))
 
     addPendingMutations()
 
@@ -125,11 +128,11 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
 
   @Test
   fun `Ignores mutations partially if there are multiple users`() = runWithTestDispatcher {
-    localUserStore.insertOrUpdateUser(FakeData.USER.copy(id = "user1"))
+    localUserStore.insertOrUpdateUser(TEST_USER.copy(id = "user1"))
     localLocationOfInterestStore.applyAndEnqueue(createLoiMutation("user1"))
 
-    localUserStore.insertOrUpdateUser(FakeData.USER.copy(id = TEST_USER_ID))
-    localSubmissionStore.applyAndEnqueue(createSubmissionMutation(TEST_USER_ID))
+    localUserStore.insertOrUpdateUser(TEST_USER.copy(id = TEST_USER_ID))
+    localSubmissionStore.applyAndEnqueue(createSubmissionMutation())
 
     val result = createAndDoWork(context)
 
@@ -169,6 +172,41 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
         lastErrors = listOf(ERROR_MESSAGE, ERROR_MESSAGE),
       )
     }
+
+  @Test
+  fun `Enqueues media upload worker when any mutation has pending photos`() =
+    runWithTestDispatcher {
+      val jobWithPhotoTask =
+        TEST_JOB.copy(tasks = mapOf("photoTaskId" to FakeDataGenerator.newTask(id = "photoTaskId", type = Task.Type.PHOTO)))
+      localSurveyStore.insertOrUpdateSurvey(
+        TEST_SURVEY.copy(jobMap = mapOf(jobWithPhotoTask.id to jobWithPhotoTask))
+      )
+      localLocationOfInterestStore.applyAndEnqueue(createLoiMutation(TEST_USER_ID))
+      localSubmissionStore.applyAndEnqueue(
+        createSubmissionMutation()
+          .copy(
+            deltas =
+              listOf(ValueDelta("photoTaskId", Task.Type.PHOTO, PhotoTaskData("some/photo.jpg")))
+          )
+      )
+
+      val result = createAndDoWork(context)
+
+      assertThat(result).isEqualTo(success())
+      assertMutationsState(complete = 1)
+      assertThat(getMutations(MEDIA_UPLOAD_PENDING)).hasSize(1)
+      verify(mockMediaUploadWorkManager).enqueueSyncWorker()
+    }
+
+  @Test
+  fun `Does not enqueue media upload worker when no mutation has photos`() = runWithTestDispatcher {
+    addPendingMutations()
+
+    val result = createAndDoWork(context)
+
+    assertThat(result).isEqualTo(success())
+    verify(mockMediaUploadWorkManager, never()).enqueueSyncWorker()
+  }
 
   @Test
   fun `Worker retries on failure`() = runWithTestDispatcher {
@@ -217,7 +255,7 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
       .that(getMutations(IN_PROGRESS))
       .hasSize(inProgress)
     assertWithMessage("Completed mutations count incorrect")
-      .that(getMutations(MEDIA_UPLOAD_PENDING))
+      .that(getMutations(COMPLETED))
       .hasSize(complete)
 
     val failedMutations = getMutations(FAILED)
@@ -227,15 +265,13 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
   }
 
   private suspend fun addPendingMutations() {
-    localLocationOfInterestStore.applyAndEnqueue(createLoiMutation(TEST_USER_ID))
-    localSubmissionStore.applyAndEnqueue(createSubmissionMutation(TEST_USER_ID))
+    localLocationOfInterestStore.applyAndEnqueue(createLoiMutation())
+    localSubmissionStore.applyAndEnqueue(createSubmissionMutation())
   }
 
-  private fun createLoiMutation(userId: String) =
-    LocationOfInterestMutation(
+  private fun createLoiMutation(userId: String = TEST_USER_ID) =
+    FakeDataGenerator.newLoiMutation(
       jobId = TEST_JOB.id,
-      type = Mutation.Type.CREATE,
-      syncStatus = Mutation.SyncStatus.PENDING,
       locationOfInterestId = TEST_LOI_ID,
       userId = userId,
       surveyId = TEST_SURVEY_ID,
@@ -243,12 +279,10 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
       collectionId = "collectionId",
     )
 
-  private fun createSubmissionMutation(userId: String) =
-    SubmissionMutation(
-      type = Mutation.Type.CREATE,
-      syncStatus = Mutation.SyncStatus.PENDING,
-      locationOfInterestId = TEST_LOI_ID,
-      userId = userId,
+  private fun createSubmissionMutation() =
+    FakeDataGenerator.newSubmissionMutation(
+      loiId = TEST_LOI_ID,
+      userId = TEST_USER_ID,
       job = TEST_JOB,
       surveyId = TEST_SURVEY_ID,
       collectionId = "collectionId",
@@ -266,6 +300,9 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
     private const val TEST_SURVEY_ID = "surveyId"
     private const val TEST_USER_ID = "userId"
     private val TEST_GEOMETRY = Point(FakeData.COORDINATES)
-    private val TEST_JOB = FakeData.JOB
+    private val TEST_JOB = FakeDataGenerator.newJob()
+    private val TEST_USER = FakeDataGenerator.newUser(id = TEST_USER_ID)
+    private val TEST_SURVEY =
+      FakeDataGenerator.newSurvey(id = TEST_SURVEY_ID, jobMap = mapOf(TEST_JOB.id to TEST_JOB))
   }
 }

--- a/app/src/test/java/org/groundplatform/android/data/sync/LocalMutationSyncWorkerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/data/sync/LocalMutationSyncWorkerTest.kt
@@ -177,7 +177,12 @@ class LocalMutationSyncWorkerTest : BaseHiltTest() {
   fun `Enqueues media upload worker when any mutation has pending photos`() =
     runWithTestDispatcher {
       val jobWithPhotoTask =
-        TEST_JOB.copy(tasks = mapOf("photoTaskId" to FakeDataGenerator.newTask(id = "photoTaskId", type = Task.Type.PHOTO)))
+        TEST_JOB.copy(
+          tasks =
+            mapOf(
+              "photoTaskId" to FakeDataGenerator.newTask(id = "photoTaskId", type = Task.Type.PHOTO)
+            )
+        )
       localSurveyStore.insertOrUpdateSurvey(
         TEST_SURVEY.copy(jobMap = mapOf(jobWithPhotoTask.id to jobWithPhotoTask))
       )

--- a/app/src/test/java/org/groundplatform/android/repository/MutationRepositoryTest.kt
+++ b/app/src/test/java/org/groundplatform/android/repository/MutationRepositoryTest.kt
@@ -34,6 +34,10 @@ import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.MEDIA_UPLOAD
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.MEDIA_UPLOAD_PENDING
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.PENDING
 import org.groundplatform.domain.model.mutation.SubmissionMutation
+import org.groundplatform.domain.model.submission.ValueDelta
+import org.groundplatform.domain.model.task.PhotoTaskData
+import org.groundplatform.domain.model.task.Task
+import org.groundplatform.domain.repository.MutationRepositoryInterface.MutationResult
 import org.groundplatform.domain.repository.UserRepositoryInterface
 import org.groundplatform.testing.FakeDataGenerator
 import org.junit.Before
@@ -41,8 +45,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -155,49 +161,117 @@ class MutationRepositoryTest {
   }
 
   @Test
-  fun `finalizePendingMutationsForMediaUpload marks non-delete mutations for media upload`() =
+  fun `processMutations uploads, marks non-media mutations as COMPLETED, and reports no media`() =
     runTest {
+      setupMocks()
       val loi = FakeDataGenerator.newLoiMutation(id = 1, collectionId = "a")
       val submission = FakeDataGenerator.newSubmissionMutation(id = 2, collectionId = "a")
 
-      repository.finalizePendingMutationsForMediaUpload(listOf(loi, submission))
+      val result = repository.processMutations(listOf(loi, submission))
 
+      assertThat(result).isEqualTo(MutationResult.Success(hasPendingMediaUploads = false))
+      verify(remoteDataStore).applyMutations(listOf(loi, submission), TEST_USER)
+      // Stores are touched twice: once for IN_PROGRESS, once for COMPLETED.
       val loiCaptor = argumentCaptor<List<LocationOfInterestMutation>>()
       val submissionCaptor = argumentCaptor<List<SubmissionMutation>>()
-      verify(localLoiStore).updateAll(loiCaptor.capture())
-      verify(localSubmissionStore).updateAll(submissionCaptor.capture())
-      assertThat(loiCaptor.firstValue.map { it.syncStatus }).containsExactly(MEDIA_UPLOAD_PENDING)
-      assertThat(submissionCaptor.firstValue.map { it.syncStatus })
-        .containsExactly(MEDIA_UPLOAD_PENDING)
+      verify(localLoiStore, times(2)).updateAll(loiCaptor.capture())
+      verify(localSubmissionStore, times(2)).updateAll(submissionCaptor.capture())
+      assertThat(loiCaptor.allValues.map { it.single().syncStatus })
+        .containsExactly(IN_PROGRESS, COMPLETED)
+        .inOrder()
+      assertThat(submissionCaptor.allValues.map { it.single().syncStatus })
+        .containsExactly(IN_PROGRESS, COMPLETED)
+        .inOrder()
     }
 
   @Test
-  fun `finalizePendingMutationsForMediaUpload deletes LOI and submission for DELETE mutations`() =
+  fun `processMutations marks submissions with photos for media upload and signals pending media`() =
     runTest {
-      val loi = FakeDataGenerator.newLoiMutation(id = 1, mutationType = Mutation.Type.DELETE)
-      val submission =
-        FakeDataGenerator.newSubmissionMutation(
-          id = 2,
-          collectionId = "a",
-          mutationType = Mutation.Type.DELETE,
-          submissionId = "submission-to-delete",
-        )
+      setupMocks()
+      val loi = FakeDataGenerator.newLoiMutation(id = 1, collectionId = "a")
+      val submissionWithPhoto =
+        FakeDataGenerator.newSubmissionMutation(id = 2, collectionId = "a")
+          .copy(
+            deltas =
+              listOf(ValueDelta("photoTaskId", Task.Type.PHOTO, PhotoTaskData("some/photo.jpg")))
+          )
 
-      repository.finalizePendingMutationsForMediaUpload(listOf(loi, submission))
+      val result = repository.processMutations(listOf(loi, submissionWithPhoto))
 
-      verify(localLoiStore).deleteLocationOfInterest(loi.locationOfInterestId)
-      verify(localSubmissionStore).deleteSubmission("submission-to-delete")
+      assertThat(result).isEqualTo(MutationResult.Success(hasPendingMediaUploads = true))
+      val loiCaptor = argumentCaptor<List<LocationOfInterestMutation>>()
+      val submissionCaptor = argumentCaptor<List<SubmissionMutation>>()
+      // Stores are touched twice: once for IN_PROGRESS, once for COMPLETED/MEDIA_UPLOAD_PENDING.
+      verify(localLoiStore, times(2)).updateAll(loiCaptor.capture())
+      verify(localSubmissionStore, times(2)).updateAll(submissionCaptor.capture())
+      assertThat(loiCaptor.allValues.last().single().syncStatus).isEqualTo(COMPLETED)
+      assertThat(submissionCaptor.allValues.last().single().syncStatus)
+        .isEqualTo(MEDIA_UPLOAD_PENDING)
     }
 
   @Test
-  fun `markAsInProgress saves mutations with IN_PROGRESS status`() = runTest {
-    val mutation = FakeDataGenerator.newLoiMutation(syncStatus = PENDING)
+  fun `processMutations deletes local LOI and submission for DELETE mutations`() = runTest {
+    setupMocks()
+    val loiDelete =
+      FakeDataGenerator.newLoiMutation(
+        id = 1,
+        collectionId = "a",
+        mutationType = Mutation.Type.DELETE,
+      )
+    val submissionDelete =
+      FakeDataGenerator.newSubmissionMutation(
+        id = 2,
+        collectionId = "a",
+        submissionId = "submission-to-delete",
+        mutationType = Mutation.Type.DELETE,
+      )
 
-    repository.markAsInProgress(listOf(mutation))
+    val result = repository.processMutations(listOf(loiDelete, submissionDelete))
 
-    val captor = argumentCaptor<List<LocationOfInterestMutation>>()
-    verify(localLoiStore).updateAll(captor.capture())
-    assertThat(captor.firstValue.single().syncStatus).isEqualTo(IN_PROGRESS)
+    assertThat(result).isEqualTo(MutationResult.Success(hasPendingMediaUploads = false))
+    verify(localLoiStore).deleteLocationOfInterest(loiDelete.locationOfInterestId)
+    verify(localSubmissionStore).deleteSubmission("submission-to-delete")
+  }
+
+  @Test
+  fun `processMutations marks all mutations FAILED and returns Failure when remote upload throws`() =
+    runTest {
+      setupMocks()
+      val loi = FakeDataGenerator.newLoiMutation(id = 1, collectionId = "a", retryCount = 1)
+      val submission =
+        FakeDataGenerator.newSubmissionMutation(id = 2, collectionId = "a", retryCount = 0)
+      whenever(remoteDataStore.applyMutations(any(), any())).thenThrow(RuntimeException("boom"))
+
+      val result = repository.processMutations(listOf(loi, submission))
+
+      assertThat(result).isEqualTo(MutationResult.Failure)
+      val loiCaptor = argumentCaptor<List<LocationOfInterestMutation>>()
+      val submissionCaptor = argumentCaptor<List<SubmissionMutation>>()
+      // Stores are touched twice: once for IN_PROGRESS, once for COMPLETED.
+      verify(localLoiStore, times(2)).updateAll(loiCaptor.capture())
+      verify(localSubmissionStore, times(2)).updateAll(submissionCaptor.capture())
+      with(loiCaptor.allValues.last().single()) {
+        assertThat(syncStatus).isEqualTo(FAILED)
+        assertThat(retryCount).isEqualTo(2)
+        assertThat(lastError).isEqualTo("boom")
+      }
+      with(submissionCaptor.allValues.last().single()) {
+        assertThat(syncStatus).isEqualTo(FAILED)
+        assertThat(retryCount).isEqualTo(1)
+        assertThat(lastError).isEqualTo("boom")
+      }
+    }
+
+  @Test
+  fun `processMutations does not do any deletions if there are no DELETE mutations`() = runTest {
+    setupMocks()
+    val loi = FakeDataGenerator.newLoiMutation(id = 1, collectionId = "a")
+    val submission = FakeDataGenerator.newSubmissionMutation(id = 2, collectionId = "a")
+
+    repository.processMutations(listOf(loi, submission))
+
+    verify(localLoiStore, never()).deleteLocationOfInterest(any())
+    verify(localSubmissionStore, never()).deleteSubmission(any())
   }
 
   @Test
@@ -228,22 +302,6 @@ class MutationRepositoryTest {
   }
 
   @Test
-  fun `markAsFailedMediaUpload increments retry count and records error message`() = runTest {
-    val mutation = FakeDataGenerator.newSubmissionMutation(retryCount = 0)
-    val error = RuntimeException("upload failed")
-
-    repository.markAsFailedMediaUpload(listOf(mutation), error)
-
-    val captor = argumentCaptor<List<SubmissionMutation>>()
-    verify(localSubmissionStore).updateAll(captor.capture())
-    with(captor.firstValue.single()) {
-      assertThat(syncStatus).isEqualTo(MEDIA_UPLOAD_AWAITING_RETRY)
-      assertThat(retryCount).isEqualTo(1)
-      assertThat(lastError).isEqualTo("upload failed")
-    }
-  }
-
-  @Test
   fun `markAsMediaUploadInProgress preserves retry count`() = runTest {
     val mutation = FakeDataGenerator.newSubmissionMutation(retryCount = 4, lastError = "last error")
 
@@ -256,24 +314,6 @@ class MutationRepositoryTest {
       assertThat(retryCount).isEqualTo(4)
       assertThat(lastError).isEqualTo("last error")
     }
-  }
-
-  @Test
-  fun `uploadMutations delegates to remote data store with authenticated user`() = runTest {
-    setupMocks()
-    val mutations = listOf(FakeDataGenerator.newLoiMutation())
-
-    repository.uploadMutations(mutations)
-
-    verify(remoteDataStore).applyMutations(mutations, TEST_USER)
-  }
-
-  @Test
-  fun `finalizePendingMutationsForMediaUpload with empty list does not touch stores`() = runTest {
-    repository.finalizePendingMutationsForMediaUpload(emptyList())
-
-    verify(localLoiStore, never()).deleteLocationOfInterest(org.mockito.kotlin.any())
-    verify(localSubmissionStore, never()).deleteSubmission(org.mockito.kotlin.any())
   }
 
   private suspend fun setupMocks(

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/MutationRepositoryInterface.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/MutationRepositoryInterface.kt
@@ -45,14 +45,13 @@ interface MutationRepositoryInterface {
   fun getUploadQueueFlow(): Flow<List<UploadQueueEntry>>
 
   /**
-   * Mark pending mutations as ready for media upload. If the mutation is of type DELETE, also
-   * removes the corresponding submission or LOI.
+   * Applies mutations to remote data store, updating their status in the queue accordingly. Catches
+   * and handles all exceptions.
+   *
+   * @return [MutationResult] indicating the outcome of the sync attempt, including whether any
+   *   media uploads are pending.
    */
-  suspend fun finalizePendingMutationsForMediaUpload(mutations: List<Mutation>)
-
-  suspend fun markAsInProgress(mutations: List<Mutation>)
-
-  suspend fun uploadMutations(mutations: List<Mutation>)
+  suspend fun processMutations(mutations: List<Mutation>): MutationResult
 
   suspend fun markAsComplete(mutations: List<Mutation>)
 
@@ -61,4 +60,20 @@ interface MutationRepositoryInterface {
   suspend fun markAsMediaUploadInProgress(mutations: List<SubmissionMutation>)
 
   suspend fun markAsFailedMediaUpload(mutations: List<SubmissionMutation>, error: Throwable)
+
+  /** Specifies whether the sync succeeded and if there is any follow-up work. */
+  sealed class MutationResult {
+    /**
+     * All mutations were successfully applied to the remote data store.
+     *
+     * @property hasPendingMediaUploads `true` if one or more mutations contain media that still
+     *   need to be uploaded.
+     */
+    data class Success(val hasPendingMediaUploads: Boolean) : MutationResult()
+
+    /**
+     * At least one mutation failed to apply; all mutations in the batch have been marked failed.
+     */
+    data object Failure : MutationResult()
+  }
 }

--- a/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
+++ b/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
@@ -209,6 +209,6 @@ object FakeDataGenerator {
       clientTimestamp = timestamp,
       retryCount = retryCount,
       lastError = lastError,
-      deltas = deltas
+      deltas = deltas,
     )
 }

--- a/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
+++ b/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
@@ -40,7 +40,8 @@ import org.groundplatform.domain.model.task.Task
 
 @Suppress("StringLiteralDuplication")
 object FakeDataGenerator {
-  fun newUser(): User = User("user id", "", "User")
+  fun newUser(id: String = "user id", email: String = "", displayName: String = "User"): User =
+    User(id, email, displayName)
 
   fun newUserSettings(
     language: String = "en",
@@ -193,6 +194,7 @@ object FakeDataGenerator {
     timestamp: Long = Clock.System.now().toEpochMilliseconds(),
     retryCount: Long = 0,
     lastError: String = "",
+    deltas: List<ValueDelta> = emptyList(),
   ): SubmissionMutation =
     SubmissionMutation(
       id = id,
@@ -207,5 +209,6 @@ object FakeDataGenerator {
       clientTimestamp = timestamp,
       retryCount = retryCount,
       lastError = lastError,
+      deltas = deltas
     )
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #2836
Fixes #2873 

<!-- PR description. -->

All mutations (submissions or LOIs) were being marked as `MEDIA_UPLOAD_PENDING` in the `MutationRepository`. This not only is a waste of resources, queuing the `MediaUploadWorkManager` needlessly, but it also marked the LOI mutations as `MEDIA_UPLOAD_PENDING` indefinitely, since the `MediaUploadWorker` only marks mutations as `COMPLETE` if they contain photo data (even if it's an empty list), and only submission mutations contain that.

This PR adds the logic to only apply `MEDIA_UPLOAD_PENDING` to submissions that actually have photo data to upload. It also adds a Room migration to make sure the LOI mutations are set as `COMPLETE` if they were with a `MEDIA_UPLOAD_PENDING` state

@shobhitagarwal1612 PTAL?
