### PR TITLE
Replace legacy apply plugin usage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-parcelize'
-apply plugin: 'kotlinx-serialization'
-apply plugin: 'com.google.dagger.hilt.android'
-apply plugin: 'com.google.devtools.ksp'
-apply plugin: 'androidx.room'
-apply plugin: 'com.google.firebase.firebase-perf'
-apply plugin: 'com.google.firebase.crashlytics'
-apply plugin: 'com.google.android.gms.oss-licenses-plugin'
-apply plugin: 'com.google.protobuf'
-apply plugin: 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
-apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+plugins {
+    alias libs.plugins.android.application
+    alias libs.plugins.kotlin.parcelize
+    alias libs.plugins.kotlin.serialization
+    alias libs.plugins.hilt.android
+    alias libs.plugins.ksp
+    alias libs.plugins.room
+    alias libs.plugins.firebase.perf
+    alias libs.plugins.firebase.crashlytics
+    alias libs.plugins.oss.licenses
+    alias libs.plugins.protobuf
+    alias libs.plugins.androidx.navigation.safeargs
+    alias libs.plugins.secrets.gradle.plugin
+    alias libs.plugins.compose.compiler
+    alias libs.plugins.google.services
+}
 
 apply from: '../config/checkstyle/checkstyle.gradle'
 apply from: '../config/lint/lint.gradle'
@@ -88,6 +92,10 @@ android {
         buildConfigField "int", "AUTH_EMULATOR_PORT", "9099"
         buildConfigField "String", "SIGNUP_FORM_LINK", "\"\""
         manifestPlaceholders.usesCleartextTraffic = true
+
+        def secretsFile = rootProject.file('secrets.properties')
+        def secretProps = new Properties()
+        if (secretsFile.exists()) secretsFile.withInputStream { secretProps.load(it) }
     }
 
     // Use flag -PtestBuildType with desired variant to change default behavior.
@@ -363,12 +371,6 @@ task extractGroundProtoJar(type: Copy) {
     into extractedGroundProtoPath
     include "**/*.proto"
 }
