### PR TITLE
Fix language switch delay on release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,6 +174,12 @@ android {
     }
 
     namespace = 'org.groundplatform.android'
+
+    bundle {
+        language {
+            enableSplit = false
+        }
+    }
 }
 
 configurations {


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3730

In release builds (AAB via Play Store), language config splits are only delivered at install time for locales matching the device's system languages. Other languages are fetched on demand the first time they're requested. This can cause a delay and requires internet access when changing the language.

This PR disables per-language bundle splits so all translated string resources ship in the release aab. Install-size cost is negligible since the app only localizes string resources.

@shobhitagarwal1612  PTAL?
