### PR TITLE
Use correct submission date for the PDF reports

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionScreenPreviews.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionScreenPreviews.kt
@@ -29,7 +29,6 @@ import org.groundplatform.android.ui.common.ExcludeFromJacocoGeneratedReport
 import org.groundplatform.domain.model.job.Job
 import org.groundplatform.domain.model.locationofinterest.LoiReport
 import org.groundplatform.ui.theme.AppTheme
-import kotlin.time.Clock
 
 private const val PAGER_CONTENT_TEXT = "Pager Content Area"
 
@@ -114,7 +113,6 @@ private fun DataCollectionContentCompletePreview() {
                   surveyName = "Test Survey",
                   userName = "John Doe",
                   userEmail = "john.doe@example.com",
-                  dateMillis = Clock.System.now().toEpochMilliseconds(),
                   submissions = emptyList(),
                 ),
             )

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/DataSubmissionConfirmationScreen.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/DataSubmissionConfirmationScreen.kt
@@ -62,7 +62,6 @@ import org.groundplatform.ui.components.loireport.LoiReportAction
 import org.groundplatform.ui.components.loireport.SubmissionPdfItem
 import org.groundplatform.ui.components.qrcode.GroundQrCode
 import org.groundplatform.ui.theme.AppTheme
-import kotlin.time.Clock
 import org.jetbrains.compose.resources.stringResource as multiplatformStringResource
 
 @Composable
@@ -174,15 +173,18 @@ private fun ShareableContent(
         )
       }
 
-      loiReport.submissionDetails?.let {
+      val details = loiReport.submissionDetails
+      val submission = details?.submissions?.firstOrNull()
+      if (details != null && submission != null) {
         SubmissionPdfItem(
           modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
-          title = it.surveyName,
+          title = details.surveyName,
           loiName = loiReport.loiName,
-          userName = it.userName,
-          date = DateFormat.getDateFormat(context).format(Date(it.dateMillis)),
-          onItemClick = { onLoiReportAction(LoiReportAction.OnPdfItemClicked) },
-          onShareClick = { onLoiReportAction(LoiReportAction.OnShareClicked) },
+          userName = details.userName,
+          date =
+            DateFormat.getDateFormat(context).format(Date(submission.lastModified.clientTimestamp)),
+          onItemClick = { onLoiReportAction(LoiReportAction.OnPdfItemClicked(submission)) },
+          onShareClick = { onLoiReportAction(LoiReportAction.OnShareClicked(submission)) },
         )
       }
     }
@@ -211,7 +213,6 @@ private val testLoiReport =
         surveyName = "Test Survey",
         userName = "John Doe",
         userEmail = "john.doe@example.com",
-        dateMillis = Clock.System.now().toEpochMilliseconds(),
         submissions = emptyList(),
       ),
   )

--- a/app/src/main/java/org/groundplatform/android/ui/home/mapcontainer/jobs/ShareLocationModal.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/home/mapcontainer/jobs/ShareLocationModal.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.window.DialogProperties
 import ground_android.core.ui.generated.resources.Res
 import ground_android.core.ui.generated.resources.scan_this_qr_to_download_geojson
 import java.util.Date
-import kotlin.time.Clock
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -100,15 +99,19 @@ fun ShareLocationModal(
           )
         }
 
-        loiReport.submissionDetails?.let {
+        val details = loiReport.submissionDetails
+        val submission = details?.submissions?.firstOrNull()
+        if (details != null && submission != null) {
           SubmissionPdfItem(
             modifier = Modifier.fillMaxWidth(),
-            title = it.surveyName,
+            title = details.surveyName,
             loiName = loiReport.loiName,
-            userName = it.userName,
-            date = DateFormat.getDateFormat(context).format(Date(it.dateMillis)),
-            onItemClick = { onLoiReportAction(LoiReportAction.OnPdfItemClicked) },
-            onShareClick = { onLoiReportAction(LoiReportAction.OnShareClicked) },
+            userName = details.userName,
+            date =
+              DateFormat.getDateFormat(context)
+                .format(Date(submission.lastModified.clientTimestamp)),
+            onItemClick = { onLoiReportAction(LoiReportAction.OnPdfItemClicked(submission)) },
+            onShareClick = { onLoiReportAction(LoiReportAction.OnShareClicked(submission)) },
           )
         }
 
@@ -148,7 +151,6 @@ private fun ShareLocationModalPreview() {
           surveyName = "Test Survey",
           userName = "John Doe",
           userEmail = "john.doe@example.com",
-          dateMillis = Clock.System.now().toEpochMilliseconds(),
           submissions = emptyList(),
         ),
     )

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/DataCollectionFragmentTest.kt
@@ -69,6 +69,7 @@ import org.groundplatform.domain.repository.MutationRepositoryInterface
 import org.groundplatform.domain.repository.SubmissionRepositoryInterface
 import org.groundplatform.domain.repository.UserRepositoryInterface
 import org.groundplatform.feature.pdf.LoiReportExporter
