### PR TITLE
Pre-install module for GmsQrCodeScanner

### DIFF
--- a/app/src/main/java/org/groundplatform/android/system/GmsQrCodeScanner.kt
+++ b/app/src/main/java/org/groundplatform/android/system/GmsQrCodeScanner.kt
@@ -16,13 +16,17 @@
 package org.groundplatform.android.system
 
 import android.content.Context
+import com.google.android.gms.common.moduleinstall.ModuleInstall
+import com.google.android.gms.common.moduleinstall.ModuleInstallRequest
 import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanner
 import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
 
@@ -32,7 +36,23 @@ class GmsQrCodeScanner @Inject constructor(@ApplicationContext private val conte
   suspend fun scan(): Result = suspendCancellableCoroutine { coroutine ->
     val options =
       GmsBarcodeScannerOptions.Builder().setBarcodeFormats(Barcode.FORMAT_QR_CODE).build()
-    GmsBarcodeScanning.getClient(context, options)
+    val scanner = GmsBarcodeScanning.getClient(context, options)
+
+    // On some devices the code-scanner fails to start with an error code 13 (INTERNAL). Explicitly
+    // requesting the module install first is a workaround for this.
+    // https://issuetracker.google.com/issues/261579118.
+    val moduleInstallRequest = ModuleInstallRequest.newBuilder().addApi(scanner).build()
+    ModuleInstall.getClient(context)
+      .installModules(moduleInstallRequest)
+      .addOnSuccessListener { if (coroutine.isActive) startScan(scanner, coroutine) }
+      .addOnFailureListener { e ->
+        Timber.e(e, "Failed to install QR code scanner module")
+        if (coroutine.isActive) coroutine.resume(Result.Error(e))
+      }
+  }
+
+  private fun startScan(scanner: GmsBarcodeScanner, coroutine: CancellableContinuation<Result>) {
+    scanner
       .startScan()
       .addOnSuccessListener { barcode ->
         Timber.d("Scanned QR code with raw value: ${barcode.rawValue}")

--- a/app/src/test/java/org/groundplatform/android/system/GmsQrCodeScannerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/system/GmsQrCodeScannerTest.kt
@@ -71,10 +71,10 @@ class GmsQrCodeScannerTest {
     whenever(moduleInstallClient.installModules(any())).thenReturn(moduleInstallTask)
     whenever(moduleInstallTask.addOnFailureListener(any())).thenReturn(moduleInstallTask)
     doAnswer { invocation ->
-      @Suppress("UNCHECKED_CAST")
-      (invocation.arguments[0] as OnSuccessListener<ModuleInstallResponse>).onSuccess(mock())
-      moduleInstallTask
-    }
+        @Suppress("UNCHECKED_CAST")
+        (invocation.arguments[0] as OnSuccessListener<ModuleInstallResponse>).onSuccess(mock())
+        moduleInstallTask
+      }
       .whenever(moduleInstallTask)
       .addOnSuccessListener(any())
     scanner = GmsQrCodeScanner(context)
@@ -134,9 +134,9 @@ class GmsQrCodeScannerTest {
     val cause = RuntimeException()
     whenever(moduleInstallTask.addOnSuccessListener(any())).thenReturn(moduleInstallTask)
     doAnswer { invocation ->
-      (invocation.arguments[0] as OnFailureListener).onFailure(cause)
-      moduleInstallTask
-    }
+        (invocation.arguments[0] as OnFailureListener).onFailure(cause)
+        moduleInstallTask
+      }
       .whenever(moduleInstallTask)
       .addOnFailureListener(any())
 

--- a/app/src/test/java/org/groundplatform/android/system/GmsQrCodeScannerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/system/GmsQrCodeScannerTest.kt
@@ -17,6 +17,9 @@ package org.groundplatform.android.system
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.common.moduleinstall.ModuleInstall
+import com.google.android.gms.common.moduleinstall.ModuleInstallClient
+import com.google.android.gms.common.moduleinstall.ModuleInstallResponse
 import com.google.android.gms.tasks.OnCanceledListener
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
@@ -45,7 +48,10 @@ class GmsQrCodeScannerTest {
   private val context: Context = ApplicationProvider.getApplicationContext()
   private val client: GmsBarcodeScanner = mock()
   private val task: Task<Barcode> = mock<Task<Barcode>>()
+  private val moduleInstallClient: ModuleInstallClient = mock()
+  private val moduleInstallTask: Task<ModuleInstallResponse> = mock()
   private lateinit var staticScanning: MockedStatic<GmsBarcodeScanning>
+  private lateinit var staticModuleInstall: MockedStatic<ModuleInstall>
   private lateinit var scanner: GmsQrCodeScanner
 
   @Before
@@ -54,16 +60,30 @@ class GmsQrCodeScannerTest {
     staticScanning
       .`when`<GmsBarcodeScanner> { GmsBarcodeScanning.getClient(any(), any()) }
       .thenReturn(client)
+    staticModuleInstall = mockStatic(ModuleInstall::class.java)
+    staticModuleInstall
+      .`when`<ModuleInstallClient> { ModuleInstall.getClient(any<Context>()) }
+      .thenReturn(moduleInstallClient)
     whenever(client.startScan()).thenReturn(task)
     whenever(task.addOnSuccessListener(any())).thenReturn(task)
     whenever(task.addOnCanceledListener(any())).thenReturn(task)
     whenever(task.addOnFailureListener(any())).thenReturn(task)
+    whenever(moduleInstallClient.installModules(any())).thenReturn(moduleInstallTask)
+    whenever(moduleInstallTask.addOnFailureListener(any())).thenReturn(moduleInstallTask)
+    doAnswer { invocation ->
+      @Suppress("UNCHECKED_CAST")
+      (invocation.arguments[0] as OnSuccessListener<ModuleInstallResponse>).onSuccess(mock())
+      moduleInstallTask
+    }
+      .whenever(moduleInstallTask)
+      .addOnSuccessListener(any())
     scanner = GmsQrCodeScanner(context)
   }
 
   @After
   fun tearDown() {
     staticScanning.close()
+    staticModuleInstall.close()
   }
 
   @Test
@@ -102,6 +122,22 @@ class GmsQrCodeScannerTest {
         task
       }
       .whenever(task)
+      .addOnFailureListener(any())
+
+    val result = scanner.scan()
+    assertTrue(result is GmsQrCodeScanner.Result.Error)
+    assertEquals(cause, (result as GmsQrCodeScanner.Result.Error).cause)
+  }
+
+  @Test
+  fun `scan returns Error when module install fails`() = runTest {
+    val cause = RuntimeException()
+    whenever(moduleInstallTask.addOnSuccessListener(any())).thenReturn(moduleInstallTask)
+    doAnswer { invocation ->
+      (invocation.arguments[0] as OnFailureListener).onFailure(cause)
+      moduleInstallTask
+    }
+      .whenever(moduleInstallTask)
       .addOnFailureListener(any())
 
     val result = scanner.scan()


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

On some devices the QR scanner fails immediately with `MlKitException: Failed to scan code`. This is a known, recurring GMS issue https://issuetracker.google.com/issues/261579118

This PR applies the suggested fix, ensuring the barcode module is installed via `ModuleInstall`  before calling `startScan()`

@shobhitagarwal1612 PTAL?
