### PR TITLE
Update to compile SDK 37

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,7 +92,6 @@ android {
         buildConfigField "int", "FIRESTORE_EMULATOR_PORT", "8080"
         buildConfigField "int", "AUTH_EMULATOR_PORT", "9099"
         buildConfigField "String", "SIGNUP_FORM_LINK", "\"\""
-        manifestPlaceholders.usesCleartextTraffic = true
 
         def secretsFile = rootProject.file('secrets.properties')
         def secretProps = new Properties()
@@ -142,7 +141,6 @@ android {
             dimension "backend"
             versionNameSuffix "-local"
             buildConfigField "boolean", "USE_EMULATORS", "true"
-            manifestPlaceholders.usesCleartextTraffic = true
         }
         dev {
             dimension "backend"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,7 @@ static def getGitHash() {
 
 android {
     compileSdk = libs.versions.androidCompileSdk.get().toInteger()
+    compileSdkMinor = libs.versions.androidCompileSdkMinor.get().toInteger()
     sourceSets {
         main {
             proto {
@@ -96,6 +97,7 @@ android {
         def secretsFile = rootProject.file('secrets.properties')
         def secretProps = new Properties()
         if (secretsFile.exists()) secretsFile.withInputStream { secretProps.load(it) }
+        manifestPlaceholders.MAPS_API_KEY = secretProps.getProperty("MAPS_API_KEY", "DEFAULT_API_KEY")
     }
 
     // Use flag -PtestBuildType with desired variant to change default behavior.

--- a/app/src/local/res/xml/network_security_config.xml
+++ b/app/src/local/res/xml/network_security_config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2026 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  local flavor override: permits cleartext (http://) traffic only to the
+  Firebase Emulator hosts. All other cleartext remains denied via the base
+  config. 10.0.2.2 is the emulator's alias for the host loopback (see
+  EMULATOR_HOST in app/build.gradle).
+  -->
+
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">10.0.2.2</domain>
+    <domain includeSubdomains="false">localhost</domain>
+  </domain-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
     android:theme="@style/AppTheme.Base"
-    android:usesCleartextTraffic="${usesCleartextTraffic}">
+    android:networkSecurityConfig="@xml/network_security_config">
 
     <service
       android:name="org.groundplatform.android.data.remote.firebase.FirebaseMessagingService"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2026 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<network-security-config>
+  <base-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -60,7 +60,4 @@
   <issue id="UseCompatTextViewDrawableXml" severity="error" />
   <issue id="ValidActionsXml" severity="error" />
   <issue id="WrongThreadInterprocedural" severity="error" />
-  <issue id="usesCleartextTraffic">
-    <ignore path="AndroidManifest.xml" />
-  </issue>
 </lint>

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -23,7 +23,12 @@ kotlin {
   jvmToolchain(libs.versions.jvmToolchainVersion.get().toInt())
   androidLibrary {
     namespace = "org.groundplatform.core.testing"
-    compileSdk = libs.versions.androidCompileSdk.get().toInt()
+    compileSdk {
+      version =
+        release(libs.versions.androidCompileSdk.get().toInt()) {
+          minorApiLevel = libs.versions.androidCompileSdkMinor.get().toInt()
+        }
+    }
     minSdk = libs.versions.androidMinSdk.get().toInt()
   }
 

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 
 kotlin {
   jvmToolchain(libs.versions.jvmToolchainVersion.get().toInt())
-  androidLibrary {
+  android {
     namespace = "org.groundplatform.core.testing"
     compileSdk {
       version =

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -27,7 +27,12 @@ kotlin {
   jvmToolchain(libs.versions.jvmToolchainVersion.get().toInt())
   androidLibrary {
     namespace = "org.groundplatform.core.ui"
-    compileSdk = libs.versions.androidCompileSdk.get().toInt()
+    compileSdk {
+      version =
+        release(libs.versions.androidCompileSdk.get().toInt()) {
+          minorApiLevel = libs.versions.androidCompileSdkMinor.get().toInt()
+        }
+    }
     minSdk = libs.versions.androidMinSdk.get().toInt()
     androidResources.enable = true
 

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -25,7 +25,7 @@ compose.resources { publicResClass = true }
 
 kotlin {
   jvmToolchain(libs.versions.jvmToolchainVersion.get().toInt())
-  androidLibrary {
+  android {
     namespace = "org.groundplatform.core.ui"
     compileSdk {
       version =

--- a/feature/pdf/build.gradle.kts
+++ b/feature/pdf/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 kotlin {
-  androidLibrary {
+  android {
     namespace = "org.groundplatform.feature.pdf"
     compileSdk {
       version =

--- a/feature/pdf/build.gradle.kts
+++ b/feature/pdf/build.gradle.kts
@@ -22,7 +22,12 @@ plugins {
 kotlin {
   androidLibrary {
     namespace = "org.groundplatform.feature.pdf"
-    compileSdk { version = release(libs.versions.androidCompileSdk.get().toInt()) }
+    compileSdk {
+      version =
+        release(libs.versions.androidCompileSdk.get().toInt()) {
+          minorApiLevel = libs.versions.androidCompileSdkMinor.get().toInt()
+        }
+    }
     minSdk = libs.versions.androidMinSdk.get().toInt()
     withHostTest {}
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 [versions]
-androidCompileSdk = "36"
+androidCompileSdk = "37"
+androidCompileSdkMinor = "0"
 androidMinSdk = "24"
 androidTargetSdk = "36"
 androidMapsUtilsVersion = "4.4.0"
@@ -36,7 +37,7 @@ firebaseCrashlyticsGradleVersion = "3.0.7"
 fragmentVersion = "1.8.9"
 googleServicesVersion = "4.4.4"
 googleZxingVersion = "3.5.4"
-gradleVersion = "9.0.1"
+gradleVersion = "9.2.1"
 groundPlatformVersion = "bc2596d"
 gsonVersion = "2.14.0"
 hiltJetpackVersion = "1.3.0"


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #3772 

This PR updates compileSdk to 37. This update came as a result of trying to use the updated `androidx.core:core-ktx` on KMP modules, which requires the SDK 37 and AGP>=9.1.0. This leaves the target SDK still at 36, since changing that requires thorough testing as it causes behavior changes.

Changes include:
- Replacing deprecations:
    - `android:usesCleartextTraffic` with `android:networkSecurityConfig="@xml/network_security_config"`, with a specific config file for local builds to allow for cleartext traffic on the Firebase emulator, as this is the [recommended approach ](https://developer.android.com/about/versions/17/behavior-changes-all#uses-clear-traffic-deprecation)
    - `androidLibrary` with `android` in KMP modules
- added `manifestPlaceholders.MAPS_API_KEY` since the newer AGP version applies stricter manifest merging on the test Gradle tasks, which now require the placeholder to be resolvable


@shobhitagarwal1612  PTAL?
