### PR TITLE
Enforce 6 digit coordinates on LOI GeoJSON

### DIFF
--- a/app/src/test/java/org/groundplatform/android/FakeData.kt
+++ b/app/src/test/java/org/groundplatform/android/FakeData.kt
@@ -18,8 +18,8 @@ package org.groundplatform.android
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonUnquotedLiteral
 import kotlinx.serialization.json.buildJsonObject
-import org.groundplatform.domain.model.imagery.OfflineArea
 import org.groundplatform.android.ui.map.Feature
 import org.groundplatform.android.ui.map.gms.features.FeatureClusterItem
 import org.groundplatform.domain.model.Survey
@@ -30,6 +30,7 @@ import org.groundplatform.domain.model.geometry.LinearRing
 import org.groundplatform.domain.model.geometry.MultiPolygon
 import org.groundplatform.domain.model.geometry.Point
 import org.groundplatform.domain.model.geometry.Polygon
+import org.groundplatform.domain.model.imagery.OfflineArea
 import org.groundplatform.domain.model.job.Job
 import org.groundplatform.domain.model.job.Style
 import org.groundplatform.domain.model.locationofinterest.AuditInfo
@@ -120,7 +121,10 @@ object FakeData {
               JsonObject(
                 mapOf(
                   "type" to JsonPrimitive("Point"),
-                  "coordinates" to JsonArray(listOf(JsonPrimitive(0.0), JsonPrimitive(0.0))),
+                  "coordinates" to
+                    JsonArray(
+                      listOf(JsonUnquotedLiteral("0.000000"), JsonUnquotedLiteral("0.000000"))
+                    ),
                 )
               ),
           )

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
@@ -15,9 +15,8 @@
  */
 package org.groundplatform.domain.usecases
 
-import kotlin.math.abs
+import kotlin.math.absoluteValue
 import kotlin.math.round
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -34,7 +33,6 @@ import org.groundplatform.domain.model.locationofinterest.LOI_NAME_PROPERTY
 import org.groundplatform.domain.model.locationofinterest.LoiProperties
 import org.groundplatform.domain.model.locationofinterest.LoiReport
 import org.groundplatform.domain.repository.LocationOfInterestRepositoryInterface
-import kotlin.math.absoluteValue
 
 /**
  * Use case that generates a [LoiReport] containing the LOI geometry and properties as a GeoJSON.
@@ -102,7 +100,7 @@ class GetLoiReportUseCase(
 
   /** Converts a single [Coordinates] to a GeoJSON position: [lng, lat]. */
   private fun coordinatesToPosition(coordinates: Coordinates): JsonArray =
-    JsonArray(listOf(coordinates.lng.toFixed6Json(), coordinates.lat.toFixed6Json()))
+    JsonArray(listOf(coordinates.lng.roundTo6Decimals(), coordinates.lat.roundTo6Decimals()))
 
   /** Converts a list of [Coordinates] to a GeoJSON array of positions. */
   private fun coordinatesToPositions(coordinates: List<Coordinates>): JsonArray =
@@ -116,7 +114,7 @@ class GetLoiReportUseCase(
   }
 
   /** Renders this [Double] as a JSON number with exactly 6 decimal digits */
