### PR TITLE
Add 8dp of padding at the bottom to fix bug 3673

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskScreen.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/photo/PhotoTaskScreen.kt
@@ -106,7 +106,7 @@ internal fun PhotoTaskContent(
     if (uri == Uri.EMPTY) {
       CaptureButton(onTakePhoto)
     } else {
-      UriImage(uri = uri, modifier = Modifier.fillMaxWidth().padding(top = 4.dp))
+      UriImage(uri = uri, modifier = Modifier.fillMaxWidth().padding(top = 4.dp, bottom = 8.dp))
     }
   }
 


### PR DESCRIPTION
Photos with 16:9 aspect ratio do not displayed correctly in the photo task. 


<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3673 

<!-- PR description. -->
Add 8dp of padding at the bottom to fix the overlapping of the content area and the footer 

<!-- Checklist or simple bullet list of things done in the PR. If the PR is WIP, then leave the corresponding task unchecked.

Example:
- [x] Refactor SubmissionViewModel allow modification of sort order.
- [x] Sort results when returned from SubmissionRepository.
-->
-[x] Refactor PhotoTaskScreen add 8.dp botton padding to UriImage

<!-- Add steps to verify bug/feature. -->

<!-- Attach or paste in a screenshot or GIF (optional) to illustrate the proposed change. -->
<img width="1080" height="2400" alt="Screenshot_20260520_161154" src="https://github.com/user-attachments/assets/d0e01f95-43cf-4083-a172-003eafd90687" />




@... PTAL?
