### PR TITLE
Add jacoco plugin to android multiplatform libs

### DIFF
--- a/config/jacoco/jacoco.gradle
+++ b/config/jacoco/jacoco.gradle
@@ -26,6 +26,7 @@ tasks.withType(Test).configureEach {
 }
 
 def isAndroidModule = plugins.hasPlugin('com.android.application') || plugins.hasPlugin('com.android.library')
+def isAndroidKmpModule = plugins.hasPlugin('com.android.kotlin.multiplatform.library')
 def isKmpModule = plugins.hasPlugin('org.jetbrains.kotlin.multiplatform')
 def excludesList = [
     '**/databinding/*',
@@ -54,6 +55,11 @@ if (isAndroidModule) {
     classDirs = 'build/intermediates/classes/localDebug/transformLocalDebugClassesWithAsm/dirs/org/groundplatform/android'
     sourceDirs = ['src/main/java/org/groundplatform/android']
     execData = 'build/jacoco/testLocalDebugUnitTest.exec'
+} else if (isAndroidKmpModule) {
+    testTaskName = 'testAndroidHostTest'
+    classDirs = 'build/classes/kotlin/android/main'
+    sourceDirs = ['src/commonMain/kotlin', 'src/androidMain/kotlin']
+    execData = 'build/jacoco/testAndroidHostTest.exec'
 } else if (isKmpModule) {
     testTaskName = 'jvmTest'
     classDirs = 'build/classes/kotlin/jvm/main'

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -21,6 +21,8 @@ plugins {
   alias(libs.plugins.compose.compiler)
 }
 
+apply(from = "../../config/jacoco/jacoco.gradle")
+
 compose.resources { publicResClass = true }
 
 kotlin {

--- a/feature/pdf/build.gradle.kts
+++ b/feature/pdf/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
   alias(libs.plugins.android.lint)
 }
 
+apply(from = "../../config/jacoco/jacoco.gradle")
+
 kotlin {
   android {
     namespace = "org.groundplatform.feature.pdf"


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

Only `:app` and `:core:domain` were reporting test coverage at the moment. At the moment, the jacoco setup supported only kmp modules with a jvm target. This PR adds the code to the jacoco gradle script, so that android multiplatform libs correctly report their coverage and applies the plugin to `:core:ui` and `:feature:pdf`.

@shobhitagarwal1612 PTAL?
