### PR TITLE
Add groups for dependabot CodeQL updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,9 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
     target-branch: "master"
+    # Keep all github/codeql-action entry points in a single PR. They share one version and must
+    # be bumped together, otherwise CodeQL fails with a version mismatch.
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
The CodeQL updates need to be bumped together, otherwise the action fails with a version mismatch. Example in the PR that updates `init` separate from `analyze`: https://github.com/google/ground-android/pull/3813

This PR udpates the dependabot config to add `groups` in order to make sure all CodeQL actions will be updated simultaneously

@shobhitagarwal1612  PTAL?