+import org.groundplatform.testing.FakeDataGenerator
 import org.groundplatform.ui.components.loireport.LoiReportAction
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -772,7 +773,9 @@ class DataCollectionFragmentTest : BaseHiltTest() {
     val state = fragment.viewModel.uiState.value as DataCollectionUiState.TaskSubmitted
     assertThat(state.loiReport).isNotNull()
 
-    fragment.viewModel.onLoiReportAction(LoiReportAction.OnShareClicked)
+    fragment.viewModel.onLoiReportAction(
+      LoiReportAction.OnShareClicked(FakeDataGenerator.newSubmission())
+    )
     advanceUntilIdle()
     composeTestRule.waitForIdle()
 
@@ -794,7 +797,9 @@ class DataCollectionFragmentTest : BaseHiltTest() {
       val state = fragment.viewModel.uiState.value as DataCollectionUiState.TaskSubmitted
       assertThat(state.loiReport).isNotNull()
 
-      fragment.viewModel.onLoiReportAction(LoiReportAction.OnShareClicked)
+      fragment.viewModel.onLoiReportAction(
+        LoiReportAction.OnShareClicked(FakeDataGenerator.newSubmission())
+      )
       advanceUntilIdle()
       composeTestRule.waitForIdle()
 

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/DataSubmissionConfirmationScreenTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/DataSubmissionConfirmationScreenTest.kt
@@ -154,16 +154,19 @@ class DataSubmissionConfirmationScreenTest {
     composeTestRule.onNodeWithTag(TEST_TAG_PDF_ITEM).performScrollTo()
     composeTestRule.onNodeWithText(details.surveyName).performClick()
 
-    composeTestRule.runOnIdle { assertEquals(LoiReportAction.OnPdfItemClicked, action) }
+    composeTestRule.runOnIdle {
+      assertEquals(LoiReportAction.OnPdfItemClicked(details.submissions.first()), action)
+    }
   }
 
   @Test
   fun `Clicking the share button triggers OnShareClicked`() {
     var action: LoiReportAction? = null
+    val details = FakeDataGenerator.newSubmissionDetails()
 
     composeTestRule.setContent {
       DataSubmissionConfirmationScreen(
-        loiReport = LOI_REPORT.copy(submissionDetails = FakeDataGenerator.newSubmissionDetails()),
+        loiReport = LOI_REPORT.copy(submissionDetails = details),
         onDismissed = {},
         onLoiReportAction = { action = it },
       )
@@ -171,7 +174,9 @@ class DataSubmissionConfirmationScreenTest {
 
     composeTestRule.onNodeWithText(getString(Res.string.share)).performScrollTo().performClick()
 
-    composeTestRule.runOnIdle { assertEquals(LoiReportAction.OnShareClicked, action) }
+    composeTestRule.runOnIdle {
+      assertEquals(LoiReportAction.OnShareClicked(details.submissions.first()), action)
+    }
   }
 
   @Test

--- a/app/src/test/java/org/groundplatform/android/ui/home/mapcontainer/HomeScreenMapContainerViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/home/mapcontainer/HomeScreenMapContainerViewModelTest.kt
@@ -48,6 +48,7 @@ import org.groundplatform.domain.model.map.Bounds
 import org.groundplatform.domain.model.map.CameraPosition
 import org.groundplatform.domain.repository.LocationOfInterestRepositoryInterface
 import org.groundplatform.domain.repository.UserRepositoryInterface
+import org.groundplatform.testing.FakeDataGenerator
 import org.groundplatform.ui.components.loireport.LoiReportAction
 import org.junit.Before
 import org.junit.Test
@@ -298,7 +299,7 @@ class HomeScreenMapContainerViewModelTest : BaseHiltTest() {
   @Test
   fun `onLoiReportAction emits ShowError when no LOI is selected`() = runWithTestDispatcher {
     // No LOI is selected, so there is no report to export.
-    viewModel.onLoiReportAction(LoiReportAction.OnShareClicked)
+    viewModel.onLoiReportAction(LoiReportAction.OnShareClicked(FakeDataGenerator.newSubmission()))
     advanceUntilIdle()
 
     assertThat(viewModel.uiEffects.first())

--- a/app/src/test/java/org/groundplatform/android/ui/home/mapcontainer/jobs/ShareLocationModalTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/home/mapcontainer/jobs/ShareLocationModalTest.kt
@@ -111,17 +111,20 @@ class ShareLocationModalTest {
     composeTestRule.onNodeWithTag(TEST_TAG_PDF_ITEM).performScrollTo()
     composeTestRule.onNodeWithText(details.surveyName).performClick()
 
-    composeTestRule.runOnIdle { assertEquals(LoiReportAction.OnPdfItemClicked, action) }
+    composeTestRule.runOnIdle {
+      assertEquals(LoiReportAction.OnPdfItemClicked(details.submissions.first()), action)
+    }
   }
 
   @Test
   fun `Clicking the share button triggers OnShareClicked`() {
     var action: LoiReportAction? = null
+    val details = FakeDataGenerator.newSubmissionDetails()
 
     composeTestRule.setContent {
       AppTheme {
         ShareLocationModal(
-          loiReport = LOI_REPORT.copy(submissionDetails = FakeDataGenerator.newSubmissionDetails()),
+          loiReport = LOI_REPORT.copy(submissionDetails = details),
           onDismiss = {},
           onLoiReportAction = { action = it },
         )
@@ -130,7 +133,9 @@ class ShareLocationModalTest {
 
     composeTestRule.onNodeWithText(getString(Res.string.share)).performScrollTo().performClick()
 
-    composeTestRule.runOnIdle { assertEquals(LoiReportAction.OnShareClicked, action) }
+    composeTestRule.runOnIdle {
+      assertEquals(LoiReportAction.OnShareClicked(details.submissions.first()), action)
+    }
   }
 
   @Test

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/locationofinterest/LoiReport.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/locationofinterest/LoiReport.kt
@@ -28,7 +28,6 @@ data class LoiReport(
     val surveyName: String,
     val userName: String,
     val userEmail: String,
-    val dateMillis: Long,
     val submissions: List<Submission>,
   )
 }

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
@@ -69,7 +69,6 @@ class GetLoiReportUseCase(
           surveyName = surveyName,
           userName = user.displayName,
           userEmail = user.email,
-          dateMillis = loi.lastModified.clientTimestamp,
           submissions = submissions,
         )
       } else null

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
@@ -311,20 +311,15 @@ class GetLoiReportUseCaseTest {
   }
 
   @Test
-  fun `Should populate loiName, userName and dateMillis from the inputs`() = runTest {
+  fun `Should populate loiName and userName from the inputs`() = runTest {
     userRepository.currentUser = FakeDataGenerator.newUser(displayName = "John Doe")
     submissionRepository.submissions = listOf(FakeDataGenerator.newSubmission())
-    loiRepository.offlineLoi =
-      loiRepository.offlineLoi.copy(
-        lastModified = AuditInfo(user = userRepository.currentUser, clientTimestamp = 987654321L)
-      )
 
     val loiReport =
       getLoiReportUseCase.invoke(loiName = "Test LOI", loiId = "loiId", surveyId = "surveyId")!!
 
     assertEquals("Test LOI", loiReport.loiName)
     assertEquals("John Doe", loiReport.submissionDetails!!.userName)
-    assertEquals(987654321L, loiReport.submissionDetails.dateMillis)
   }
 
   @Test

--- a/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
+++ b/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
@@ -248,14 +248,12 @@ object FakeDataGenerator {
     surveyName: String = "survey",
     userName: String = "user",
     userEmail: String = "user@email.com",
-    dateMillis: Long = 0L,
     submissions: List<Submission> = listOf(newSubmission()),
   ): LoiReport.SubmissionDetails =
     LoiReport.SubmissionDetails(
       surveyName = surveyName,
       userName = userName,
       userEmail = userEmail,
-      dateMillis = dateMillis,
       submissions = submissions,
     )
 

--- a/core/ui/src/commonMain/kotlin/org/groundplatform/ui/components/loireport/LoiReportAction.kt
+++ b/core/ui/src/commonMain/kotlin/org/groundplatform/ui/components/loireport/LoiReportAction.kt
@@ -15,8 +15,14 @@
  */
 package org.groundplatform.ui.components.loireport
 
-sealed interface LoiReportAction {
-  data object OnShareClicked : LoiReportAction
+import org.groundplatform.domain.model.submission.Submission
 
-  data object OnPdfItemClicked : LoiReportAction
+/** A user action taken on a specific [Submission] within an LOI report. */
+sealed interface LoiReportAction {
+  /** The submission the action was taken on. */
+  val submission: Submission
+
+  data class OnShareClicked(override val submission: Submission) : LoiReportAction
+
+  data class OnPdfItemClicked(override val submission: Submission) : LoiReportAction
 }

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/LoiReportExporter.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/LoiReportExporter.kt
@@ -26,13 +26,11 @@ class LoiReportExporter(
   suspend fun export(loiReport: LoiReport, action: LoiReportAction): Result<Unit> = runCatching {
     val pdfAction =
       when (action) {
-        LoiReportAction.OnShareClicked -> PdfExportService.Action.Share
-        LoiReportAction.OnPdfItemClicked -> PdfExportService.Action.Open
+        is LoiReportAction.OnShareClicked -> PdfExportService.Action.Share
+        is LoiReportAction.OnPdfItemClicked -> PdfExportService.Action.Open
       }
 
-    val submission =
-      loiReport.submissionDetails?.submissions?.firstOrNull() ?: error("No submission to export")
-    val request = mapper.map(loiReport, submission) ?: error("Failed to map LoiReport")
+    val request = mapper.map(loiReport, action.submission) ?: error("Failed to map LoiReport")
     exportService.export(request, pdfAction)
   }
 }

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapper.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapper.kt
@@ -55,8 +55,9 @@ class LoiReportMapper(
             rows = rows,
           ),
       )
+    val dateMillis = submission.lastModified.clientTimestamp
     val timestamp =
-      "${dateFormatter.formatDate(details.dateMillis)}_${dateFormatter.formatTime(details.dateMillis)}"
+      "${dateFormatter.formatDate(dateMillis)}_${dateFormatter.formatTime(dateMillis)}"
     val fileName =
       listOf(details.surveyName, loiReport.loiName, details.userName, timestamp)
         .map { it.filter(::isSafeFileChar) }
@@ -81,7 +82,8 @@ class LoiReportMapper(
       jobLabel = strings.resolve(Res.string.job),
       jobName = submission.job.name ?: submission.job.id,
       timestamp =
-        "${dateFormatter.formatDate(details.dateMillis)} ${dateFormatter.formatTime(details.dateMillis)}",
+        "${dateFormatter.formatDate(submission.lastModified.clientTimestamp)} " +
+          dateFormatter.formatTime(submission.lastModified.clientTimestamp),
     )
 
   private suspend fun buildQrBlock(): QrBlock =

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/LoiReportExporterTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/LoiReportExporterTest.kt
@@ -43,7 +43,11 @@ class LoiReportExporterTest {
     val service = FakePdfExportService()
     val exporter = LoiReportExporter(mapper, service.service)
 
-    val result = exporter.export(FakeDataGenerator.newLoiReport(), LoiReportAction.OnPdfItemClicked)
+    val result =
+      exporter.export(
+        FakeDataGenerator.newLoiReport(),
+        LoiReportAction.OnPdfItemClicked(FakeDataGenerator.newSubmission()),
+      )
 
     assertTrue(result.isSuccess)
     assertEquals(service.outputPath, service.openedPath)
@@ -55,7 +59,11 @@ class LoiReportExporterTest {
     val service = FakePdfExportService()
     val exporter = LoiReportExporter(mapper, service.service)
 
-    val result = exporter.export(FakeDataGenerator.newLoiReport(), LoiReportAction.OnShareClicked)
+    val result =
+      exporter.export(
+        FakeDataGenerator.newLoiReport(),
+        LoiReportAction.OnShareClicked(FakeDataGenerator.newSubmission()),
+      )
 
     assertTrue(result.isSuccess)
     assertEquals(service.outputPath, service.sharedPath)
@@ -63,15 +71,16 @@ class LoiReportExporterTest {
   }
 
   @Test
-  fun `returns failure without exporting when report has no submission`() = runTest {
+  fun `returns failure without exporting when report cannot be mapped`() = runTest {
     val service = FakePdfExportService()
     val exporter = LoiReportExporter(mapper, service.service)
-    val loiReport =
-      FakeDataGenerator.newLoiReport(
-        submissionDetails = FakeDataGenerator.newSubmissionDetails(submissions = emptyList())
-      )
+    val loiReport = FakeDataGenerator.newLoiReport(submissionDetails = null)
 
-    val result = exporter.export(loiReport, LoiReportAction.OnPdfItemClicked)
+    val result =
+      exporter.export(
+        loiReport,
+        LoiReportAction.OnPdfItemClicked(FakeDataGenerator.newSubmission()),
+      )
 
     assertTrue(result.isFailure)
     assertNull(service.openedPath)
@@ -82,7 +91,11 @@ class LoiReportExporterTest {
     val service = FakePdfExportService().apply { renderError = RuntimeException("boom") }
     val exporter = LoiReportExporter(mapper, service.service)
 
-    val result = exporter.export(FakeDataGenerator.newLoiReport(), LoiReportAction.OnPdfItemClicked)
+    val result =
+      exporter.export(
+        FakeDataGenerator.newLoiReport(),
+        LoiReportAction.OnPdfItemClicked(FakeDataGenerator.newSubmission()),
+      )
 
     assertTrue(result.isFailure)
   }

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapperTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapperTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
+import org.groundplatform.domain.model.locationofinterest.AuditInfo
 import org.groundplatform.feature.pdf.helpers.FakeDateFormatter
 import org.groundplatform.feature.pdf.helpers.FakeStringResolver
 import org.groundplatform.testing.FakeDataGenerator
@@ -33,6 +34,12 @@ class LoiReportMapperTest {
       dateFormatter = FakeDateFormatter,
     )
 
+  /** Submission with a fixed last-modified timestamp so date assertions are deterministic. */
+  private val submission =
+    FakeDataGenerator.newSubmission(
+      lastModified = AuditInfo(FakeDataGenerator.newUser(), clientTimestamp = 0L)
+    )
+
   private val timestampSegment = "DATE0_TIME0"
 
   @Test
@@ -45,7 +52,7 @@ class LoiReportMapperTest {
             submissionDetails =
               FakeDataGenerator.newSubmissionDetails(surveyName = "Survey", userName = "User"),
           ),
-        submission = FakeDataGenerator.newSubmission(),
+        submission = submission,
       )
 
     assertEquals("Survey_Loi_User_$timestampSegment", request!!.fileName)
@@ -64,7 +71,7 @@ class LoiReportMapperTest {
                 userName = "user@email.com",
               ),
           ),
-        submission = FakeDataGenerator.newSubmission(),
+        submission = submission,
       )
 
     assertEquals("MySurvey_loiname_useremailcom_$timestampSegment", request!!.fileName)
@@ -80,7 +87,7 @@ class LoiReportMapperTest {
             submissionDetails =
               FakeDataGenerator.newSubmissionDetails(surveyName = "", userName = "@@@"),
           ),
-        submission = FakeDataGenerator.newSubmission(),
+        submission = submission,
       )
 
     assertEquals("loi_$timestampSegment", request!!.fileName)
@@ -96,7 +103,7 @@ class LoiReportMapperTest {
             submissionDetails =
               FakeDataGenerator.newSubmissionDetails(surveyName = "แบบสำรวจ", userName = "テスト"),
           ),
-        submission = FakeDataGenerator.newSubmission(),
+        submission = submission,
       )
 
     assertEquals("แบบสำรวจ_ເພີ່ມຈຸດສຳຫຼວດ_テスト_$timestampSegment", request!!.fileName)
@@ -115,7 +122,7 @@ class LoiReportMapperTest {
                 userName = "Test?",
               ),
           ),
-        submission = FakeDataGenerator.newSubmission(),
+        submission = submission,
       )
 
     assertEquals("CaféSãoJosé_ß_Test_$timestampSegment", request!!.fileName)
@@ -131,16 +138,35 @@ class LoiReportMapperTest {
             submissionDetails =
               FakeDataGenerator.newSubmissionDetails(surveyName = "a".repeat(300), userName = "y"),
           ),
-        submission = FakeDataGenerator.newSubmission(),
+        submission = submission,
       )
 
     assertEquals(100, request!!.fileName.length)
   }
 
   @Test
+  fun `timestamp comes from the submission's own last modified date`() = runTest {
+    val request =
+      mapper.map(
+        loiReport =
+          FakeDataGenerator.newLoiReport(
+            loiName = "Loi",
+            submissionDetails =
+              FakeDataGenerator.newSubmissionDetails(surveyName = "Survey", userName = "User"),
+          ),
+        submission =
+          FakeDataGenerator.newSubmission(
+            lastModified = AuditInfo(FakeDataGenerator.newUser(), clientTimestamp = 42L)
+          ),
+      )
+
+    assertEquals("Survey_Loi_User_DATE42_TIME42", request!!.fileName)
+  }
+
+  @Test
   fun `map returns null when submissionDetails are missing`() = runTest {
     val report = FakeDataGenerator.newLoiReport(submissionDetails = null)
 
-    assertNull(mapper.map(report, FakeDataGenerator.newSubmission()))
+    assertNull(mapper.map(report, submission))
   }
 }


### PR DESCRIPTION
The PDF report was using the LOI lastModified date. This was incorrect, the date displayed should come from the specific submission lastModified date. This PR fixes that and updates the unit tests accordingly.


@shobhitagarwal1612  PTAL?
