### PR TITLE
Improve error handling in the scan survey QR flow

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorEvent.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorEvent.kt
@@ -30,5 +30,8 @@ sealed interface SurveySelectorEvent {
 
     /** The scanned QR code did not encode a valid survey link. */
     data object InvalidQrCode : ErrorType
+
+    /** The QR code scanner module is unavailable or failed to install. */
+    data object ScannerUnavailable : ErrorType
   }
 }

--- a/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorFragment.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorFragment.kt
@@ -59,6 +59,8 @@ class SurveySelectorFragment : AbstractFragment(), BackPressListener {
                   ephemeralPopups.ErrorPopup().unknownError()
                 SurveySelectorEvent.ErrorType.InvalidQrCode ->
                   ephemeralPopups.ErrorPopup().show(R.string.invalid_survey_qr_code)
+                SurveySelectorEvent.ErrorType.ScannerUnavailable ->
+                  ephemeralPopups.ErrorPopup().show(R.string.google_api_install_failed)
               }
             },
           )

--- a/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModel.kt
@@ -17,6 +17,8 @@ package org.groundplatform.android.ui.surveyselector
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.google.mlkit.common.MlKitException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -59,7 +61,7 @@ internal constructor(
   private val gmsQrCodeScanner: GmsQrCodeScanner,
   private val surveyDeepLinkParser: SurveyDeepLinkParser,
   private val removeOfflineSurveyUseCase: RemoveOfflineSurveyUseCase,
-  private val getSurveyListItem: GetSurveyListItemUseCase,
+  private val getSurveyListItemUseCase: GetSurveyListItemUseCase,
   private val userRepository: UserRepositoryInterface,
   savedStateHandle: SavedStateHandle,
 ) : AbstractViewModel() {
@@ -156,17 +158,22 @@ internal constructor(
 
   private suspend fun requestJoinSurveyConfirmation(surveyId: String) {
     _isLoadingSurvey.value = true
-    val item =
-      surveyList.first().firstOrNull { it.id == surveyId }
-        ?: runCatching { getSurveyListItem(surveyId) }
-          .onFailure { Timber.e(it, "Failed to load survey $surveyId for confirmation") }
-          .getOrNull()
-    _isLoadingSurvey.value = false
-    if (item == null) {
-      _events.send(SurveySelectorEvent.ShowError(SurveySelectorEvent.ErrorType.InvalidQrCode))
-    } else {
-      _pendingJoinSurvey.value = item
+    val item = runCatching {
+      surveyList.first().firstOrNull { it.id == surveyId } ?: getSurveyListItemUseCase(surveyId)
     }
+    _isLoadingSurvey.value = false
+    item
+      .onSuccess { survey ->
+        if (survey == null) {
+          _events.send(SurveySelectorEvent.ShowError(SurveySelectorEvent.ErrorType.InvalidQrCode))
+        } else {
+          _pendingJoinSurvey.value = survey
+        }
+      }
+      .onFailure {
+        Timber.e(it, "Failed to load survey $surveyId for confirmation")
+        _events.send(SurveySelectorEvent.ShowError(it.toSurveySelectorError()))
+      }
   }
 
   fun confirmJoinSurvey() {
@@ -195,6 +202,16 @@ internal constructor(
   }
 
   private fun Throwable.toSurveySelectorError(): SurveySelectorEvent.ErrorType =
-    if (this is TimeoutCancellationException) SurveySelectorEvent.ErrorType.Timeout
-    else SurveySelectorEvent.ErrorType.Generic(this)
+    when {
+      this is TimeoutCancellationException ||
+        (this is FirebaseFirestoreException &&
+          code == FirebaseFirestoreException.Code.UNAVAILABLE) ||
+        (this is MlKitException && errorCode == MlKitException.NETWORK_ISSUE) ->
+        SurveySelectorEvent.ErrorType.Timeout
+      this is MlKitException &&
+        (errorCode == MlKitException.CODE_SCANNER_UNAVAILABLE ||
+          errorCode == MlKitException.CODE_SCANNER_GOOGLE_PLAY_SERVICES_VERSION_TOO_OLD) ->
+        SurveySelectorEvent.ErrorType.ScannerUnavailable
+      else -> SurveySelectorEvent.ErrorType.Generic(this)
+    }
 }

--- a/app/src/test/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/surveyselector/SurveySelectorViewModelTest.kt
@@ -18,6 +18,8 @@ package org.groundplatform.android.ui.surveyselector
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.google.mlkit.common.MlKitException
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.CoroutineDispatcher
@@ -44,6 +46,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
@@ -152,6 +155,19 @@ class SurveySelectorViewModelTest : BaseHiltTest() {
           .isEqualTo(SurveySelectorEvent.ShowError(SurveySelectorEvent.ErrorType.Timeout))
       }
     }
+
+  @Test
+  fun `activateSurvey emits Timeout on Firestore UNAVAILABLE`() = runWithTestDispatcher {
+    createViewModel()
+    val error = FirebaseFirestoreException("offline", FirebaseFirestoreException.Code.UNAVAILABLE)
+    doAnswer { throw error }.whenever(activateSurveyUseCase).invoke("1")
+
+    viewModel.events.test {
+      viewModel.activateSurvey("1")
+      assertThat(awaitItem())
+        .isEqualTo(SurveySelectorEvent.ShowError(SurveySelectorEvent.ErrorType.Timeout))
+    }
+  }
 
   @Test
   fun `activateSurvey from deeplink works correctly`() = runWithTestDispatcher {
@@ -275,6 +291,35 @@ class SurveySelectorViewModelTest : BaseHiltTest() {
           .isEqualTo(SurveySelectorEvent.ShowError(SurveySelectorEvent.ErrorType.Generic(error)))
       }
     }
+
+  @Test
+  fun `joinSurveyByQrCode emits ScannerUnavailable when scanner module is unavailable`() =
+    runWithTestDispatcher {
+      createViewModel()
+      val error = MlKitException("scanner unavailable", MlKitException.CODE_SCANNER_UNAVAILABLE)
+      whenever(qrCodeScanner.scan()).thenReturn(GmsQrCodeScanner.Result.Error(error))
+
+      viewModel.events.test {
+        viewModel.joinSurveyByQrCode()
+        assertThat(awaitItem())
+          .isEqualTo(
+            SurveySelectorEvent.ShowError(SurveySelectorEvent.ErrorType.ScannerUnavailable)
+          )
+      }
+    }
+
+  @Test
+  fun `joinSurveyByQrCode emits Timeout on MlKit NETWORK_ISSUE`() = runWithTestDispatcher {
+    createViewModel()
+    val error = MlKitException("network issue", MlKitException.NETWORK_ISSUE)
+    whenever(qrCodeScanner.scan()).thenReturn(GmsQrCodeScanner.Result.Error(error))
+
+    viewModel.events.test {
+      viewModel.joinSurveyByQrCode()
+      assertThat(awaitItem())
+        .isEqualTo(SurveySelectorEvent.ShowError(SurveySelectorEvent.ErrorType.Timeout))
+    }
+  }
 
   @Test
   fun `surveyList failure emits Generic error event`() = runWithTestDispatcher {


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->
This PR improves error handling when there are network issues while scanning a survey QR code, or if there are problems launching the ML kit barcode scanner. Changes include:
  - new `ScannerUnavailable` error type for when the ML Kit barcode scanner module fails to install or is unavailable on the device
  - updated `toSurveySelectorError()` to distinguish network-related failures from generic ones by mapping them to the existing Timeout error type, which already prompts the user to check their connection.

@shobhitagarwal1612  PTAL?
