### PR TITLE
Refactor UserMediaRepository

### DIFF
--- a/app/src/main/java/org/groundplatform/android/data/sync/MediaUploadWorker.kt
+++ b/app/src/main/java/org/groundplatform/android/data/sync/MediaUploadWorker.kt
@@ -23,6 +23,7 @@ import androidx.work.ListenableWorker.Result.success
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import java.io.File
 import java.io.FileNotFoundException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -91,7 +92,7 @@ constructor(
   private suspend fun uploadPhotoMedia(photoTaskData: PhotoTaskData): kotlin.Result<Unit> {
     try {
       val path = photoTaskData.remoteFilename
-      val photoFile = userMediaRepository.getLocalFileFromRemotePath(path)
+      val photoFile = File(userMediaRepository.getLocalFileFromRemotePath(path))
       Timber.d("Starting photo upload. local path: ${photoFile.path}, remote path: $path")
       if (!photoFile.exists()) {
         throw FileNotFoundException(photoFile.path)

--- a/app/src/main/java/org/groundplatform/android/data/sync/MediaUploadWorker.kt
+++ b/app/src/main/java/org/groundplatform/android/data/sync/MediaUploadWorker.kt
@@ -29,11 +29,11 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.groundplatform.android.data.remote.RemoteStorageManager
 import org.groundplatform.android.di.coroutines.IoDispatcher
-import org.groundplatform.android.repository.UserMediaRepository
 import org.groundplatform.android.util.priority
 import org.groundplatform.domain.model.mutation.SubmissionMutation
 import org.groundplatform.domain.model.task.PhotoTaskData
 import org.groundplatform.domain.repository.MutationRepositoryInterface
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface
 import timber.log.Timber
 
 /**
@@ -53,7 +53,7 @@ constructor(
   @Assisted workerParams: WorkerParameters,
   private val remoteStorageManager: RemoteStorageManager,
   private val mutationRepository: MutationRepositoryInterface,
-  private val userMediaRepository: UserMediaRepository,
+  private val userMediaRepository: UserMediaRepositoryInterface,
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : CoroutineWorker(context, workerParams) {
 
@@ -92,7 +92,7 @@ constructor(
   private suspend fun uploadPhotoMedia(photoTaskData: PhotoTaskData): kotlin.Result<Unit> {
     try {
       val path = photoTaskData.remoteFilename
-      val photoFile = File(userMediaRepository.getLocalFileFromRemotePath(path))
+      val photoFile = File(userMediaRepository.getLocalFileFromRemotePath(path).value)
       Timber.d("Starting photo upload. local path: ${photoFile.path}, remote path: $path")
       if (!photoFile.exists()) {
         throw FileNotFoundException(photoFile.path)

--- a/app/src/main/java/org/groundplatform/android/di/RepositoryModule.kt
+++ b/app/src/main/java/org/groundplatform/android/di/RepositoryModule.kt
@@ -27,6 +27,7 @@ import org.groundplatform.android.repository.OfflineAreaRepository
 import org.groundplatform.android.repository.SubmissionRepository
 import org.groundplatform.android.repository.SurveyRepository
 import org.groundplatform.android.repository.TermsOfServiceRepository
+import org.groundplatform.android.repository.UserMediaRepository
 import org.groundplatform.android.repository.UserRepository
 import org.groundplatform.domain.repository.LocationOfInterestRepositoryInterface
 import org.groundplatform.domain.repository.MapStateRepositoryInterface
@@ -35,6 +36,7 @@ import org.groundplatform.domain.repository.OfflineAreaRepositoryInterface
 import org.groundplatform.domain.repository.SubmissionRepositoryInterface
 import org.groundplatform.domain.repository.SurveyRepositoryInterface
 import org.groundplatform.domain.repository.TermsOfServiceRepositoryInterface
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface
 import org.groundplatform.domain.repository.UserRepositoryInterface
 
 @Module
@@ -103,4 +105,12 @@ abstract class OfflineAreaRepositoryModule {
   abstract fun bindOfflineAreaRepositoryRepository(
     impl: OfflineAreaRepository
   ): OfflineAreaRepositoryInterface
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class UserMediaRepositoryModule {
+  @Binds
+  @Singleton
+  abstract fun bindUserMediaRepository(impl: UserMediaRepository): UserMediaRepositoryInterface
 }

--- a/app/src/main/java/org/groundplatform/android/repository/UserMediaRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/UserMediaRepository.kt
@@ -64,7 +64,8 @@ constructor(
    * @param path Final destination path of the uploaded file relative to Firestore
    */
   override suspend fun getDownloadUrl(path: String?): MediaUri =
-    if (path.isNullOrEmpty()) "" else getFileUriFromRemotePath(path).toMediaUri()
+    if (path.isNullOrEmpty()) Uri.EMPTY.toMediaUri()
+    else getFileUriFromRemotePath(path).toMediaUri()
 
   private suspend fun getFileUriFromRemotePath(destinationPath: String): Uri {
     val file = getLocalFileFromRemotePath(destinationPath).toFile()
@@ -94,13 +95,13 @@ constructor(
     FileProvider.getUriForFile(
         context,
         org.groundplatform.android.BuildConfig.APPLICATION_ID,
-        File(mediaFilePath),
+        mediaFilePath.toFile(),
       )
       .toMediaUri()
 
-  private fun File.toMediaFile(): MediaFilePath = absolutePath
+  private fun File.toMediaFile(): MediaFilePath = MediaFilePath(absolutePath)
 
-  private fun MediaFilePath.toFile(): File = File(this)
+  private fun MediaFilePath.toFile(): File = File(value)
 
-  private fun Uri.toMediaUri(): MediaUri = toString()
+  private fun Uri.toMediaUri(): MediaUri = MediaUri(toString())
 }

--- a/app/src/main/java/org/groundplatform/android/repository/UserMediaRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/UserMediaRepository.kt
@@ -29,7 +29,7 @@ import org.groundplatform.android.common.Constants
 import org.groundplatform.android.data.remote.RemoteStorageManager
 import org.groundplatform.android.data.uuid.OfflineUuidGenerator
 import org.groundplatform.domain.repository.UserMediaRepositoryInterface
-import org.groundplatform.domain.repository.UserMediaRepositoryInterface.MediaFile
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface.MediaFilePath
 import org.groundplatform.domain.repository.UserMediaRepositoryInterface.MediaUri
 import timber.log.Timber
 
@@ -50,7 +50,7 @@ constructor(
   private suspend fun createImageFilename(fieldId: String): String =
     fieldId + "-" + uuidGenerator.generateUuid() + Constants.PHOTO_EXT
 
-  override suspend fun createImageFile(fieldId: String): MediaFile =
+  override suspend fun createImageFile(fieldId: String): MediaFilePath =
     File(rootDir, createImageFilename(fieldId)).toMediaFile()
 
   @Throws(FileNotFoundException::class)
@@ -80,7 +80,7 @@ constructor(
    * Returns the path of the file saved in the sdcard used for uploading to the provided destination
    * path.
    */
-  override fun getLocalFileFromRemotePath(destinationPath: String): MediaFile {
+  override fun getLocalFileFromRemotePath(destinationPath: String): MediaFilePath {
     val filename = destinationPath.split('/').last()
     require(filename.matches(strFilePattern)) { "Invalid filename $filename" }
     val file = File(rootDir, filename)
@@ -90,17 +90,17 @@ constructor(
     return file.toMediaFile()
   }
 
-  override fun getUriForFile(mediaFile: MediaFile): MediaUri =
+  override fun getUriForFile(mediaFilePath: MediaFilePath): MediaUri =
     FileProvider.getUriForFile(
         context,
         org.groundplatform.android.BuildConfig.APPLICATION_ID,
-        File(mediaFile),
+        File(mediaFilePath),
       )
       .toMediaUri()
 
-  private fun File.toMediaFile(): MediaFile = absolutePath
+  private fun File.toMediaFile(): MediaFilePath = absolutePath
 
-  private fun MediaFile.toFile(): File = File(this)
+  private fun MediaFilePath.toFile(): File = File(this)
 
   private fun Uri.toMediaUri(): MediaUri = toString()
 }

--- a/app/src/main/java/org/groundplatform/android/repository/UserMediaRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/UserMediaRepository.kt
@@ -16,28 +16,23 @@
 package org.groundplatform.android.repository
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
+import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import java.io.FileNotFoundException
-import java.io.FileOutputStream
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.groundplatform.android.common.Constants
 import org.groundplatform.android.data.remote.RemoteStorageManager
 import org.groundplatform.android.data.uuid.OfflineUuidGenerator
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface.MediaFile
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface.MediaUri
 import timber.log.Timber
 
-/**
- * Provides access to user-provided media stored locally and remotely. This currently includes only
- * photos.
- */
 @Singleton
 class UserMediaRepository
 @Inject
@@ -45,7 +40,7 @@ constructor(
   @ApplicationContext private val context: Context,
   private val remoteStorageManager: RemoteStorageManager,
   private val uuidGenerator: OfflineUuidGenerator,
-) {
+) : UserMediaRepositoryInterface {
 
   private var strFilePattern = Regex("^[a-zA-Z0-9._ -]+\\.(png|jpg)$")
 
@@ -55,54 +50,24 @@ constructor(
   private suspend fun createImageFilename(fieldId: String): String =
     fieldId + "-" + uuidGenerator.generateUuid() + Constants.PHOTO_EXT
 
-  suspend fun createImageFile(fieldId: String): File = File(rootDir, createImageFilename(fieldId))
-
-  /**
-   * Creates a new file from bitmap and saves under external app directory.
-   *
-   * @throws IOException If path is not accessible or error occurs while saving file
-   */
-  @Throws(IOException::class)
-  suspend fun savePhoto(bitmap: Bitmap, fieldId: String): File =
-    createImageFile(fieldId).apply {
-      FileOutputStream(this).use { fos -> bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos) }
-      Timber.d("Photo saved %s : %b", path, exists())
-    }
-
-  /**
-   * Saves the original image from the given [uri] to a file associated with the given [fieldId].
-   *
-   * This method copies the image bytes directly from the input stream without decoding it into
-   * memory, preserving the original quality, metadata, and resolution. It avoids potential
-   * OutOfMemoryError caused by loading large images into a Bitmap.
-   */
-  suspend fun savePhotoFromUri(uri: Uri, fieldId: String): File =
-    withContext(Dispatchers.IO) {
-      val file = createImageFile(fieldId)
-
-      context.contentResolver.openInputStream(uri)?.use { input ->
-        FileOutputStream(file).use { output -> input.copyTo(output) }
-      } ?: throw IOException("Unable to open URI: $uri")
-
-      Timber.d("Photo saved ${file.path} : ${file.exists()}")
-      file
-    }
+  override suspend fun createImageFile(fieldId: String): MediaFile =
+    File(rootDir, createImageFilename(fieldId)).toMediaFile()
 
   @Throws(FileNotFoundException::class)
-  fun addImageToGallery(filePath: String, title: String): String =
+  override fun addImageToGallery(filePath: String, title: String): String =
     MediaStore.Images.Media.insertImage(context.contentResolver, filePath, title, "")
 
   /**
    * Attempts to load the file from local cache. Else attempts to fetch it from Firestore Storage.
-   * Returns the uri of the file.
+   * Returns the string uri of the file.
    *
    * @param path Final destination path of the uploaded file relative to Firestore
    */
-  suspend fun getDownloadUrl(path: String?): Uri =
-    if (path.isNullOrEmpty()) Uri.EMPTY else getFileUriFromRemotePath(path)
+  override suspend fun getDownloadUrl(path: String?): MediaUri =
+    if (path.isNullOrEmpty()) "" else getFileUriFromRemotePath(path).toMediaUri()
 
   private suspend fun getFileUriFromRemotePath(destinationPath: String): Uri {
-    val file = getLocalFileFromRemotePath(destinationPath)
+    val file = getLocalFileFromRemotePath(destinationPath).toFile()
     return if (file.exists()) {
       Uri.fromFile(file)
     } else {
@@ -115,20 +80,27 @@ constructor(
    * Returns the path of the file saved in the sdcard used for uploading to the provided destination
    * path.
    */
-  fun getLocalFileFromRemotePath(destinationPath: String): File {
+  override fun getLocalFileFromRemotePath(destinationPath: String): MediaFile {
     val filename = destinationPath.split('/').last()
     require(filename.matches(strFilePattern)) { "Invalid filename $filename" }
     val file = File(rootDir, filename)
     if (!file.exists()) {
       Timber.e("File not found: %s", file.path)
     }
-    return file
+    return file.toMediaFile()
   }
 
-  fun getUriForFile(file: File): Uri =
-    androidx.core.content.FileProvider.getUriForFile(
-      context,
-      org.groundplatform.android.BuildConfig.APPLICATION_ID,
-      file,
-    )
+  override fun getUriForFile(mediaFile: MediaFile): MediaUri =
+    FileProvider.getUriForFile(
+        context,
+        org.groundplatform.android.BuildConfig.APPLICATION_ID,
+        File(mediaFile),
+      )
+      .toMediaUri()
+
+  private fun File.toMediaFile(): MediaFile = absolutePath
+
+  private fun MediaFile.toFile(): File = File(this)
+
+  private fun Uri.toMediaUri(): MediaUri = toString()
 }

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskViewModel.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.groundplatform.android.data.remote.firebase.FirebaseStorageManager
-import org.groundplatform.android.repository.UserMediaRepository
 import org.groundplatform.android.system.PermissionDeniedException
 import org.groundplatform.android.system.PermissionsManager
 import org.groundplatform.android.ui.datacollection.components.ButtonActionState
@@ -43,12 +42,13 @@ import org.groundplatform.android.ui.datacollection.tasks.AbstractTaskViewModel
 import org.groundplatform.domain.model.submission.TaskData
 import org.groundplatform.domain.model.submission.isNotNullOrEmpty
 import org.groundplatform.domain.model.task.PhotoTaskData
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface
 import timber.log.Timber
 
 class PhotoTaskViewModel
 @Inject
 constructor(
-  private val userMediaRepository: UserMediaRepository,
+  private val userMediaRepository: UserMediaRepositoryInterface,
   private val permissionsManager: PermissionsManager,
 ) : AbstractTaskViewModel() {
 
@@ -64,7 +64,7 @@ constructor(
     taskTaskData
       .map { taskData ->
         if (taskData is PhotoTaskData && taskData.isNotNullOrEmpty()) {
-          userMediaRepository.getDownloadUrl(taskData.remoteFilename).toUri()
+          userMediaRepository.getDownloadUrl(taskData.remoteFilename).value.toUri()
         } else {
           Uri.EMPTY
         }
@@ -93,8 +93,8 @@ constructor(
   private suspend fun launchPhotoCapture() {
     try {
       val mediaFilePath = userMediaRepository.createImageFile(task.id)
-      tempPhotoFilePath = mediaFilePath
-      val mediaUri = userMediaRepository.getUriForFile(mediaFilePath)
+      tempPhotoFilePath = mediaFilePath.value
+      val mediaUri = userMediaRepository.getUriForFile(mediaFilePath).value
       _events.send(PhotoTaskEvent.LaunchCamera(mediaUri.toUri()))
       Timber.d("Capture photo intent sent")
     } catch (e: IllegalArgumentException) {

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskViewModel.kt
@@ -20,6 +20,7 @@ import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION_CODES
+import androidx.core.net.toUri
 import androidx.lifecycle.viewModelScope
 import java.io.File
 import javax.inject.Inject
@@ -63,7 +64,7 @@ constructor(
     taskTaskData
       .map { taskData ->
         if (taskData is PhotoTaskData && taskData.isNotNullOrEmpty()) {
-          userMediaRepository.getDownloadUrl(taskData.remoteFilename)
+          userMediaRepository.getDownloadUrl(taskData.remoteFilename).toUri()
         } else {
           Uri.EMPTY
         }
@@ -91,10 +92,10 @@ constructor(
 
   private suspend fun launchPhotoCapture() {
     try {
-      val file = userMediaRepository.createImageFile(task.id)
-      tempPhotoFilePath = file.absolutePath
-      val uri = userMediaRepository.getUriForFile(file)
-      _events.send(PhotoTaskEvent.LaunchCamera(uri))
+      val mediaFilePath = userMediaRepository.createImageFile(task.id)
+      tempPhotoFilePath = mediaFilePath
+      val mediaUri = userMediaRepository.getUriForFile(mediaFilePath)
+      _events.send(PhotoTaskEvent.LaunchCamera(mediaUri.toUri()))
       Timber.d("Capture photo intent sent")
     } catch (e: IllegalArgumentException) {
       _isAwaitingPhotoCapture.value = false

--- a/app/src/test/java/org/groundplatform/android/data/sync/MediaUploadWorkerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/data/sync/MediaUploadWorkerTest.kt
@@ -36,7 +36,6 @@ import org.groundplatform.android.data.local.stores.LocalUserStore
 import org.groundplatform.android.data.remote.FakeRemoteDataStore
 import org.groundplatform.android.data.remote.FakeRemoteStorageManager
 import org.groundplatform.android.di.coroutines.IoDispatcher
-import org.groundplatform.android.repository.UserMediaRepository
 import org.groundplatform.domain.model.mutation.Mutation
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.COMPLETED
 import org.groundplatform.domain.model.mutation.Mutation.SyncStatus.FAILED
@@ -52,6 +51,7 @@ import org.groundplatform.domain.model.task.PhotoTaskData
 import org.groundplatform.domain.model.task.Task
 import org.groundplatform.domain.model.task.Task.Type.PHOTO
 import org.groundplatform.domain.repository.MutationRepositoryInterface
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -63,7 +63,7 @@ class MediaUploadWorkerTest : BaseHiltTest() {
   private lateinit var context: Context
   @Inject lateinit var fakeRemoteDataStore: FakeRemoteDataStore
   @Inject lateinit var mutationRepository: MutationRepositoryInterface
-  @Inject lateinit var userMediaRepository: UserMediaRepository
+  @Inject lateinit var userMediaRepository: UserMediaRepositoryInterface
   @Inject lateinit var fakeRemoteStorageManager: FakeRemoteStorageManager
   @Inject lateinit var localSubmissionStore: LocalSubmissionStore
   @Inject lateinit var localUserStore: LocalUserStore
@@ -193,7 +193,7 @@ class MediaUploadWorkerTest : BaseHiltTest() {
     localSubmissionStore.applyAndEnqueue(createSubmissionMutation().copy(syncStatus = status))
 
   private suspend fun createSubmissionMutation(photoName: String? = null): SubmissionMutation {
-    val photo = userMediaRepository.createImageFile(TEST_PHOTO_TASK.id)
+    val photo = userMediaRepository.createImageFile(TEST_PHOTO_TASK.id).value
     File(photo).writeBytes(ByteArray(0))
 
     return SUBMISSION_MUTATION.copy(

--- a/app/src/test/java/org/groundplatform/android/data/sync/MediaUploadWorkerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/data/sync/MediaUploadWorkerTest.kt
@@ -16,7 +16,6 @@
 package org.groundplatform.android.data.sync
 
 import android.content.Context
-import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
@@ -24,6 +23,7 @@ import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.google.common.truth.Truth.assertWithMessage
 import dagger.hilt.android.testing.HiltAndroidTest
+import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
@@ -193,15 +193,12 @@ class MediaUploadWorkerTest : BaseHiltTest() {
     localSubmissionStore.applyAndEnqueue(createSubmissionMutation().copy(syncStatus = status))
 
   private suspend fun createSubmissionMutation(photoName: String? = null): SubmissionMutation {
-    val photo =
-      userMediaRepository.savePhoto(
-        Bitmap.createBitmap(1, 1, Bitmap.Config.HARDWARE),
-        TEST_PHOTO_TASK.id,
-      )
+    val photo = userMediaRepository.createImageFile(TEST_PHOTO_TASK.id)
+    File(photo).writeBytes(ByteArray(0))
 
     return SUBMISSION_MUTATION.copy(
       job = TEST_JOB,
-      deltas = listOf(ValueDelta(PHOTO_TASK_ID, PHOTO, PhotoTaskData(photoName ?: photo.name))),
+      deltas = listOf(ValueDelta(PHOTO_TASK_ID, PHOTO, PhotoTaskData(photoName ?: photo))),
     )
   }
 

--- a/app/src/test/java/org/groundplatform/android/repository/UserMediaRepositoryTest.kt
+++ b/app/src/test/java/org/groundplatform/android/repository/UserMediaRepositoryTest.kt
@@ -17,6 +17,7 @@ package org.groundplatform.android.repository
 
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidTest
+import java.io.File
 import javax.inject.Inject
 import org.groundplatform.android.BaseHiltTest
 import org.junit.Assert.assertThrows
@@ -52,5 +53,58 @@ class UserMediaRepositoryTest : BaseHiltTest() {
       val localFile = userMediaRepository.getLocalFileFromRemotePath(path)
       assertThat(localFile).isNotNull()
     }
+  }
+
+  @Test
+  fun `createImageFile returns path with fieldId, uuid and jpg extension`() =
+    runWithTestDispatcher {
+      val mediaFile = userMediaRepository.createImageFile("field1")
+
+      assertThat(File(mediaFile).name).isEqualTo("field1-TEST UUID.jpg")
+    }
+
+  @Test
+  fun `createImageFile returns distinct names for different fieldIds`() = runWithTestDispatcher {
+    val first = userMediaRepository.createImageFile("fieldA")
+    val second = userMediaRepository.createImageFile("fieldB")
+
+    assertThat(first).isNotEqualTo(second)
+  }
+
+  @Test
+  fun `getDownloadUrl returns empty when path is null`() = runWithTestDispatcher {
+    assertThat(userMediaRepository.getDownloadUrl(null)).isEmpty()
+  }
+
+  @Test
+  fun `getDownloadUrl returns empty when path is empty`() = runWithTestDispatcher {
+    assertThat(userMediaRepository.getDownloadUrl("")).isEmpty()
+  }
+
+  @Test
+  fun `getDownloadUrl falls back to remote when local file is missing`() = runWithTestDispatcher {
+    assertThat(userMediaRepository.getDownloadUrl("remote/path/missing.jpg")).isEmpty()
+  }
+
+  @Test
+  fun `getDownloadUrl returns local file uri when file exists`() = runWithTestDispatcher {
+    val mediaFile = userMediaRepository.createImageFile("field1")
+    File(mediaFile).writeBytes(ByteArray(0))
+
+    val downloadUrl = userMediaRepository.getDownloadUrl("remote/path/${File(mediaFile).name}")
+
+    assertThat(downloadUrl).startsWith("file://")
+    assertThat(downloadUrl).endsWith(File(mediaFile).name.replace(" ", "%20"))
+  }
+
+  @Test
+  fun `getUriForFile returns content uri backed by FileProvider`() = runWithTestDispatcher {
+    val mediaFile = userMediaRepository.createImageFile("field1")
+    File(mediaFile).writeBytes(ByteArray(0))
+
+    val uri = userMediaRepository.getUriForFile(mediaFile)
+
+    assertThat(uri).startsWith("content://org.groundplatform.android/")
+    assertThat(uri).endsWith(File(mediaFile).name.replace(" ", "%20"))
   }
 }

--- a/app/src/test/java/org/groundplatform/android/repository/UserMediaRepositoryTest.kt
+++ b/app/src/test/java/org/groundplatform/android/repository/UserMediaRepositoryTest.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import java.io.File
 import javax.inject.Inject
 import org.groundplatform.android.BaseHiltTest
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,7 +30,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class UserMediaRepositoryTest : BaseHiltTest() {
 
-  @Inject lateinit var userMediaRepository: UserMediaRepository
+  @Inject lateinit var userMediaRepository: UserMediaRepositoryInterface
 
   @Test
   fun `getLocalFileFromRemotePath handles invalid image filename`() {
@@ -58,7 +59,7 @@ class UserMediaRepositoryTest : BaseHiltTest() {
   @Test
   fun `createImageFile returns path with fieldId, uuid and jpg extension`() =
     runWithTestDispatcher {
-      val mediaFile = userMediaRepository.createImageFile("field1")
+      val mediaFile = userMediaRepository.createImageFile("field1").value
 
       assertThat(File(mediaFile).name).isEqualTo("field1-TEST UUID.jpg")
     }
@@ -73,25 +74,26 @@ class UserMediaRepositoryTest : BaseHiltTest() {
 
   @Test
   fun `getDownloadUrl returns empty when path is null`() = runWithTestDispatcher {
-    assertThat(userMediaRepository.getDownloadUrl(null)).isEmpty()
+    assertThat(userMediaRepository.getDownloadUrl(null).value).isEmpty()
   }
 
   @Test
   fun `getDownloadUrl returns empty when path is empty`() = runWithTestDispatcher {
-    assertThat(userMediaRepository.getDownloadUrl("")).isEmpty()
+    assertThat(userMediaRepository.getDownloadUrl("").value).isEmpty()
   }
 
   @Test
   fun `getDownloadUrl falls back to remote when local file is missing`() = runWithTestDispatcher {
-    assertThat(userMediaRepository.getDownloadUrl("remote/path/missing.jpg")).isEmpty()
+    assertThat(userMediaRepository.getDownloadUrl("remote/path/missing.jpg").value).isEmpty()
   }
 
   @Test
   fun `getDownloadUrl returns local file uri when file exists`() = runWithTestDispatcher {
-    val mediaFile = userMediaRepository.createImageFile("field1")
+    val mediaFile = userMediaRepository.createImageFile("field1").value
     File(mediaFile).writeBytes(ByteArray(0))
 
-    val downloadUrl = userMediaRepository.getDownloadUrl("remote/path/${File(mediaFile).name}")
+    val downloadUrl =
+      userMediaRepository.getDownloadUrl("remote/path/${File(mediaFile).name}").value
 
     assertThat(downloadUrl).startsWith("file://")
     assertThat(downloadUrl).endsWith(File(mediaFile).name.replace(" ", "%20"))
@@ -100,11 +102,11 @@ class UserMediaRepositoryTest : BaseHiltTest() {
   @Test
   fun `getUriForFile returns content uri backed by FileProvider`() = runWithTestDispatcher {
     val mediaFile = userMediaRepository.createImageFile("field1")
-    File(mediaFile).writeBytes(ByteArray(0))
+    File(mediaFile.value).writeBytes(ByteArray(0))
 
-    val uri = userMediaRepository.getUriForFile(mediaFile)
+    val uri = userMediaRepository.getUriForFile(mediaFile).value
 
     assertThat(uri).startsWith("content://org.groundplatform.android/")
-    assertThat(uri).endsWith(File(mediaFile).name.replace(" ", "%20"))
+    assertThat(uri).endsWith(File(mediaFile.value).name.replace(" ", "%20"))
   }
 }

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskScreenTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskScreenTest.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import kotlinx.coroutines.runBlocking
-import org.groundplatform.android.repository.UserMediaRepository
 import org.groundplatform.android.system.PermissionDeniedException
 import org.groundplatform.android.system.PermissionsManager
 import org.groundplatform.android.ui.datacollection.components.ButtonAction
@@ -39,12 +38,15 @@ import org.groundplatform.domain.model.job.Style
 import org.groundplatform.domain.model.submission.TaskData
 import org.groundplatform.domain.model.task.PhotoTaskData
 import org.groundplatform.domain.model.task.Task
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -54,7 +56,7 @@ class PhotoTaskScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  @Mock private lateinit var userMediaRepository: UserMediaRepository
+  @Mock private lateinit var userMediaRepository: UserMediaRepositoryInterface
   @Mock private lateinit var permissionsManager: PermissionsManager
   private lateinit var viewModel: PhotoTaskViewModel
   private var lastButtonAction: ButtonAction? = null
@@ -111,8 +113,9 @@ class PhotoTaskScreenTest {
   @Test
   fun `shows photo preview when photo is present`() {
     runBlocking {
-      whenever(userMediaRepository.getDownloadUrl("test_file.jpg"))
-        .thenReturn("content://media/external/images/media/1")
+      doReturn(UserMediaRepositoryInterface.MediaUri("content://media/external/images/media/1"))
+        .whenever(userMediaRepository)
+        .getDownloadUrl("test_file.jpg")
     }
 
     setupTaskScreen(TASK, PhotoTaskData("test_file.jpg"))
@@ -125,10 +128,10 @@ class PhotoTaskScreenTest {
   fun `invokes onTakePhoto callback when capture button is clicked`() {
     setupTaskScreen(TASK)
 
-    val file = "test.jpg"
-    val dummyUri = "content://test"
-    runBlocking { whenever(userMediaRepository.createImageFile(TASK.id)).thenReturn(file) }
-    whenever(userMediaRepository.getUriForFile(file)).thenReturn(dummyUri)
+    val file = UserMediaRepositoryInterface.MediaFilePath("test.jpg")
+    val dummyUri = UserMediaRepositoryInterface.MediaUri("content://test")
+    runBlocking { doReturn(file).whenever(userMediaRepository).createImageFile(TASK.id) }
+    doReturn(dummyUri).whenever(userMediaRepository).getUriForFile(file)
 
     composeTestRule.onNodeWithText("Camera").performClick()
 
@@ -169,8 +172,9 @@ class PhotoTaskScreenTest {
   @Test
   fun `sets action buttons state when data is present`() {
     runBlocking {
-      whenever(userMediaRepository.getDownloadUrl("test_file.jpg"))
-        .thenReturn("content://media/external/images/media/1")
+      doReturn(UserMediaRepositoryInterface.MediaUri("content://media/external/images/media/1"))
+        .whenever(userMediaRepository)
+        .getDownloadUrl("test_file.jpg")
     }
     setupTaskScreen(TASK.copy(isRequired = true), PhotoTaskData("test_file.jpg"))
 
@@ -236,13 +240,16 @@ class PhotoTaskScreenTest {
 
     val file = File("test.jpg")
     val dummyUri = Uri.parse("content://test")
+    val mediaFilePath = UserMediaRepositoryInterface.MediaFilePath(file.absolutePath)
     runBlocking {
-      whenever(userMediaRepository.createImageFile(TASK.id)).thenReturn(file.absolutePath)
+      doReturn(mediaFilePath).whenever(userMediaRepository).createImageFile(TASK.id)
       whenever(userMediaRepository.addImageToGallery(file.absolutePath, file.name)).then {
         error("Save failed")
       }
     }
-    whenever(userMediaRepository.getUriForFile(file.absolutePath)).thenReturn(dummyUri.toString())
+    doReturn(UserMediaRepositoryInterface.MediaUri(dummyUri.toString()))
+      .whenever(userMediaRepository)
+      .getUriForFile(mediaFilePath)
 
     viewModel.onTakePhoto()
     viewModel.onCaptureResult(true)
@@ -255,9 +262,9 @@ class PhotoTaskScreenTest {
     setupTaskScreen(TASK)
 
     runBlocking {
-      whenever(userMediaRepository.createImageFile(TASK.id)).then {
-        throw IllegalArgumentException("Launch failed")
-      }
+      doThrow(IllegalArgumentException("Launch failed"))
+        .whenever(userMediaRepository)
+        .createImageFile(TASK.id)
     }
 
     viewModel.onTakePhoto()

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskScreenTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskScreenTest.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.core.net.toUri
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import kotlinx.coroutines.runBlocking
@@ -113,7 +112,7 @@ class PhotoTaskScreenTest {
   fun `shows photo preview when photo is present`() {
     runBlocking {
       whenever(userMediaRepository.getDownloadUrl("test_file.jpg"))
-        .thenReturn("content://media/external/images/media/1".toUri())
+        .thenReturn("content://media/external/images/media/1")
     }
 
     setupTaskScreen(TASK, PhotoTaskData("test_file.jpg"))
@@ -126,8 +125,8 @@ class PhotoTaskScreenTest {
   fun `invokes onTakePhoto callback when capture button is clicked`() {
     setupTaskScreen(TASK)
 
-    val file = File("test.jpg")
-    val dummyUri = Uri.parse("content://test")
+    val file = "test.jpg"
+    val dummyUri = "content://test"
     runBlocking { whenever(userMediaRepository.createImageFile(TASK.id)).thenReturn(file) }
     whenever(userMediaRepository.getUriForFile(file)).thenReturn(dummyUri)
 
@@ -171,7 +170,7 @@ class PhotoTaskScreenTest {
   fun `sets action buttons state when data is present`() {
     runBlocking {
       whenever(userMediaRepository.getDownloadUrl("test_file.jpg"))
-        .thenReturn("content://media/external/images/media/1".toUri())
+        .thenReturn("content://media/external/images/media/1")
     }
     setupTaskScreen(TASK.copy(isRequired = true), PhotoTaskData("test_file.jpg"))
 
@@ -238,12 +237,12 @@ class PhotoTaskScreenTest {
     val file = File("test.jpg")
     val dummyUri = Uri.parse("content://test")
     runBlocking {
-      whenever(userMediaRepository.createImageFile(TASK.id)).thenReturn(file)
+      whenever(userMediaRepository.createImageFile(TASK.id)).thenReturn(file.absolutePath)
       whenever(userMediaRepository.addImageToGallery(file.absolutePath, file.name)).then {
         error("Save failed")
       }
     }
-    whenever(userMediaRepository.getUriForFile(file)).thenReturn(dummyUri)
+    whenever(userMediaRepository.getUriForFile(file.absolutePath)).thenReturn(dummyUri.toString())
 
     viewModel.onTakePhoto()
     viewModel.onCaptureResult(true)

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskViewModelTest.kt
@@ -22,6 +22,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
 import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +32,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.groundplatform.android.BaseHiltTest
-import org.groundplatform.android.repository.UserMediaRepository
+import org.groundplatform.android.di.UserMediaRepositoryModule
 import org.groundplatform.android.system.PermissionsManager
 import org.groundplatform.android.ui.datacollection.tasks.TaskPositionInterface
 import org.groundplatform.domain.model.job.Job
@@ -39,21 +40,24 @@ import org.groundplatform.domain.model.job.Style
 import org.groundplatform.domain.model.submission.TaskData
 import org.groundplatform.domain.model.task.PhotoTaskData
 import org.groundplatform.domain.model.task.Task
+import org.groundplatform.domain.repository.UserMediaRepositoryInterface
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @HiltAndroidTest
+@UninstallModules(UserMediaRepositoryModule::class)
 @RunWith(RobolectricTestRunner::class)
 class PhotoTaskViewModelTest : BaseHiltTest() {
 
-  @BindValue @Mock lateinit var userMediaRepository: UserMediaRepository
+  @BindValue @Mock lateinit var userMediaRepository: UserMediaRepositoryInterface
   @BindValue @Mock lateinit var permissionsManager: PermissionsManager
   @Inject lateinit var viewModel: PhotoTaskViewModel
 
@@ -72,9 +76,9 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
   fun `onCaptureResult saves photo when result is true`() = runWithTestDispatcher {
     whenever(permissionsManager.obtainPermission(any())).thenReturn(Unit)
     val mockFile = mock<File>()
-    whenever(userMediaRepository.createImageFile(any())).thenReturn(TEST_FILE_PATH)
-    whenever(userMediaRepository.getUriForFile(TEST_FILE_PATH)).thenReturn(TEST_URI)
-    whenever(mockFile.absolutePath).thenReturn(TEST_FILE_PATH)
+    doReturn(TEST_FILE_PATH).whenever(userMediaRepository).createImageFile(any())
+    doReturn(TEST_URI).whenever(userMediaRepository).getUriForFile(TEST_FILE_PATH)
+    whenever(mockFile.absolutePath).thenReturn(TEST_FILE_PATH.value)
     whenever(mockFile.name).thenReturn(TEST_FILE_NAME)
 
     viewModel.onTakePhoto()
@@ -101,9 +105,9 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
     runWithTestDispatcher {
       whenever(permissionsManager.obtainPermission(any())).thenReturn(Unit)
       val mockFile = mock<File>()
-      whenever(userMediaRepository.createImageFile(any())).thenReturn(TEST_FILE_PATH)
-      whenever(userMediaRepository.getUriForFile(TEST_FILE_PATH)).thenReturn(TEST_URI)
-      whenever(mockFile.absolutePath).thenReturn(TEST_FILE_PATH)
+      doReturn(TEST_FILE_PATH).whenever(userMediaRepository).createImageFile(any())
+      doReturn(TEST_URI).whenever(userMediaRepository).getUriForFile(TEST_FILE_PATH)
+      whenever(mockFile.absolutePath).thenReturn(TEST_FILE_PATH.value)
       whenever(mockFile.name).thenReturn(TEST_FILE_NAME)
 
       viewModel.events.test {
@@ -123,10 +127,10 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
   @Test
   fun `onTakePhoto emits LaunchCamera event`() = runWithTestDispatcher {
     whenever(permissionsManager.obtainPermission(any())).thenReturn(Unit)
-    whenever(userMediaRepository.createImageFile(any())).thenReturn(TEST_FILE_PATH)
+    doReturn(TEST_FILE_PATH).whenever(userMediaRepository).createImageFile(any())
     val mockUri = mock<Uri>()
-    whenever(mockUri.toString()).thenReturn(TEST_URI)
-    whenever(userMediaRepository.getUriForFile(TEST_FILE_PATH)).thenReturn(TEST_URI)
+    whenever(mockUri.toString()).thenReturn(TEST_URI.value)
+    doReturn(TEST_URI).whenever(userMediaRepository).getUriForFile(TEST_FILE_PATH)
 
     viewModel.events.test {
       viewModel.onTakePhoto()
@@ -138,7 +142,7 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
 
   @Test
   fun clearResponse_clearsUriFlow() = runWithTestDispatcher {
-    whenever(userMediaRepository.getDownloadUrl(any())).thenReturn(TEST_URI)
+    doReturn(TEST_URI).whenever(userMediaRepository).getDownloadUrl(any())
 
     viewModel.setValue(PhotoTaskData("path/photo.jpg"))
     advanceUntilIdle()
@@ -179,8 +183,8 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
       )
     val JOB = Job("job", Style("#112233"))
 
-    const val TEST_FILE_PATH = "/path/to/file.jpg"
+    val TEST_FILE_PATH = UserMediaRepositoryInterface.MediaFilePath("/path/to/file.jpg")
     const val TEST_FILE_NAME = "file.jpg"
-    const val TEST_URI = "content://test"
+    val TEST_URI = UserMediaRepositoryInterface.MediaUri("content://test")
   }
 }

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskViewModelTest.kt
@@ -72,10 +72,10 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
   fun `onCaptureResult saves photo when result is true`() = runWithTestDispatcher {
     whenever(permissionsManager.obtainPermission(any())).thenReturn(Unit)
     val mockFile = mock<File>()
-    whenever(userMediaRepository.createImageFile(any())).thenReturn(mockFile)
-    whenever(userMediaRepository.getUriForFile(mockFile)).thenReturn(mock<Uri>())
-    whenever(mockFile.absolutePath).thenReturn("/path/to/file.jpg")
-    whenever(mockFile.name).thenReturn("file.jpg")
+    whenever(userMediaRepository.createImageFile(any())).thenReturn(TEST_FILE_PATH)
+    whenever(userMediaRepository.getUriForFile(TEST_FILE_PATH)).thenReturn(TEST_URI)
+    whenever(mockFile.absolutePath).thenReturn(TEST_FILE_PATH)
+    whenever(mockFile.name).thenReturn(TEST_FILE_NAME)
 
     viewModel.onTakePhoto()
     advanceUntilIdle()
@@ -101,10 +101,10 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
     runWithTestDispatcher {
       whenever(permissionsManager.obtainPermission(any())).thenReturn(Unit)
       val mockFile = mock<File>()
-      whenever(userMediaRepository.createImageFile(any())).thenReturn(mockFile)
-      whenever(userMediaRepository.getUriForFile(mockFile)).thenReturn(mock<Uri>())
-      whenever(mockFile.absolutePath).thenReturn("/path/to/file.jpg")
-      whenever(mockFile.name).thenReturn("file.jpg")
+      whenever(userMediaRepository.createImageFile(any())).thenReturn(TEST_FILE_PATH)
+      whenever(userMediaRepository.getUriForFile(TEST_FILE_PATH)).thenReturn(TEST_URI)
+      whenever(mockFile.absolutePath).thenReturn(TEST_FILE_PATH)
+      whenever(mockFile.name).thenReturn(TEST_FILE_NAME)
 
       viewModel.events.test {
         viewModel.onTakePhoto()
@@ -123,10 +123,10 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
   @Test
   fun `onTakePhoto emits LaunchCamera event`() = runWithTestDispatcher {
     whenever(permissionsManager.obtainPermission(any())).thenReturn(Unit)
-    val mockFile = mock<File>()
-    whenever(userMediaRepository.createImageFile(any())).thenReturn(mockFile)
+    whenever(userMediaRepository.createImageFile(any())).thenReturn(TEST_FILE_PATH)
     val mockUri = mock<Uri>()
-    whenever(userMediaRepository.getUriForFile(mockFile)).thenReturn(mockUri)
+    whenever(mockUri.toString()).thenReturn(TEST_URI)
+    whenever(userMediaRepository.getUriForFile(TEST_FILE_PATH)).thenReturn(TEST_URI)
 
     viewModel.events.test {
       viewModel.onTakePhoto()
@@ -138,8 +138,7 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
 
   @Test
   fun clearResponse_clearsUriFlow() = runWithTestDispatcher {
-    val mockUri = mock<Uri>()
-    whenever(userMediaRepository.getDownloadUrl(any())).thenReturn(mockUri)
+    whenever(userMediaRepository.getDownloadUrl(any())).thenReturn(TEST_URI)
 
     viewModel.setValue(PhotoTaskData("path/photo.jpg"))
     advanceUntilIdle()
@@ -169,8 +168,8 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
     )
   }
 
-  companion object {
-    private val TASK =
+  private companion object {
+    val TASK =
       Task(
         id = "task_1",
         index = 0,
@@ -178,6 +177,10 @@ class PhotoTaskViewModelTest : BaseHiltTest() {
         label = "Task for capturing a photo",
         isRequired = false,
       )
-    private val JOB = Job("job", Style("#112233"))
+    val JOB = Job("job", Style("#112233"))
+
+    const val TEST_FILE_PATH = "/path/to/file.jpg"
+    const val TEST_FILE_NAME = "file.jpg"
+    const val TEST_URI = "content://test"
   }
 }

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/UserMediaRepositoryInterface.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/UserMediaRepositoryInterface.kt
@@ -22,9 +22,9 @@ package org.groundplatform.domain.repository
 interface UserMediaRepositoryInterface {
   typealias MediaUri = String
 
-  typealias MediaFile = String
+  typealias MediaFilePath = String
 
-  suspend fun createImageFile(fieldId: String): MediaFile
+  suspend fun createImageFile(fieldId: String): MediaFilePath
 
   fun addImageToGallery(filePath: String, title: String): String
 
@@ -40,7 +40,7 @@ interface UserMediaRepositoryInterface {
    * Returns the path of the file saved in the sdcard used for uploading to the provided destination
    * path.
    */
-  fun getLocalFileFromRemotePath(destinationPath: String): MediaFile
+  fun getLocalFileFromRemotePath(destinationPath: String): MediaFilePath
 
-  fun getUriForFile(mediaFile: MediaFile): MediaUri
+  fun getUriForFile(mediaFilePath: MediaFilePath): MediaUri
 }

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/UserMediaRepositoryInterface.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/UserMediaRepositoryInterface.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.groundplatform.domain.repository
 
 /**
@@ -6,6 +21,7 @@ package org.groundplatform.domain.repository
  */
 interface UserMediaRepositoryInterface {
   typealias MediaUri = String
+
   typealias MediaFile = String
 
   suspend fun createImageFile(fieldId: String): MediaFile

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/UserMediaRepositoryInterface.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/UserMediaRepositoryInterface.kt
@@ -1,0 +1,30 @@
+package org.groundplatform.domain.repository
+
+/**
+ * Provides access to user-provided media stored locally and remotely. This currently includes only
+ * photos.
+ */
+interface UserMediaRepositoryInterface {
+  typealias MediaUri = String
+  typealias MediaFile = String
+
+  suspend fun createImageFile(fieldId: String): MediaFile
+
+  fun addImageToGallery(filePath: String, title: String): String
+
+  /**
+   * Attempts to load the file from local cache. Else attempts to fetch it from Firestore Storage.
+   * Returns the uri of the file.
+   *
+   * @param path Final destination path of the uploaded file relative to Firestore
+   */
+  suspend fun getDownloadUrl(path: String?): MediaUri
+
+  /**
+   * Returns the path of the file saved in the sdcard used for uploading to the provided destination
+   * path.
+   */
+  fun getLocalFileFromRemotePath(destinationPath: String): MediaFile
+
+  fun getUriForFile(mediaFile: MediaFile): MediaUri
+}

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/UserMediaRepositoryInterface.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/repository/UserMediaRepositoryInterface.kt
@@ -15,14 +15,16 @@
  */
 package org.groundplatform.domain.repository
 
+import kotlin.jvm.JvmInline
+
 /**
  * Provides access to user-provided media stored locally and remotely. This currently includes only
  * photos.
  */
 interface UserMediaRepositoryInterface {
-  typealias MediaUri = String
+  @JvmInline value class MediaUri(val value: String)
 
-  typealias MediaFilePath = String
+  @JvmInline value class MediaFilePath(val value: String)
 
   suspend fun createImageFile(fieldId: String): MediaFilePath
 


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3634 

This PR adds a `UserMediaRepositoryInterface` to `:core:domain` (last one :tada:). Other changes include:
- removed 2 repository methods: `savePhotoFromUri` because it was unused and `savePhoto` because it was only used in a test
- refactored arguments and return types of the repository methods in order to remove android-specific dependencies: introduced new value classes for that `MediaUri` and `MediaFilePath`, so we don't have to use Uri and File and the  repository contract becomes platform-agnostic
- added more tests to `UserMediaRepositoryTest`

@shobhitagarwal1612  PTAL?