-  private fun Double.toFixed6Json(): JsonPrimitive {
+  private fun Double.roundTo6Decimals(): JsonPrimitive {
     val scaled = round(this * DECIMAL_SCALE).toLong()
     val sign = if (scaled < 0) "-" else ""
     val absScaled = scaled.absoluteValue

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
@@ -15,11 +15,14 @@
  */
 package org.groundplatform.domain.usecases
 
+import kotlin.math.abs
 import kotlin.math.round
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonUnquotedLiteral
 import org.groundplatform.domain.model.geometry.Coordinates
 import org.groundplatform.domain.model.geometry.Geometry
 import org.groundplatform.domain.model.geometry.LineString
@@ -31,6 +34,7 @@ import org.groundplatform.domain.model.locationofinterest.LOI_NAME_PROPERTY
 import org.groundplatform.domain.model.locationofinterest.LoiProperties
 import org.groundplatform.domain.model.locationofinterest.LoiReport
 import org.groundplatform.domain.repository.LocationOfInterestRepositoryInterface
+import kotlin.math.absoluteValue
 
 /**
  * Use case that generates a [LoiReport] containing the LOI geometry and properties as a GeoJSON.
@@ -98,12 +102,7 @@ class GetLoiReportUseCase(
 
   /** Converts a single [Coordinates] to a GeoJSON position: [lng, lat]. */
   private fun coordinatesToPosition(coordinates: Coordinates): JsonArray =
-    JsonArray(
-      listOf(
-        JsonPrimitive(coordinates.lng.roundTo6Decimals()),
-        JsonPrimitive(coordinates.lat.roundTo6Decimals()),
-      )
-    )
+    JsonArray(listOf(coordinates.lng.toFixed6Json(), coordinates.lat.toFixed6Json()))
 
   /** Converts a list of [Coordinates] to a GeoJSON array of positions. */
   private fun coordinatesToPositions(coordinates: List<Coordinates>): JsonArray =
@@ -116,7 +115,15 @@ class GetLoiReportUseCase(
     return JsonArray(rings)
   }
 
-  private fun Double.roundTo6Decimals(): Double = round(this * 1e6) / 1e6
+  /** Renders this [Double] as a JSON number with exactly 6 decimal digits */
+  private fun Double.toFixed6Json(): JsonPrimitive {
+    val scaled = round(this * DECIMAL_SCALE).toLong()
+    val sign = if (scaled < 0) "-" else ""
+    val absScaled = scaled.absoluteValue
+    val intPart = absScaled / DECIMAL_SCALE
+    val fracPart = (absScaled % DECIMAL_SCALE).toString().padStart(DECIMAL_DIGITS, '0')
+    return JsonUnquotedLiteral("$sign$intPart.$fracPart")
+  }
 
   private companion object {
     const val KEY_TYPE = "type"
@@ -128,5 +135,7 @@ class GetLoiReportUseCase(
     const val TYPE_LINE_STRING = "LineString"
     const val TYPE_POLYGON = "Polygon"
     const val TYPE_MULTI_POLYGON = "MultiPolygon"
+    const val DECIMAL_DIGITS = 6
+    const val DECIMAL_SCALE = 1_000_000L
   }
 }

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
@@ -113,7 +113,7 @@ class GetLoiReportUseCase(
     return JsonArray(rings)
   }
 
-  /** Renders this [Double] as a JSON number with exactly 6 decimal digits */
+  /** Renders this [Double] as a JSON number with exactly 6 decimal digits. */
   private fun Double.roundTo6Decimals(): JsonPrimitive {
     val scaled = round(this * DECIMAL_SCALE).toLong()
     val sign = if (scaled < 0) "-" else ""

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
@@ -52,7 +52,7 @@ class GetLoiReportUseCaseTest {
         "properties": {"name": "Point test"},
         "geometry": {
           "type": "Point",
-          "coordinates": [-89.0, 41.0]
+          "coordinates": [-89.000000, 41.000000]
         }
       }
       """
@@ -82,7 +82,7 @@ class GetLoiReportUseCaseTest {
         "geometry": {
           "type": "Polygon",
           "coordinates": [
-            [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.0, 0.0]]
+            [[0.000000, 0.000000], [0.000000, 1.000000], [1.000000, 1.000000], [0.000000, 0.000000]]
           ]
         }
       }
@@ -125,8 +125,8 @@ class GetLoiReportUseCaseTest {
         "geometry": {
           "type": "Polygon",
           "coordinates": [
-            [[0.0, 0.0], [0.0, 10.0], [10.0, 10.0], [0.0, 0.0]],
-            [[2.0, 2.0], [2.0, 3.0], [3.0, 3.0], [2.0, 2.0]]
+            [[0.000000, 0.000000], [0.000000, 10.000000], [10.000000, 10.000000], [0.000000, 0.000000]],
+            [[2.000000, 2.000000], [2.000000, 3.000000], [3.000000, 3.000000], [2.000000, 2.000000]]
           ]
         }
       }
@@ -169,8 +169,8 @@ class GetLoiReportUseCaseTest {
         "geometry": {
           "type": "MultiPolygon",
           "coordinates": [
-            [[[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.0, 0.0]]],
-            [[[5.0, 5.0], [5.0, 6.0], [6.0, 6.0], [5.0, 5.0]]]
+            [[[0.000000, 0.000000], [0.000000, 1.000000], [1.000000, 1.000000], [0.000000, 0.000000]]],
+            [[[5.000000, 5.000000], [5.000000, 6.000000], [6.000000, 6.000000], [5.000000, 5.000000]]]
           ]
         }
       }
@@ -193,7 +193,7 @@ class GetLoiReportUseCaseTest {
         "properties": {"name": "LineString test"},
         "geometry": {
           "type": "LineString",
-          "coordinates": [[20.0, 10.0], [40.0, 30.0], [60.0, 50.0]]
+          "coordinates": [[20.000000, 10.000000], [40.000000, 30.000000], [60.000000, 50.000000]]
         }
       }
       """
@@ -216,7 +216,7 @@ class GetLoiReportUseCaseTest {
         "properties": {},
         "geometry": {
           "type": "Point",
-          "coordinates": [0.0, 0.0]
+          "coordinates": [0.000000, 0.000000]
         }
       }
       """
@@ -291,7 +291,7 @@ class GetLoiReportUseCaseTest {
         "properties": {"name": "Name test"},
         "geometry": {
           "type": "Point",
-          "coordinates": [0.0, 0.0]
+          "coordinates": [0.000000, 0.000000]
         }
       }
       """


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3718

This PR fixes the `GetLoiReportUseCase` where the geometry geoJSON would have less than 6 digits because the trailing zeroes were dropped

@shobhitagarwal1612  PTAL?
