### PR TITLE
Display language names in own language

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/SettingsScreen.kt
@@ -99,6 +99,7 @@ internal fun SettingsScreen(
       SettingsCategory(stringResource(R.string.general_title)) {
         // Upload Media
         SettingsSwitchItem(
+          trailingIcon = R.drawable.ic_cloud_upload,
           title = stringResource(R.string.upload_media_title),
           summary = stringResource(R.string.over_wifi_summary),
           checked = settings.shouldUploadPhotosOnWifiOnly,
@@ -107,6 +108,7 @@ internal fun SettingsScreen(
 
         // Language
         SettingsSelectItem(
+          trailingIcon = R.drawable.ic_language,
           title = stringResource(R.string.select_language_title),
           entriesResId = R.array.language_entries,
           entryValues = R.array.language_entry_values,
@@ -116,6 +118,7 @@ internal fun SettingsScreen(
 
         // Measurement Units
         SettingsSelectItem(
+          trailingIcon = R.drawable.ic_measurement,
           title = stringResource(R.string.select_length_title),
           entriesResId = R.array.length_entries,
           entryValues = R.array.length_entry_values,
@@ -129,6 +132,7 @@ internal fun SettingsScreen(
       // Help Section
       SettingsCategory(stringResource(R.string.help_title)) {
         SettingsItem(
+          trailingIcon = R.drawable.ic_open_in_new,
           title = stringResource(R.string.visit_website_title),
           summary = stringResource(R.string.ground_website),
           onClick = onVisitWebsiteClick,

--- a/app/src/main/java/org/groundplatform/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/SettingsScreen.kt
@@ -99,7 +99,7 @@ internal fun SettingsScreen(
       SettingsCategory(stringResource(R.string.general_title)) {
         // Upload Media
         SettingsSwitchItem(
-          trailingIcon = R.drawable.ic_cloud_upload,
+          icon = R.drawable.ic_cloud_upload,
           title = stringResource(R.string.upload_media_title),
           summary = stringResource(R.string.over_wifi_summary),
           checked = settings.shouldUploadPhotosOnWifiOnly,
@@ -108,7 +108,7 @@ internal fun SettingsScreen(
 
         // Language
         SettingsSelectItem(
-          trailingIcon = R.drawable.ic_language,
+          icon = R.drawable.ic_language,
           title = stringResource(R.string.select_language_title),
           entriesResId = R.array.language_entries,
           entryValues = R.array.language_entry_values,
@@ -118,7 +118,7 @@ internal fun SettingsScreen(
 
         // Measurement Units
         SettingsSelectItem(
-          trailingIcon = R.drawable.ic_measurement,
+          icon = R.drawable.ic_measurement,
           title = stringResource(R.string.select_length_title),
           entriesResId = R.array.length_entries,
           entryValues = R.array.length_entry_values,
@@ -132,7 +132,7 @@ internal fun SettingsScreen(
       // Help Section
       SettingsCategory(stringResource(R.string.help_title)) {
         SettingsItem(
-          trailingIcon = R.drawable.ic_open_in_new,
+          icon = R.drawable.ic_open_in_new,
           title = stringResource(R.string.visit_website_title),
           summary = stringResource(R.string.ground_website),
           onClick = onVisitWebsiteClick,

--- a/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsItem.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsItem.kt
@@ -68,7 +68,7 @@ internal fun SettingsItem(
       contentDescription = null,
       tint = MaterialTheme.colorScheme.onSurfaceVariant,
     )
-    Column {
+    Column(modifier = Modifier.weight(1f)) {
       Text(text = title, style = MaterialTheme.typography.titleMedium)
       if (summary != null) {
         Text(
@@ -87,18 +87,8 @@ internal fun SettingsItem(
 private fun Preview() {
   AppTheme {
     Column(verticalArrangement = Arrangement.SpaceEvenly) {
-      SettingsItem(
-        icon = R.drawable.ic_language,
-        title = "Name",
-        summary = "Summary",
-        onClick = {},
-      )
-      SettingsItem(
-        icon = R.drawable.ic_language,
-        title = "Name",
-        summary = null,
-        onClick = {},
-      )
+      SettingsItem(icon = R.drawable.ic_language, title = "Name", summary = "Summary", onClick = {})
+      SettingsItem(icon = R.drawable.ic_language, title = "Name", summary = null, onClick = {})
       SettingsItem(
         icon = R.drawable.ic_language,
         title = "Language",

--- a/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsItem.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsItem.kt
@@ -15,38 +15,60 @@
  */
 package org.groundplatform.android.ui.settings.components
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.groundplatform.android.R
 import org.groundplatform.android.ui.common.ExcludeFromJacocoGeneratedReport
 import org.groundplatform.ui.theme.AppTheme
+import org.groundplatform.ui.theme.sizes
 
 /**
  * A reusable UI component representing a single row in a settings screen.
  *
+ * @param modifier The [Modifier] to be applied to the root of this item.
+ * @param trailingIcon Drawable resource for the icon shown next to the title.
  * @param title The primary text to be displayed for the setting.
  * @param summary Optional secondary text to be displayed below the title, providing more detail.
  * @param onClick The callback to be invoked when the item is clicked.
  */
 @Composable
-internal fun SettingsItem(title: String, summary: String? = null, onClick: () -> Unit) {
+internal fun SettingsItem(
+  modifier: Modifier = Modifier,
+  @DrawableRes trailingIcon: Int,
+  title: String,
+  summary: String? = null,
+  onClick: () -> Unit,
+) {
   Row(
     modifier =
-      Modifier.fillMaxWidth().clickable(onClick = onClick, role = Role.Button).padding(16.dp),
+      modifier.fillMaxWidth().clickable(onClick = onClick, role = Role.Button).padding(16.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    Column(modifier = Modifier.weight(1f)) {
+    Icon(
+      modifier =
+        Modifier.padding(end = MaterialTheme.sizes.settingsTrailingIconEndPadding)
+          .size(MaterialTheme.sizes.settingsTrailingIconSize),
+      painter = painterResource(trailingIcon),
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Column {
       Text(text = title, style = MaterialTheme.typography.titleMedium)
       if (summary != null) {
         Text(
@@ -65,8 +87,24 @@ internal fun SettingsItem(title: String, summary: String? = null, onClick: () ->
 private fun Preview() {
   AppTheme {
     Column(verticalArrangement = Arrangement.SpaceEvenly) {
-      SettingsItem(title = "Name", summary = "Summary", onClick = {})
-      SettingsItem(title = "Name", summary = null, onClick = {})
+      SettingsItem(
+        trailingIcon = R.drawable.ic_language,
+        title = "Name",
+        summary = "Summary",
+        onClick = {},
+      )
+      SettingsItem(
+        trailingIcon = R.drawable.ic_language,
+        title = "Name",
+        summary = null,
+        onClick = {},
+      )
+      SettingsItem(
+        trailingIcon = R.drawable.ic_language,
+        title = "Language",
+        summary = "English",
+        onClick = {},
+      )
     }
   }
 }

--- a/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsItem.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsItem.kt
@@ -42,7 +42,7 @@ import org.groundplatform.ui.theme.sizes
  * A reusable UI component representing a single row in a settings screen.
  *
  * @param modifier The [Modifier] to be applied to the root of this item.
- * @param trailingIcon Drawable resource for the icon shown next to the title.
+ * @param icon Drawable resource for the icon shown next to the title.
  * @param title The primary text to be displayed for the setting.
  * @param summary Optional secondary text to be displayed below the title, providing more detail.
  * @param onClick The callback to be invoked when the item is clicked.
@@ -50,7 +50,7 @@ import org.groundplatform.ui.theme.sizes
 @Composable
 internal fun SettingsItem(
   modifier: Modifier = Modifier,
-  @DrawableRes trailingIcon: Int,
+  @DrawableRes icon: Int,
   title: String,
   summary: String? = null,
   onClick: () -> Unit,
@@ -62,9 +62,9 @@ internal fun SettingsItem(
   ) {
     Icon(
       modifier =
-        Modifier.padding(end = MaterialTheme.sizes.settingsTrailingIconEndPadding)
-          .size(MaterialTheme.sizes.settingsTrailingIconSize),
-      painter = painterResource(trailingIcon),
+        Modifier.padding(end = MaterialTheme.sizes.settingsItemIconEndPadding)
+          .size(MaterialTheme.sizes.settingsItemIconSize),
+      painter = painterResource(icon),
       contentDescription = null,
       tint = MaterialTheme.colorScheme.onSurfaceVariant,
     )
@@ -88,19 +88,19 @@ private fun Preview() {
   AppTheme {
     Column(verticalArrangement = Arrangement.SpaceEvenly) {
       SettingsItem(
-        trailingIcon = R.drawable.ic_language,
+        icon = R.drawable.ic_language,
         title = "Name",
         summary = "Summary",
         onClick = {},
       )
       SettingsItem(
-        trailingIcon = R.drawable.ic_language,
+        icon = R.drawable.ic_language,
         title = "Name",
         summary = null,
         onClick = {},
       )
       SettingsItem(
-        trailingIcon = R.drawable.ic_language,
+        icon = R.drawable.ic_language,
         title = "Language",
         summary = "English",
         onClick = {},

--- a/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsSelectItem.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsSelectItem.kt
@@ -15,6 +15,8 @@
  */
 package org.groundplatform.android.ui.settings.components
 
+import androidx.annotation.ArrayRes
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.widthIn
@@ -41,6 +43,7 @@ import org.groundplatform.ui.theme.AppTheme
  *
  * When clicked, it displays a dropdown menu with options populated from the provided resource IDs.
  *
+ * @param trailingIcon Drawable resource for the icon shown next to the title.
  * @param title The title of the settings item.
  * @param entriesResId The resource ID of the string array containing the display labels.
  * @param entryValues The resource ID of the string array containing the underlying values.
@@ -49,9 +52,10 @@ import org.groundplatform.ui.theme.AppTheme
  */
 @Composable
 internal fun SettingsSelectItem(
+  @DrawableRes trailingIcon: Int,
   title: String,
-  entriesResId: Int,
-  entryValues: Int,
+  @ArrayRes entriesResId: Int,
+  @ArrayRes entryValues: Int,
   currentValue: String,
   onValueChanged: (String) -> Unit,
 ) {
@@ -70,6 +74,7 @@ internal fun SettingsSelectItem(
 
   Box(modifier = Modifier.fillMaxWidth()) {
     SettingsItem(
+      trailingIcon = trailingIcon,
       title = title,
       summary = selectedOption?.label ?: "",
       onClick = { expanded = true },
@@ -102,6 +107,7 @@ internal data class Option(val label: String, val value: String)
 private fun PreviewSelectItem() {
   AppTheme {
     SettingsSelectItem(
+      trailingIcon = R.drawable.ic_language,
       title = "Language",
       entriesResId = R.array.language_entries,
       entryValues = R.array.language_entry_values,

--- a/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsSelectItem.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsSelectItem.kt
@@ -43,7 +43,7 @@ import org.groundplatform.ui.theme.AppTheme
  *
  * When clicked, it displays a dropdown menu with options populated from the provided resource IDs.
  *
- * @param trailingIcon Drawable resource for the icon shown next to the title.
+ * @param icon Drawable resource for the icon shown next to the title.
  * @param title The title of the settings item.
  * @param entriesResId The resource ID of the string array containing the display labels.
  * @param entryValues The resource ID of the string array containing the underlying values.
@@ -52,7 +52,7 @@ import org.groundplatform.ui.theme.AppTheme
  */
 @Composable
 internal fun SettingsSelectItem(
-  @DrawableRes trailingIcon: Int,
+  @DrawableRes icon: Int,
   title: String,
   @ArrayRes entriesResId: Int,
   @ArrayRes entryValues: Int,
@@ -74,7 +74,7 @@ internal fun SettingsSelectItem(
 
   Box(modifier = Modifier.fillMaxWidth()) {
     SettingsItem(
-      trailingIcon = trailingIcon,
+      icon = icon,
       title = title,
       summary = selectedOption?.label ?: "",
       onClick = { expanded = true },
@@ -107,7 +107,7 @@ internal data class Option(val label: String, val value: String)
 private fun PreviewSelectItem() {
   AppTheme {
     SettingsSelectItem(
-      trailingIcon = R.drawable.ic_language,
+      icon = R.drawable.ic_language,
       title = "Language",
       entriesResId = R.array.language_entries,
       entryValues = R.array.language_entry_values,

--- a/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsSwitchItem.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsSwitchItem.kt
@@ -15,27 +15,35 @@
  */
 package org.groundplatform.android.ui.settings.components
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.groundplatform.android.R
 import org.groundplatform.android.ui.common.ExcludeFromJacocoGeneratedReport
 import org.groundplatform.ui.theme.AppTheme
+import org.groundplatform.ui.theme.sizes
 
 /**
  * A reusable settings item component with a title, optional summary, and a switch toggle.
  *
+ * @param modifier The [Modifier] to be applied to the root of this item.
+ * @param trailingIcon Drawable resource for the icon shown next to the title.
  * @param title The primary text to be displayed for the setting.
  * @param summary Optional secondary text providing additional details about the setting.
  * @param checked Whether the switch is currently in the "on" position.
@@ -43,6 +51,8 @@ import org.groundplatform.ui.theme.AppTheme
  */
 @Composable
 internal fun SettingsSwitchItem(
+  modifier: Modifier = Modifier,
+  @DrawableRes trailingIcon: Int,
   title: String,
   summary: String? = null,
   checked: Boolean,
@@ -50,11 +60,20 @@ internal fun SettingsSwitchItem(
 ) {
   Row(
     modifier =
-      Modifier.fillMaxWidth()
+      modifier
+        .fillMaxWidth()
         .toggleable(value = checked, onValueChange = onCheckedChange, role = Role.Switch)
         .padding(16.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
+    Icon(
+      modifier =
+        Modifier.padding(end = MaterialTheme.sizes.settingsTrailingIconEndPadding)
+          .size(MaterialTheme.sizes.settingsTrailingIconSize),
+      painter = painterResource(trailingIcon),
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
     Column(modifier = Modifier.weight(1f)) {
       Text(text = title, style = MaterialTheme.typography.titleMedium)
       if (summary != null) {
@@ -75,8 +94,20 @@ internal fun SettingsSwitchItem(
 private fun Preview() {
   AppTheme {
     Column(verticalArrangement = Arrangement.SpaceEvenly) {
-      SettingsSwitchItem(title = "Name", summary = "Value", checked = true, onCheckedChange = {})
-      SettingsSwitchItem(title = "Name", summary = null, checked = false, onCheckedChange = {})
+      SettingsSwitchItem(
+        trailingIcon = R.drawable.ic_cloud_upload,
+        title = "Name",
+        summary = "Value",
+        checked = true,
+        onCheckedChange = {},
+      )
+      SettingsSwitchItem(
+        trailingIcon = R.drawable.ic_cloud_upload,
+        title = "Name",
+        summary = null,
+        checked = false,
+        onCheckedChange = {},
+      )
     }
   }
 }

--- a/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsSwitchItem.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/settings/components/SettingsSwitchItem.kt
@@ -43,7 +43,7 @@ import org.groundplatform.ui.theme.sizes
  * A reusable settings item component with a title, optional summary, and a switch toggle.
  *
  * @param modifier The [Modifier] to be applied to the root of this item.
- * @param trailingIcon Drawable resource for the icon shown next to the title.
+ * @param icon Drawable resource for the icon shown next to the title.
  * @param title The primary text to be displayed for the setting.
  * @param summary Optional secondary text providing additional details about the setting.
  * @param checked Whether the switch is currently in the "on" position.
@@ -52,7 +52,7 @@ import org.groundplatform.ui.theme.sizes
 @Composable
 internal fun SettingsSwitchItem(
   modifier: Modifier = Modifier,
-  @DrawableRes trailingIcon: Int,
+  @DrawableRes icon: Int,
   title: String,
   summary: String? = null,
   checked: Boolean,
@@ -68,9 +68,9 @@ internal fun SettingsSwitchItem(
   ) {
     Icon(
       modifier =
-        Modifier.padding(end = MaterialTheme.sizes.settingsTrailingIconEndPadding)
-          .size(MaterialTheme.sizes.settingsTrailingIconSize),
-      painter = painterResource(trailingIcon),
+        Modifier.padding(end = MaterialTheme.sizes.settingsItemIconEndPadding)
+          .size(MaterialTheme.sizes.settingsItemIconSize),
+      painter = painterResource(icon),
       contentDescription = null,
       tint = MaterialTheme.colorScheme.onSurfaceVariant,
     )
@@ -95,14 +95,14 @@ private fun Preview() {
   AppTheme {
     Column(verticalArrangement = Arrangement.SpaceEvenly) {
       SettingsSwitchItem(
-        trailingIcon = R.drawable.ic_cloud_upload,
+        icon = R.drawable.ic_cloud_upload,
         title = "Name",
         summary = "Value",
         checked = true,
         onCheckedChange = {},
       )
       SettingsSwitchItem(
-        trailingIcon = R.drawable.ic_cloud_upload,
+        icon = R.drawable.ic_cloud_upload,
         title = "Name",
         summary = null,
         checked = false,

--- a/app/src/main/res/drawable/ic_cloud_upload.xml
+++ b/app/src/main/res/drawable/ic_cloud_upload.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2026 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_cloud_upload.xml
+++ b/app/src/main/res/drawable/ic_cloud_upload.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <!--
   ~ Copyright 2026 Google LLC
   ~

--- a/app/src/main/res/drawable/ic_language.xml
+++ b/app/src/main/res/drawable/ic_language.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M476,880L658,400L742,400L924,880L840,880L797,758L603,758L560,880L476,880ZM160,760L104,704L306,502Q271,467 242.5,422Q214,377 190,320L274,320Q294,359 314,388Q334,417 362,446Q395,413 430.5,353.5Q466,294 484,240L40,240L40,160L320,160L320,80L400,80L400,160L680,160L680,240L564,240Q543,312 501,388Q459,464 418,504L514,602L484,684L362,559L160,760ZM628,688L772,688L700,484L628,688Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_language.xml
+++ b/app/src/main/res/drawable/ic_language.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2026 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/drawable/ic_measurement.xml
+++ b/app/src/main/res/drawable/ic_measurement.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2026 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M21,6H3C1.9,6 1,6.9 1,8v8c0,1.1 0.9,2 2,2h18c1.1,0 2,-0.9 2,-2V8C23,6.9 22.1,6 21,6zM21,16H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2V16z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_measurement.xml
+++ b/app/src/main/res/drawable/ic_measurement.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <!--
   ~ Copyright 2026 Google LLC
   ~

--- a/app/src/main/res/drawable/ic_open_in_new.xml
+++ b/app/src/main/res/drawable/ic_open_in_new.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M200,840Q167,840 143.5,816.5Q120,793 120,760L120,200Q120,167 143.5,143.5Q167,120 200,120L480,120L480,200L200,200Q200,200 200,200Q200,200 200,200L200,760Q200,760 200,760Q200,760 200,760L760,760Q760,760 760,760Q760,760 760,760L760,480L840,480L840,760Q840,793 816.5,816.5Q793,840 760,840L200,840ZM388,628L332,572L704,200L560,200L560,120L840,120L840,400L760,400L760,256L388,628Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_open_in_new.xml
+++ b/app/src/main/res/drawable/ic_open_in_new.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2026 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -205,14 +205,6 @@
   <string name="text_task_data_character_limit">Máx. 255 caracteres</string>
   <string name="area_message">Área: %s</string>
 
-  <string name="lang_english">Inglés</string>
-  <string name="lang_french">Francés</string>
-  <string name="lang_spanish">Español</string>
-  <string name="lang_portuguese">Portugués</string>
-
-  <string name="lang_vietnamese">Vietnamita</string>
-  <string name="lang_thai">Tailandés</string>
-  <string name="lang_lao">Lao</string>
   <string name="access_restricted">Restringido</string>
   <string name="access_unlisted">No listado</string>
   <string name="access_public">Público</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -186,13 +186,7 @@
   <string name="clear">Claire</string>
   <string name="text_task_data_character_limit">255 caractères maximum</string>
   <string name="area_message">Surface: %s</string>
-  <string name="lang_english">Anglais</string>
-  <string name="lang_french">Français</string>
-  <string name="lang_spanish">Espagnol</string>
-  <string name="lang_portuguese">Portugais</string>
-  <string name="lang_vietnamese">Vietnamien</string>
-  <string name="lang_thai">Thaï</string>
-  <string name="lang_lao">Lao</string>
+
   <string name="access_restricted">Restreint</string>
   <string name="access_unlisted">Non répertorié</string>
   <string name="access_public">Public</string>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -182,13 +182,6 @@
   <string name="clear">ລ້າງ</string>
   <string name="text_task_data_character_limit">ສູງສຸດ 255 ຕົວອັກສອນ</string>
   <string name="area_message">ພື້ນທີ່: %s</string>
-  <string name="lang_english">ພາສາອັງກິດ</string>
-  <string name="lang_french">ພາສາຝຣັ່ງ</string>
-  <string name="lang_spanish">ພາສາສະແປນ</string>
-  <string name="lang_portuguese">ພາສາໂປຣຕຸເກດ</string>
-  <string name="lang_vietnamese">ພາສາຫວຽດນາມ</string>
-  <string name="lang_thai">ພາສາໄທ</string>
-  <string name="lang_lao">ພາສາລາວ</string>
   <string name="access_restricted">ຈຳກັດການເຂົ້າເຖິງ</string>
   <string name="access_unlisted">ບໍ່ສະແດງໃນລາຍການ</string>
   <string name="access_public">ສາທາລະນະ</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -206,14 +206,6 @@
   <string name="text_task_data_character_limit">255 caracteres no máx.</string>
   <string name="area_message">Área: %s</string>
 
-  <string name="lang_english">Inglês</string>
-  <string name="lang_french">Francês</string>
-  <string name="lang_spanish">Espanhol</string>
-  <string name="lang_portuguese">Português</string>
-
-  <string name="lang_vietnamese">Vietnamita</string>
-  <string name="lang_thai">Tailandês</string>
-  <string name="lang_lao">Lao</string>
   <string name="access_restricted">Restrito</string>
   <string name="access_unlisted">Não listado</string>
   <string name="access_public">Público</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -184,13 +184,6 @@
   <string name="clear">ล้างข้อมูล</string>
   <string name="text_task_data_character_limit">สูงสุด 255 ตัวอักษร</string>
   <string name="area_message">พื้นที่: %s</string>
-  <string name="lang_english">อังกฤษ</string>
-  <string name="lang_french">ฝรั่งเศส</string>
-  <string name="lang_spanish">สเปน</string>
-  <string name="lang_portuguese">โปรตุเกส</string>
-  <string name="lang_vietnamese">เวียดนาม</string>
-  <string name="lang_thai">ไทย</string>
-  <string name="lang_lao">ลาว</string>
   <string name="access_restricted">จำกัดสิทธิ์</string>
   <string name="access_unlisted">ไม่แสดงสาธารณะ</string>
   <string name="access_public">สาธารณะ</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -181,13 +181,6 @@
   <string name="clear">Xóa</string>
   <string name="text_task_data_character_limit">Tối đa 255 ký tự</string>
   <string name="area_message">Diện tích: %s</string>
-  <string name="lang_english">Tiếng Anh</string>
-  <string name="lang_french">Tiếng Pháp</string>
-  <string name="lang_spanish">Tiếng Tây Ban Nha</string>
-  <string name="lang_portuguese">Tiếng Bồ Đào Nha</string>
-  <string name="lang_vietnamese">Tiếng Việt</string>
-  <string name="lang_thai">Tiếng Thái</string>
-  <string name="lang_lao">Tiếng Lào</string>
   <string name="access_restricted">Hạn chế</string>
   <string name="access_unlisted">Không công khai</string>
   <string name="access_public">Công khai</string>

--- a/app/src/main/res/values/strings-untranslated.xml
+++ b/app/src/main/res/values/strings-untranslated.xml
@@ -22,11 +22,11 @@
   <string name="ground_website" translatable="false">https://groundplatform.org/</string>
   <string name="deeplink_host" translatable="false">ground-dev-sig.web.app</string>
   <string name="survey_deeplink_path" translatable="false">/android/survey/</string>
-  <string name="lang_english">English</string>
-  <string name="lang_french">Français</string>
-  <string name="lang_spanish">Español</string>
-  <string name="lang_lao">ພາສາລາວ</string>
-  <string name="lang_portuguese">Português</string>
-  <string name="lang_thai">ไทย</string>
-  <string name="lang_vietnamese">Tiếng Việt</string>
+  <string name="lang_english" translatable="false">English</string>
+  <string name="lang_french" translatable="false">Français</string>
+  <string name="lang_spanish" translatable="false">Español</string>
+  <string name="lang_lao" translatable="false">ພາສາລາວ</string>
+  <string name="lang_portuguese" translatable="false">Português</string>
+  <string name="lang_thai" translatable="false">ไทย</string>
+  <string name="lang_vietnamese" translatable="false">Tiếng Việt</string>
 </resources>

--- a/app/src/main/res/values/strings-untranslated.xml
+++ b/app/src/main/res/values/strings-untranslated.xml
@@ -22,4 +22,11 @@
   <string name="ground_website" translatable="false">https://groundplatform.org/</string>
   <string name="deeplink_host" translatable="false">ground-dev-sig.web.app</string>
   <string name="survey_deeplink_path" translatable="false">/android/survey/</string>
+  <string name="lang_english">English</string>
+  <string name="lang_french">Français</string>
+  <string name="lang_spanish">Español</string>
+  <string name="lang_lao">ພາສາລາວ</string>
+  <string name="lang_portuguese">Português</string>
+  <string name="lang_thai">ไทย</string>
+  <string name="lang_vietnamese">Tiếng Việt</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,14 +208,6 @@
 
   <string name="area_message">Area: %s</string>
 
-  <string name="lang_english">English</string>
-  <string name="lang_french">French</string>
-  <string name="lang_spanish">Spanish</string>
-  <string name="lang_portuguese">Portuguese</string>
-  <string name="lang_vietnamese">Vietnamese</string>
-  <string name="lang_thai">Thai</string>
-  <string name="lang_lao">Lao</string>
-
   <string name="access_restricted">Restricted</string>
   <string name="access_unlisted">Unlisted</string>
   <string name="access_public">Public</string>

--- a/app/src/test/java/org/groundplatform/android/ui/settings/components/SettingsItemTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/settings/components/SettingsItemTest.kt
@@ -36,7 +36,7 @@ class SettingsItemTest {
     composeTestRule.setContent {
       AppTheme {
         SettingsItem(
-          trailingIcon = R.drawable.ic_language,
+          icon = R.drawable.ic_language,
           title = "Title",
           summary = "Summary",
           onClick = {},
@@ -53,7 +53,7 @@ class SettingsItemTest {
     composeTestRule.setContent {
       AppTheme {
         SettingsItem(
-          trailingIcon = R.drawable.ic_language,
+          icon = R.drawable.ic_language,
           title = "Title",
           summary = null,
           onClick = {},
@@ -72,7 +72,7 @@ class SettingsItemTest {
     composeTestRule.setContent {
       AppTheme {
         SettingsItem(
-          trailingIcon = R.drawable.ic_language,
+          icon = R.drawable.ic_language,
           title = "Title",
           summary = "Summary",
           onClick = { clicked = true },

--- a/app/src/test/java/org/groundplatform/android/ui/settings/components/SettingsItemTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/settings/components/SettingsItemTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.ui.settings.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.groundplatform.android.R
+import org.groundplatform.ui.theme.AppTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SettingsItemTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun `Displays title and summary`() {
+    composeTestRule.setContent {
+      AppTheme {
+        SettingsItem(
+          trailingIcon = R.drawable.ic_language,
+          title = "Title",
+          summary = "Summary",
+          onClick = {},
+        )
+      }
+    }
+
+    composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Summary").assertIsDisplayed()
+  }
+
+  @Test
+  fun `Should hide summary when null`() {
+    composeTestRule.setContent {
+      AppTheme {
+        SettingsItem(
+          trailingIcon = R.drawable.ic_language,
+          title = "Title",
+          summary = null,
+          onClick = {},
+        )
+      }
+    }
+
+    composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Summary").assertDoesNotExist()
+  }
+
+  @Test
+  fun `Invokes onClick action when clicked`() {
+    var clicked = false
+
+    composeTestRule.setContent {
+      AppTheme {
+        SettingsItem(
+          trailingIcon = R.drawable.ic_language,
+          title = "Title",
+          summary = "Summary",
+          onClick = { clicked = true },
+        )
+      }
+    }
+
+    composeTestRule.onNodeWithText("Title").performClick()
+    assert(clicked)
+  }
+}

--- a/app/src/test/java/org/groundplatform/android/ui/settings/components/SettingsSwitchItemTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/settings/components/SettingsSwitchItemTest.kt
@@ -38,7 +38,7 @@ class SettingsSwitchItemTest {
     composeTestRule.setContent {
       AppTheme {
         SettingsSwitchItem(
-          trailingIcon = R.drawable.ic_cloud_upload,
+          icon = R.drawable.ic_cloud_upload,
           title = "Title",
           summary = "Summary",
           checked = true,
@@ -56,7 +56,7 @@ class SettingsSwitchItemTest {
     composeTestRule.setContent {
       AppTheme {
         SettingsSwitchItem(
-          trailingIcon = R.drawable.ic_cloud_upload,
+          icon = R.drawable.ic_cloud_upload,
           title = "Title",
           summary = null,
           checked = false,
@@ -74,7 +74,7 @@ class SettingsSwitchItemTest {
     composeTestRule.setContent {
       AppTheme {
         SettingsSwitchItem(
-          trailingIcon = R.drawable.ic_cloud_upload,
+          icon = R.drawable.ic_cloud_upload,
           title = "Title",
           checked = true,
           onCheckedChange = {},
@@ -90,7 +90,7 @@ class SettingsSwitchItemTest {
     composeTestRule.setContent {
       AppTheme {
         SettingsSwitchItem(
-          trailingIcon = R.drawable.ic_cloud_upload,
+          icon = R.drawable.ic_cloud_upload,
           title = "Title",
           checked = false,
           onCheckedChange = {},
@@ -108,7 +108,7 @@ class SettingsSwitchItemTest {
     composeTestRule.setContent {
       AppTheme {
         SettingsSwitchItem(
-          trailingIcon = R.drawable.ic_cloud_upload,
+          icon = R.drawable.ic_cloud_upload,
           title = "Title",
           checked = false,
           onCheckedChange = { newValue = it },

--- a/app/src/test/java/org/groundplatform/android/ui/settings/components/SettingsSwitchItemTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/settings/components/SettingsSwitchItemTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.ui.settings.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.groundplatform.android.R
+import org.groundplatform.ui.theme.AppTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SettingsSwitchItemTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun `Displays title and summary`() {
+    composeTestRule.setContent {
+      AppTheme {
+        SettingsSwitchItem(
+          trailingIcon = R.drawable.ic_cloud_upload,
+          title = "Title",
+          summary = "Summary",
+          checked = true,
+          onCheckedChange = {},
+        )
+      }
+    }
+
+    composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Summary").assertIsDisplayed()
+  }
+
+  @Test
+  fun `Hides summary when null`() {
+    composeTestRule.setContent {
+      AppTheme {
+        SettingsSwitchItem(
+          trailingIcon = R.drawable.ic_cloud_upload,
+          title = "Title",
+          summary = null,
+          checked = false,
+          onCheckedChange = {},
+        )
+      }
+    }
+
+    composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Summary").assertDoesNotExist()
+  }
+
+  @Test
+  fun `Switch should be on when checked state is true`() {
+    composeTestRule.setContent {
+      AppTheme {
+        SettingsSwitchItem(
+          trailingIcon = R.drawable.ic_cloud_upload,
+          title = "Title",
+          checked = true,
+          onCheckedChange = {},
+        )
+      }
+    }
+
+    composeTestRule.onNodeWithText("Title").assertIsOn()
+  }
+
+  @Test
+  fun `Switch should be off when checked state is false`() {
+    composeTestRule.setContent {
+      AppTheme {
+        SettingsSwitchItem(
+          trailingIcon = R.drawable.ic_cloud_upload,
+          title = "Title",
+          checked = false,
+          onCheckedChange = {},
+        )
+      }
+    }
+
+    composeTestRule.onNodeWithText("Title").assertIsOff()
+  }
+
+  @Test
+  fun `Invokes onCheckedChange with the correct value when clicked on`() {
+    var newValue: Boolean? = null
+
+    composeTestRule.setContent {
+      AppTheme {
+        SettingsSwitchItem(
+          trailingIcon = R.drawable.ic_cloud_upload,
+          title = "Title",
+          checked = false,
+          onCheckedChange = { newValue = it },
+        )
+      }
+    }
+
+    composeTestRule.onNodeWithText("Title").performClick()
+    assert(newValue == true)
+  }
+}

--- a/core/ui/src/commonMain/kotlin/org/groundplatform/ui/theme/Size.kt
+++ b/core/ui/src/commonMain/kotlin/org/groundplatform/ui/theme/Size.kt
@@ -31,7 +31,7 @@ data class Size(
   val progressIndicatorStrokeWidth: Dp = 2.dp,
   val taskViewPadding: Dp = 16.dp,
   val settingsTrailingIconSize: Dp = 24.dp,
-  val settingsTrailingIconEndPadding: Dp = 16.dp
+  val settingsTrailingIconEndPadding: Dp = 16.dp,
 )
 
 internal val LocalSizes = compositionLocalOf { Size() }

--- a/core/ui/src/commonMain/kotlin/org/groundplatform/ui/theme/Size.kt
+++ b/core/ui/src/commonMain/kotlin/org/groundplatform/ui/theme/Size.kt
@@ -30,6 +30,8 @@ data class Size(
   val progressIndicatorSize: Dp = 24.dp,
   val progressIndicatorStrokeWidth: Dp = 2.dp,
   val taskViewPadding: Dp = 16.dp,
+  val settingsTrailingIconSize: Dp = 24.dp,
+  val settingsTrailingIconEndPadding: Dp = 16.dp
 )
 
 internal val LocalSizes = compositionLocalOf { Size() }

--- a/core/ui/src/commonMain/kotlin/org/groundplatform/ui/theme/Size.kt
+++ b/core/ui/src/commonMain/kotlin/org/groundplatform/ui/theme/Size.kt
@@ -30,8 +30,8 @@ data class Size(
   val progressIndicatorSize: Dp = 24.dp,
   val progressIndicatorStrokeWidth: Dp = 2.dp,
   val taskViewPadding: Dp = 16.dp,
-  val settingsTrailingIconSize: Dp = 24.dp,
-  val settingsTrailingIconEndPadding: Dp = 16.dp,
+  val settingsItemIconSize: Dp = 24.dp,
+  val settingsItemIconEndPadding: Dp = 16.dp,
 )
 
 internal val LocalSizes = compositionLocalOf { Size() }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3379

Moved the languages to the untranslated strings, in order to display their names in their native language. Also updated the settings page to show icons for each setting in order to improve discoverability.

<img size="442" height="880" alt="image" src="https://github.com/user-attachments/assets/81165a1d-2682-4588-bcf7-711ca39c9ff1" />

<img size="442" height="910" alt="image" src="https://github.com/user-attachments/assets/7a107611-09ca-4bc2-8b61-ac7ddac3a9d5" />


@shobhitagarwal1612  PTAL?
