### PR TITLE
Use resource values for tests instead of hardcoded strings

### DIFF
--- a/app/src/test/java/org/groundplatform/android/repository/UserMediaRepositoryTest.kt
+++ b/app/src/test/java/org/groundplatform/android/repository/UserMediaRepositoryTest.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import java.io.File
 import javax.inject.Inject
 import org.groundplatform.android.BaseHiltTest
+import org.groundplatform.android.BuildConfig
 import org.groundplatform.domain.repository.UserMediaRepositoryInterface
 import org.junit.Assert.assertThrows
 import org.junit.Test
@@ -106,7 +107,7 @@ class UserMediaRepositoryTest : BaseHiltTest() {
 
     val uri = userMediaRepository.getUriForFile(mediaFile).value
 
-    assertThat(uri).startsWith("content://org.groundplatform.android/")
+    assertThat(uri).startsWith("content://${BuildConfig.APPLICATION_ID}/")
     assertThat(uri).endsWith(File(mediaFile.value).name.replace(" ", "%20"))
   }
 }

--- a/app/src/test/java/org/groundplatform/android/ui/main/MainActivityTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/main/MainActivityTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.groundplatform.android.BaseHiltTest
 import org.groundplatform.android.FakeData
 import org.groundplatform.android.R
+import org.groundplatform.android.getString
 import org.groundplatform.android.system.auth.FakeAuthenticationManager
 import org.groundplatform.domain.model.auth.SignInState
 import org.groundplatform.domain.repository.TermsOfServiceRepositoryInterface
@@ -54,7 +55,10 @@ class MainActivityTest : BaseHiltTest() {
   fun `Launch app with survey ID navigates to survey selector when user is logged in`() =
     runWithTestDispatcher {
       tosRepository.isTermsOfServiceAccepted = true
-      val uri = Uri.parse("https://ground-dev-sig.web.app/android/survey/surveyId")
+      val uri =
+        Uri.parse(
+          "https://${getString(R.string.deeplink_host)}${getString(R.string.survey_deeplink_path)}/surveyId"
+        )
       val intent = Intent(Intent.ACTION_VIEW, uri)
 
       Robolectric.buildActivity(MainActivity::class.java, intent).use { controller ->
@@ -80,7 +84,10 @@ class MainActivityTest : BaseHiltTest() {
 
   @Test
   fun `Launch app with survey ID shows login when user needs to login`() = runWithTestDispatcher {
-    val uri = Uri.parse("https://groundplatform.org/android/survey/surveyId")
+    val uri =
+      Uri.parse(
+        "https://${getString(R.string.deeplink_host)}${getString(R.string.survey_deeplink_path)}/surveyId"
+      )
     val intent = Intent(Intent.ACTION_VIEW, uri)
 
     Robolectric.buildActivity(MainActivity::class.java, intent).use { controller ->


### PR DESCRIPTION
This PR updates a couple of tests to use resource values instead of hardcoded app IDs and deep links, so they can handle different configurations and remain flexible.

@shobhitagarwal1612  PTAL?
