### PR TITLE
Remove deprecated targets from gradle files

### DIFF
--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
   jvm()
   jvmToolchain(libs.versions.jvmToolchainVersion.get().toInt())
 
-  iosX64()
   iosArm64()
   iosSimulatorArm64()
 

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -19,7 +19,6 @@ kotlin {
   jvm()
   jvmToolchain(libs.versions.jvmToolchainVersion.get().toInt())
 
-  iosX64()
   iosArm64()
   iosSimulatorArm64()
 

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
 
   val xcfName = "GroundUiKit"
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach {
+  listOf(iosArm64(), iosSimulatorArm64()).forEach {
     it.binaries.framework {
       baseName = xcfName
       isStatic = true


### PR DESCRIPTION
The latest Compose Multiplatform 1.11.0 removed iosX64 targets https://kotlinlang.org/docs/multiplatform/whats-new-compose-111.html#changes-to-ios-target-support

This PR removes that target from the gradle files of the KMP modules

@shobhitagarwal1612  PTAL?
