### PR TITLE
Update workflows to allow e2e to run on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ name: CI
 on:
   push:
     branches: [ "master" ]
-  pull_request:
+  pull_request_target:
     branches: [ "master" ]
 
 jobs:
@@ -26,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v5
@@ -50,17 +52,16 @@ jobs:
         run: ./gradlew jacocoLocalDebugUnitTestReport
 
       - name: Upload coverage to Codecov
-        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.CODECOV_TOKEN || '' }}
           files: "**/build/reports/jacoco/**/*.xml"
           flags: service
           fail_ci_if_error: false
 
   instrumentation-tests:
     needs: build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/test-e2e.yml
     secrets:
       MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ name: CI
 on:
   push:
     branches: [ "master" ]
-  pull_request_target:
+  pull_request:
     branches: [ "master" ]
 
 jobs:
@@ -26,8 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v5
@@ -52,18 +50,10 @@ jobs:
         run: ./gradlew jacocoLocalDebugUnitTestReport
 
       - name: Upload coverage to Codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.CODECOV_TOKEN || '' }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: "**/build/reports/jacoco/**/*.xml"
           flags: service
           fail_ci_if_error: false
-
-  instrumentation-tests:
-    needs: build
-    if: github.event_name == 'pull_request_target'
-    uses: ./.github/workflows/test-e2e.yml
-    secrets:
-      MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
-    permissions:
-      contents: read

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -1,0 +1,42 @@
+# Copyright 2024 The Ground Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Dispatches the e2e workflow for every PR while keeping the CodeQL
+# "untrusted checkout in privileged context" rule satisfied:
+#   - This file holds the privileged trigger (pull_request_target) but
+#     no checkout of fork code.
+#   - test-e2e.yml does the checkout of the PR head SHA but is only
+#     reachable via workflow_call, never directly from a privileged trigger.
+# Same-repo PRs are routed via pull_request (head's workflow file applies);
+# fork PRs are routed via pull_request_target (base's workflow file applies,
+# secrets gated by the e2e-approval environment in test-e2e.yml).
+name: CI
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  pull_request_target:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  instrumentation-tests:
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    uses: ./.github/workflows/test-e2e.yml
+    secrets:
+      MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,10 +54,10 @@ jobs:
         with:
           platform-repository: google/ground-platform
 
-      - name: Restore workflow repository
+      - name: Checkout PR
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run Android tests on e2eTest module
         uses: ./.github/actions/submit-test

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Restore workflow repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Run Android tests on e2eTest module
         uses: ./.github/actions/submit-test


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3701

This PR enables e2e tests to run on forked PRs while keeping secrets protected. This introduces a new `e2e-dispatch.yml`, which is a thin dispatcher workflow that triggers on both pull_request and pull_request_target and routes each PR through exactly one of them:
- Same-repo PRs: pull_request path - uses the PR head's workflow file, so the change tests itself on this very PR                                                
- Fork PRs: pull_request_target path - uses base branch's workflow file, has access to secrets after e2e-approval environment approval

@shobhitagarwal1612  PTAL?
