### PR TITLE
Update ci workflows to allow fork PRs to run integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ name: CI
 on:
   push:
     branches: [ "master" ]
-  pull_request:
+  pull_request_target:
     branches: [ "master" ]
 
 jobs:
@@ -26,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v5
@@ -50,17 +52,16 @@ jobs:
         run: ./gradlew jacocoLocalDebugUnitTestReport
 
       - name: Upload coverage to Codecov
-        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.CODECOV_TOKEN || '' }}
           files: "**/build/reports/jacoco/**/*.xml"
           flags: service
           fail_ci_if_error: false
 
   instrumentation-tests:
     needs: build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/test-e2e.yml
     secrets:
       MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Restore workflow repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Run Android tests on e2eTest module
         uses: ./.github/actions/submit-test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3701

<!-- PR description. -->
Make e2e tests runnable on fork PRs by switching CI to pull_request_target, while keeping secrets safely gated behind the existing e2e-approval environment.

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->

@... PTAL?