-
-apply plugin: 'androidx.navigation.safeargs'
-
-// This must be last to avoid dependency collisions.
-// https://developers.google.com/android/guides/google-services-plugin#introduction
-apply plugin: 'com.google.gms.google-services'
 
 kotlin {
     jvmToolchain libs.versions.jvmToolchainVersion.get().toInteger()

--- a/build.gradle
+++ b/build.gradle
@@ -26,32 +26,16 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath libs.androidx.navigation.safe.args.gradle.plugin
-        classpath libs.gradle
-        classpath libs.google.services
-
-        // Performance Monitoring plugin: https://firebase.google.com/docs/perf-mon
-        classpath libs.perf.plugin
-
-        // Crashlytics plugin
-        classpath libs.firebase.crashlytics.gradle
-
-        // Kotlin
-        classpath libs.kotlin.gradle.plugin
-        classpath libs.kotlin.serialization
-
-        // OSS Licenses Plugin
-        classpath libs.oss.licenses.plugin
-
-        // To fetch Maps API key from secrets.properties.
-        classpath libs.secrets.gradle.plugin
-
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
 plugins {
+    alias libs.plugins.android.application apply false
+    alias libs.plugins.androidx.navigation.safeargs apply false
+    alias libs.plugins.google.services apply false
+    alias libs.plugins.kotlin.parcelize apply false
     alias libs.plugins.kotlin.serialization apply false
     alias libs.plugins.compose.compiler apply false
     alias libs.plugins.ksp apply false
@@ -60,6 +44,10 @@ plugins {
     alias libs.plugins.hilt.android apply false
     alias libs.plugins.detekt
     alias libs.plugins.protobuf apply false
+    alias libs.plugins.firebase.perf apply false
+    alias libs.plugins.firebase.crashlytics apply false
+    alias libs.plugins.oss.licenses apply false
+    alias libs.plugins.secrets.gradle.plugin apply false
     alias libs.plugins.kotlin.multiplatform apply false
     alias libs.plugins.android.kotlin.multiplatform.library apply false
     alias libs.plugins.android.lint apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,7 +102,6 @@ androidx-material-icons = { module = "androidx.compose.material:material-icons-c
 androidx-material3-android = { module = "androidx.compose.material3:material3-android" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationKtxVersion" }
-androidx-navigation-safe-args-gradle-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navigationKtxVersion" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "navigationKtxVersion" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationKtxVersion" }
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationKtxVersion" }
@@ -129,7 +128,6 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-config = { module = "com.google.firebase:firebase-config" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-auth = { module = "com.google.firebase:firebase-auth" }
-firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "firebaseCrashlyticsGradleVersion" }
 firebase-firestore = { module = "com.google.firebase:firebase-firestore" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
@@ -137,9 +135,7 @@ firebase-messaging-directboot = { module = "com.google.firebase:firebase-messagi
 firebase-storage = { module = "com.google.firebase:firebase-storage" }
 firebase-perf = { module = "com.google.firebase:firebase-perf" }
 firebase-functions = { module = "com.google.firebase:firebase-functions" }
-google-services = { module = "com.google.gms:google-services", version.ref = "googleServicesVersion" }
 google-zxing = { module = "com.google.zxing:core", version.ref = "googleZxingVersion" }
-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradleVersion" }
 ground-platform = { module = "com.github.google:ground-platform", version.ref = "groundPlatformVersion" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gsonVersion" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltVersion" }
@@ -148,9 +144,7 @@ hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", vers
 hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltJetpackVersion" }
 json = { module = "org.json:json", version.ref = "jsonVersion" }
 junit = { module = "junit:junit", version.ref = "junitVersion" }
-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinVersion" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinVersion" }
-kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlinVersion" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinVersion" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlinVersion" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
@@ -168,15 +162,12 @@ mockito-android = { module = "org.mockito:mockito-android" }
 mockito-core = { module = "org.mockito:mockito-core" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInlineVersion" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlinVersion" }
-oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "ossLicensesPluginVersion" }
-perf-plugin = { module = "com.google.firebase:perf-plugin", version.ref = "perfPluginVersion" }
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuthVersion" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesAuthVersion" }
 play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMapsVersion" }
 play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicensesVersion" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobufKotlinLiteVersion" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectricVersion" }
-secrets-gradle-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secretsGradlePluginVersion" }
 testing = { module = "com.jraska.livedata:testing", version.ref = "testingVersion" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timberVersion" }
 truth = { module = "com.google.truth:truth", version.ref = "truthVersion" }
@@ -193,6 +184,14 @@ compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-pre
 kermit = { module = "co.touchlab:kermit", version.ref = "kermitVersion" }
 
 [plugins]
+android-application = { id = "com.android.application", version.ref = "gradleVersion" }
+androidx-navigation-safeargs = { id = "androidx.navigation.safeargs", version.ref = "navigationKtxVersion" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesVersion" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsGradleVersion" }
+firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "perfPluginVersion" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinVersion" }
+oss-licenses = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "ossLicensesPluginVersion" }
+secrets-gradle-plugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secretsGradlePluginVersion" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinVersion" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatformVersion" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinVersion" }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

This PR migrates module plugin declarations from the legacy `apply plugin` syntax to the modern `plugins {}` block using version catalog aliases. This fixes issues where updating gradle plugin, builds started failing during manifest merging : https://github.com/google/ground-android/pull/3720 and https://github.com/google/ground-android/pull/3708 

The issue appears to be related to plugin evaluation order: with the legacy plugin style, the secrets gradle plugin was not being applied early enough, so manifest placeholders were not populated in time which caused manifest merge failures. According to the [official docs](https://docs.gradle.org/current/userguide/plugins_intermediate.html?utm_source=chatgpt.com#sec:root_plugins_dsl), wiith the new approach, the plugin resolution happens earlier which ensures the secrets plugin is available before manifest processing.

@shobhitagarwal1612  PTAL?
