### PR TITLE
Implement deferred deeplinks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -346,6 +346,9 @@ dependencies {
 
     // Pulls protodefs from the specified commit in the ground-platform repo.
     groundProtoJar libs.ground.platform
+
+    // Deferred deeplinks
+    implementation libs.android.install.referrer
 }
 
 protobuf {

--- a/app/src/main/java/org/groundplatform/android/common/PrefKeys.kt
+++ b/app/src/main/java/org/groundplatform/android/common/PrefKeys.kt
@@ -32,4 +32,5 @@ object PrefKeys {
   const val TOS_ACCEPTED = "tos_accepted"
   const val UPLOAD_MEDIA = "upload_media"
   const val VISIT_WEBSITE = "visit_website"
+  const val DEFERRED_DEEPLINK_CONSUMED = "deferred_deeplink_consumed"
 }

--- a/app/src/main/java/org/groundplatform/android/data/local/LocalValueStore.kt
+++ b/app/src/main/java/org/groundplatform/android/data/local/LocalValueStore.kt
@@ -123,6 +123,14 @@ constructor(private val preferences: SharedPreferences, private val locale: Loca
       preferences.edit { putBoolean(PrefKeys.UPLOAD_MEDIA, value) }
     }
 
+  var isDeferredDeeplinkConsumed: Boolean
+    get() = allowThreadDiskReads {
+      preferences.getBoolean(PrefKeys.DEFERRED_DEEPLINK_CONSUMED, false)
+    }
+    set(value) = allowThreadDiskWrites {
+      preferences.edit { putBoolean(PrefKeys.DEFERRED_DEEPLINK_CONSUMED, value) }
+    }
+
   /** Removes all values stored in the local store. */
   fun clear() = allowThreadDiskWrites { preferences.edit { clear() } }
 

--- a/app/src/main/java/org/groundplatform/android/system/deeplink/InstallReferrerManager.kt
+++ b/app/src/main/java/org/groundplatform/android/system/deeplink/InstallReferrerManager.kt
@@ -20,17 +20,19 @@ import android.net.Uri
 import com.android.installreferrer.api.InstallReferrerClient
 import com.android.installreferrer.api.InstallReferrerStateListener
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.suspendCancellableCoroutine
-import org.groundplatform.android.data.local.LocalValueStore
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.groundplatform.android.data.local.LocalValueStore
+import timber.log.Timber
 
 @Singleton
-class InstallReferrerManager @Inject constructor(
+class InstallReferrerManager
+@Inject
+constructor(
   @ApplicationContext private val context: Context,
-  private val localValueStore: LocalValueStore
+  private val localValueStore: LocalValueStore,
 ) {
   suspend fun getDeferredSurveyId(): String? {
     if (localValueStore.isDeferredDeeplinkConsumed) return null
@@ -47,30 +49,38 @@ class InstallReferrerManager @Inject constructor(
 
   private suspend fun queryInstallReferrer(): InstallReferrerResult = suspendCancellableCoroutine {
     val client = InstallReferrerClient.newBuilder(context).build()
-    try {
-      client.startConnection(object : InstallReferrerStateListener {
+    val listener =
+      object : InstallReferrerStateListener {
         override fun onInstallReferrerSetupFinished(responseCode: Int) {
-          when (responseCode) {
-            InstallReferrerClient.InstallReferrerResponse.OK -> {
-              val referrer = client.installReferrer.installReferrer
-              it.resume(InstallReferrerResult.Success(referrer))
-            }
-
-            else -> {
-              Timber.w("Install referrer service setup failed with response code: $responseCode")
-              it.resume(InstallReferrerResult.Unavailable)
-            }
-          }
+          val result = readReferrer(client, responseCode)
+          client.endConnection()
+          it.resume(result)
         }
 
         override fun onInstallReferrerServiceDisconnected() {
           it.resume(InstallReferrerResult.Unavailable)
         }
-      })
-    } catch (e: Exception) {
-      Timber.e(e, "Failed to query install referrer")
-      it.resume(InstallReferrerResult.Unavailable)
+      }
+    runCatching { client.startConnection(listener) }
+      .onFailure { throwable ->
+        Timber.e(throwable, "Failed to start install referrer connection")
+        it.resume(InstallReferrerResult.Unavailable)
+      }
+  }
+
+  private fun readReferrer(
+    client: InstallReferrerClient,
+    responseCode: Int,
+  ): InstallReferrerResult {
+    if (responseCode != InstallReferrerClient.InstallReferrerResponse.OK) {
+      Timber.w("Install referrer setup failed with response code: $responseCode")
+      return InstallReferrerResult.Unavailable
     }
+    return runCatching { InstallReferrerResult.Success(client.installReferrer.installReferrer) }
+      .getOrElse {
+        Timber.e(it, "Failed to read install referrer")
+        InstallReferrerResult.Unavailable
+      }
   }
 
   internal fun parseSurveyId(referrer: String): String? =
@@ -85,6 +95,7 @@ class InstallReferrerManager @Inject constructor(
 
   private sealed interface InstallReferrerResult {
     data class Success(val referrer: String) : InstallReferrerResult
+
     data object Unavailable : InstallReferrerResult
   }
 

--- a/app/src/main/java/org/groundplatform/android/system/deeplink/InstallReferrerManager.kt
+++ b/app/src/main/java/org/groundplatform/android/system/deeplink/InstallReferrerManager.kt
@@ -43,7 +43,9 @@ constructor(
           parseSurveyId(Uri.decode(result.referrer))
         } else null
       }
-      InstallReferrerResult.Unavailable -> null
+      InstallReferrerResult.Unavailable -> {
+        null
+      }
     }
   }
 

--- a/app/src/main/java/org/groundplatform/android/system/deeplink/InstallReferrerManager.kt
+++ b/app/src/main/java/org/groundplatform/android/system/deeplink/InstallReferrerManager.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.system.deeplink
+
+import android.content.Context
+import android.net.Uri
+import com.android.installreferrer.api.InstallReferrerClient
+import com.android.installreferrer.api.InstallReferrerStateListener
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.groundplatform.android.data.local.LocalValueStore
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+@Singleton
+class InstallReferrerManager @Inject constructor(
+  @ApplicationContext private val context: Context,
+  private val localValueStore: LocalValueStore
+) {
+  suspend fun getDeferredSurveyId(): String? {
+    if (localValueStore.isDeferredDeeplinkConsumed) return null
+    return when (val result = queryInstallReferrer()) {
+      is InstallReferrerResult.Success -> {
+        if (!result.referrer.isEmpty()) {
+          localValueStore.isDeferredDeeplinkConsumed = true
+          parseSurveyId(Uri.decode(result.referrer))
+        } else null
+      }
+      InstallReferrerResult.Unavailable -> null
+    }
+  }
+
+  private suspend fun queryInstallReferrer(): InstallReferrerResult = suspendCancellableCoroutine {
+    val client = InstallReferrerClient.newBuilder(context).build()
+    try {
+      client.startConnection(object : InstallReferrerStateListener {
+        override fun onInstallReferrerSetupFinished(responseCode: Int) {
+          when (responseCode) {
+            InstallReferrerClient.InstallReferrerResponse.OK -> {
+              val referrer = client.installReferrer.installReferrer
+              it.resume(InstallReferrerResult.Success(referrer))
+            }
+
+            else -> {
+              Timber.w("Install referrer service setup failed with response code: $responseCode")
+              it.resume(InstallReferrerResult.Unavailable)
+            }
+          }
+        }
+
+        override fun onInstallReferrerServiceDisconnected() {
+          it.resume(InstallReferrerResult.Unavailable)
+        }
+      })
+    } catch (e: Exception) {
+      Timber.e(e, "Failed to query install referrer")
+      it.resume(InstallReferrerResult.Unavailable)
+    }
+  }
+
+  internal fun parseSurveyId(referrer: String): String? =
+    referrer.split('&').firstNotNullOfOrNull { part ->
+      val idx = part.indexOf('=')
+      if (idx > 0 && part.substring(0, idx) == DEFERRED_SURVEY_ID_KEY) {
+        part.substring(idx + 1).takeIf { it.isNotBlank() }
+      } else {
+        null
+      }
+    }
+
+  private sealed interface InstallReferrerResult {
+    data class Success(val referrer: String) : InstallReferrerResult
+    data object Unavailable : InstallReferrerResult
+  }
+
+  companion object {
+    private const val DEFERRED_SURVEY_ID_KEY = "survey_id"
+  }
+}

--- a/app/src/main/java/org/groundplatform/android/system/deeplink/PlayInstallReferrerService.kt
+++ b/app/src/main/java/org/groundplatform/android/system/deeplink/PlayInstallReferrerService.kt
@@ -41,11 +41,22 @@ constructor(
     if (result == null) {
       Timber.w("Timed out reading install referrer")
     }
-    return if (result is InstallReferrerResult.Success && result.referrer.isNotEmpty()) {
-      localValueStore.isDeferredDeeplinkConsumed = true
-      parseSurveyId(result.referrer)
-    } else {
-      null
+    return when (result) {
+      is InstallReferrerResult.Success -> {
+        localValueStore.isDeferredDeeplinkConsumed = true
+        parseSurveyId(result.referrer)
+      }
+      // Play can't serve install referrers on this device, so retrying will never help
+      InstallReferrerResult.Unsupported -> {
+        localValueStore.isDeferredDeeplinkConsumed = true
+        null
+      }
+      // Transient failure. Leave the referrer eligible so the next launch can retry it, since it
+      // stays retrievable from Play for a while after install.
+      InstallReferrerResult.Unavailable,
+      null -> {
+        null
+      }
     }
   }
 
@@ -80,7 +91,13 @@ constructor(
   ): InstallReferrerResult {
     if (responseCode != InstallReferrerClient.InstallReferrerResponse.OK) {
       Timber.w("Install referrer setup failed with response code: $responseCode")
-      return InstallReferrerResult.Unavailable
+      return if (
+        responseCode == InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED
+      ) {
+        InstallReferrerResult.Unsupported
+      } else {
+        InstallReferrerResult.Unavailable
+      }
     }
     return runCatching { InstallReferrerResult.Success(client.installReferrer.installReferrer) }
       .getOrElse {
@@ -107,10 +124,12 @@ constructor(
     data class Success(val referrer: String) : InstallReferrerResult
 
     data object Unavailable : InstallReferrerResult
+
+    data object Unsupported : InstallReferrerResult
   }
 
   companion object {
     private const val DEFERRED_SURVEY_ID_KEY = "survey_id"
-    private const val QUERY_TIMEOUT_MILLIS = 5000L
+    private const val QUERY_TIMEOUT_MILLIS = 3000L
   }
 }

--- a/app/src/main/java/org/groundplatform/android/system/deeplink/PlayInstallReferrerService.kt
+++ b/app/src/main/java/org/groundplatform/android/system/deeplink/PlayInstallReferrerService.kt
@@ -22,13 +22,14 @@ import com.android.installreferrer.api.InstallReferrerStateListener
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.resume
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
 import org.groundplatform.android.data.local.LocalValueStore
 import timber.log.Timber
 
 @Singleton
-class InstallReferrerManager
+class PlayInstallReferrerService
 @Inject
 constructor(
   @ApplicationContext private val context: Context,
@@ -36,38 +37,41 @@ constructor(
 ) {
   suspend fun getDeferredSurveyId(): String? {
     if (localValueStore.isDeferredDeeplinkConsumed) return null
-    return when (val result = queryInstallReferrer()) {
-      is InstallReferrerResult.Success -> {
-        if (!result.referrer.isEmpty()) {
-          localValueStore.isDeferredDeeplinkConsumed = true
-          parseSurveyId(Uri.decode(result.referrer))
-        } else null
-      }
-      InstallReferrerResult.Unavailable -> {
-        null
-      }
+    val result = withTimeoutOrNull(QUERY_TIMEOUT_MILLIS.milliseconds) { queryInstallReferrer() }
+    if (result == null) {
+      Timber.w("Timed out reading install referrer")
+    }
+    return if (result is InstallReferrerResult.Success && result.referrer.isNotEmpty()) {
+      localValueStore.isDeferredDeeplinkConsumed = true
+      parseSurveyId(result.referrer)
+    } else {
+      null
     }
   }
 
-  private suspend fun queryInstallReferrer(): InstallReferrerResult = suspendCancellableCoroutine {
+  private suspend fun queryInstallReferrer(): InstallReferrerResult {
     val client = InstallReferrerClient.newBuilder(context).build()
-    val listener =
-      object : InstallReferrerStateListener {
-        override fun onInstallReferrerSetupFinished(responseCode: Int) {
-          val result = readReferrer(client, responseCode)
-          client.endConnection()
-          it.resume(result)
-        }
+    val result = CompletableDeferred<InstallReferrerResult>()
+    return try {
+      val listener =
+        object : InstallReferrerStateListener {
+          override fun onInstallReferrerSetupFinished(responseCode: Int) {
+            result.complete(readReferrer(client, responseCode))
+          }
 
-        override fun onInstallReferrerServiceDisconnected() {
-          it.resume(InstallReferrerResult.Unavailable)
+          override fun onInstallReferrerServiceDisconnected() {
+            result.complete(InstallReferrerResult.Unavailable)
+          }
         }
-      }
-    runCatching { client.startConnection(listener) }
-      .onFailure { throwable ->
-        Timber.e(throwable, "Failed to start install referrer connection")
-        it.resume(InstallReferrerResult.Unavailable)
-      }
+      runCatching { client.startConnection(listener) }
+        .onFailure { throwable ->
+          Timber.e(throwable, "Failed to start install referrer connection")
+          result.complete(InstallReferrerResult.Unavailable)
+        }
+      result.await()
+    } finally {
+      finish(client)
+    }
   }
 
   private fun readReferrer(
@@ -86,14 +90,18 @@ constructor(
   }
 
   internal fun parseSurveyId(referrer: String): String? =
-    referrer.split('&').firstNotNullOfOrNull { part ->
-      val idx = part.indexOf('=')
-      if (idx > 0 && part.substring(0, idx) == DEFERRED_SURVEY_ID_KEY) {
-        part.substring(idx + 1).takeIf { it.isNotBlank() }
+    referrer.split('&').firstNotNullOfOrNull { param ->
+      if (param.substringBefore('=', "") == DEFERRED_SURVEY_ID_KEY) {
+        Uri.decode(param.substringAfter('=')).takeIf { it.isNotBlank() }
       } else {
         null
       }
     }
+
+  private fun finish(client: InstallReferrerClient) {
+    runCatching { client.endConnection() }
+      .onFailure { Timber.e(it, "Failed to close install referrer connection") }
+  }
 
   private sealed interface InstallReferrerResult {
     data class Success(val referrer: String) : InstallReferrerResult
@@ -103,5 +111,6 @@ constructor(
 
   companion object {
     private const val DEFERRED_SURVEY_ID_KEY = "survey_id"
+    private const val QUERY_TIMEOUT_MILLIS = 5000L
   }
 }

--- a/app/src/main/java/org/groundplatform/android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/main/MainViewModel.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.withContext
 import org.groundplatform.android.BuildConfig
 import org.groundplatform.android.di.coroutines.IoDispatcher
 import org.groundplatform.android.system.auth.AuthenticationManager
+import org.groundplatform.android.system.deeplink.InstallReferrerManager
 import org.groundplatform.android.ui.common.AbstractViewModel
 import org.groundplatform.android.ui.common.SharedViewModel
 import org.groundplatform.android.usecases.session.ClearUserSessionUseCase
@@ -53,6 +54,7 @@ constructor(
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
   private val remoteConfig: FirebaseRemoteConfig,
   authenticationManager: AuthenticationManager,
+  private val installReferrerManager: InstallReferrerManager,
 ) : AbstractViewModel() {
 
   private val _navigationRequests: MutableSharedFlow<MainUiState?> = MutableSharedFlow()
@@ -102,11 +104,13 @@ constructor(
         } else {
           MainUiState.NoActiveSurvey
         }
-      } else if (!reactivateLastSurvey()) {
-        MainUiState.NoActiveSurvey
       } else {
-        // Everything is fine, show the home screen
-        MainUiState.ShowHomeScreen
+        val deferredSurveyId = installReferrerManager.getDeferredSurveyId()
+        when {
+          deferredSurveyId != null -> MainUiState.ActiveSurveyById(deferredSurveyId)
+          reactivateLastSurvey() -> MainUiState.ShowHomeScreen
+          else -> MainUiState.NoActiveSurvey
+        }
       }
     } catch (e: Throwable) {
       Timber.e(e)

--- a/app/src/main/java/org/groundplatform/android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/main/MainViewModel.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.withContext
 import org.groundplatform.android.BuildConfig
 import org.groundplatform.android.di.coroutines.IoDispatcher
 import org.groundplatform.android.system.auth.AuthenticationManager
-import org.groundplatform.android.system.deeplink.InstallReferrerManager
+import org.groundplatform.android.system.deeplink.PlayInstallReferrerService
 import org.groundplatform.android.ui.common.AbstractViewModel
 import org.groundplatform.android.ui.common.SharedViewModel
 import org.groundplatform.android.usecases.session.ClearUserSessionUseCase
@@ -54,7 +54,7 @@ constructor(
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
   private val remoteConfig: FirebaseRemoteConfig,
   authenticationManager: AuthenticationManager,
-  private val installReferrerManager: InstallReferrerManager,
+  private val playInstallReferrerService: PlayInstallReferrerService,
 ) : AbstractViewModel() {
 
   private val _navigationRequests: MutableSharedFlow<MainUiState?> = MutableSharedFlow()
@@ -105,7 +105,7 @@ constructor(
           MainUiState.NoActiveSurvey
         }
       } else {
-        val deferredSurveyId = installReferrerManager.getDeferredSurveyId()
+        val deferredSurveyId = playInstallReferrerService.getDeferredSurveyId()
         when {
           deferredSurveyId != null -> MainUiState.ActiveSurveyById(deferredSurveyId)
           reactivateLastSurvey() -> MainUiState.ShowHomeScreen

--- a/app/src/main/java/org/groundplatform/android/ui/tos/TermsOfServiceFragment.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/tos/TermsOfServiceFragment.kt
@@ -52,8 +52,9 @@ class TermsOfServiceFragment : AbstractFragment() {
   ): View = createComposeView {
     TermsOfServiceScreen(
       onNavigateUp = { findNavController().navigateUp() },
-      onNavigateToSurveySelector = {
-        openSurveySelector(activity?.intent?.data?.let { surveyDeepLinkParser.parse(it) })
+      onNavigateToSurveySelector = { deferredSurveyId ->
+        val explicitSurveyId = activity?.intent?.data?.let { surveyDeepLinkParser.parse(it) }
+        openSurveySelector(explicitSurveyId ?: deferredSurveyId)
       },
       onLoadError = { popups.ErrorPopup().show(R.string.load_tos_failed) },
       termsContent = { html -> TermsTextView(fromHtml(html, 0)) },

--- a/app/src/main/java/org/groundplatform/android/ui/tos/TermsOfServiceScreen.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/tos/TermsOfServiceScreen.kt
@@ -54,7 +54,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun TermsOfServiceScreen(
   onNavigateUp: () -> Unit,
-  onNavigateToSurveySelector: () -> Unit,
+  onNavigateToSurveySelector: (String?) -> Unit,
   onLoadError: () -> Unit,
   termsContent: @Composable (String) -> Unit,
   viewModel: TermsOfServiceViewModel = hiltViewModel(),
@@ -64,7 +64,7 @@ fun TermsOfServiceScreen(
   LaunchedEffect(Unit) {
     viewModel.events.collect { event ->
       when (event) {
-        is TosEvent.NavigateToSurveySelector -> onNavigateToSurveySelector()
+        is TosEvent.NavigateToSurveySelector -> onNavigateToSurveySelector(event.deferredSurveyId)
         is TosEvent.LoadError -> onLoadError()
       }
     }

--- a/app/src/main/java/org/groundplatform/android/ui/tos/TermsOfServiceViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/tos/TermsOfServiceViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.groundplatform.android.system.auth.AuthenticationManager
+import org.groundplatform.android.system.deeplink.InstallReferrerManager
 import org.groundplatform.android.ui.common.AbstractViewModel
 import org.groundplatform.android.util.isPermissionDeniedException
 import org.groundplatform.domain.repository.TermsOfServiceRepositoryInterface
@@ -51,7 +52,7 @@ sealed interface TosUiState {
 }
 
 sealed interface TosEvent {
-  object NavigateToSurveySelector : TosEvent
+  data class NavigateToSurveySelector(val deferredSurveyId: String?) : TosEvent
 
   object LoadError : TosEvent
 }
@@ -62,6 +63,7 @@ class TermsOfServiceViewModel
 constructor(
   private val authManager: AuthenticationManager,
   private val termsOfServiceRepository: TermsOfServiceRepositoryInterface,
+  private val installReferrerManager: InstallReferrerManager,
   savedStateHandle: SavedStateHandle,
 ) : AbstractViewModel() {
 
@@ -90,7 +92,8 @@ constructor(
   fun onAgreeButtonClicked() {
     viewModelScope.launch {
       termsOfServiceRepository.isTermsOfServiceAccepted = true
-      _events.send(TosEvent.NavigateToSurveySelector)
+      val deferredSurveyId = installReferrerManager.getDeferredSurveyId()
+      _events.send(TosEvent.NavigateToSurveySelector(deferredSurveyId))
     }
   }
 

--- a/app/src/main/java/org/groundplatform/android/ui/tos/TermsOfServiceViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/tos/TermsOfServiceViewModel.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.groundplatform.android.system.auth.AuthenticationManager
-import org.groundplatform.android.system.deeplink.InstallReferrerManager
+import org.groundplatform.android.system.deeplink.PlayInstallReferrerService
 import org.groundplatform.android.ui.common.AbstractViewModel
 import org.groundplatform.android.util.isPermissionDeniedException
 import org.groundplatform.domain.repository.TermsOfServiceRepositoryInterface
@@ -63,7 +63,7 @@ class TermsOfServiceViewModel
 constructor(
   private val authManager: AuthenticationManager,
   private val termsOfServiceRepository: TermsOfServiceRepositoryInterface,
-  private val installReferrerManager: InstallReferrerManager,
+  private val playInstallReferrerService: PlayInstallReferrerService,
   savedStateHandle: SavedStateHandle,
 ) : AbstractViewModel() {
 
@@ -92,7 +92,7 @@ constructor(
   fun onAgreeButtonClicked() {
     viewModelScope.launch {
       termsOfServiceRepository.isTermsOfServiceAccepted = true
-      val deferredSurveyId = installReferrerManager.getDeferredSurveyId()
+      val deferredSurveyId = playInstallReferrerService.getDeferredSurveyId()
       _events.send(TosEvent.NavigateToSurveySelector(deferredSurveyId))
     }
   }

--- a/app/src/main/java/org/groundplatform/android/usecases/session/ClearUserSessionUseCase.kt
+++ b/app/src/main/java/org/groundplatform/android/usecases/session/ClearUserSessionUseCase.kt
@@ -16,6 +16,7 @@
 package org.groundplatform.android.usecases.session
 
 import javax.inject.Inject
+import org.groundplatform.android.data.local.LocalValueStore
 import org.groundplatform.android.data.local.room.LocalDatabase
 import org.groundplatform.domain.repository.OfflineAreaRepositoryInterface
 import org.groundplatform.domain.repository.SurveyRepositoryInterface
@@ -33,6 +34,7 @@ class ClearUserSessionUseCase
 @Inject
 constructor(
   private val localDatabase: LocalDatabase,
+  private val localValueStore: LocalValueStore,
   private val offlineAreaRepository: OfflineAreaRepositoryInterface,
   private val surveyRepository: SurveyRepositoryInterface,
   private val userRepository: UserRepositoryInterface,
@@ -41,7 +43,13 @@ constructor(
   suspend operator fun invoke() {
     offlineAreaRepository.removeAllOfflineAreas()
     surveyRepository.clearActiveSurvey()
+    val deferredDeeplinkConsumed = localValueStore.isDeferredDeeplinkConsumed
     userRepository.clearUserPreferences()
+    if (deferredDeeplinkConsumed) {
+      // A deferred deep link is spent once per install, so signing out must not make an already
+      // consumed one eligible to be consumed again.
+      localValueStore.isDeferredDeeplinkConsumed = true
+    }
 
     // TODO: Once multi-user login is supported, avoid clearing local db data. This is
     //  currently being done to prevent one user's data to be submitted as another user after

--- a/app/src/test/java/org/groundplatform/android/data/local/LocalValueStoreTest.kt
+++ b/app/src/test/java/org/groundplatform/android/data/local/LocalValueStoreTest.kt
@@ -137,6 +137,29 @@ class LocalValueStoreTest {
     assertThat(localValueStore.getLastCameraPosition("survey-b")).isEqualTo(b)
   }
 
+  @Test
+  fun `isDeferredDeeplinkConsumed defaults to false`() {
+    assertThat(localValueStore.isDeferredDeeplinkConsumed).isFalse()
+  }
+
+  @Test
+  fun `isDeferredDeeplinkConsumed sets the shared preferences value accordingly`() {
+    localValueStore.isDeferredDeeplinkConsumed = true
+    assertThat(sharedPreferences.getBoolean(PrefKeys.DEFERRED_DEEPLINK_CONSUMED, false)).isTrue()
+
+    localValueStore.isDeferredDeeplinkConsumed = false
+    assertThat(sharedPreferences.getBoolean(PrefKeys.DEFERRED_DEEPLINK_CONSUMED, false)).isFalse()
+  }
+
+  @Test
+  fun `clear resets isDeferredDeeplinkConsumed`() {
+    localValueStore.isDeferredDeeplinkConsumed = true
+
+    localValueStore.clear()
+
+    assertThat(localValueStore.isDeferredDeeplinkConsumed).isFalse()
+  }
+
   companion object {
     private const val SURVEY_ID = "survey-1"
     private val BOUNDS = Bounds(-10.0, -20.0, 10.0, 20.0)

--- a/app/src/test/java/org/groundplatform/android/system/deeplink/PlayInstallReferrerServiceTest.kt
+++ b/app/src/test/java/org/groundplatform/android/system/deeplink/PlayInstallReferrerServiceTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.system.deeplink
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.groundplatform.android.data.local.LocalValueStore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PlayInstallReferrerServiceTest {
+
+  private val localValueStore: LocalValueStore = mock()
+  private val manager =
+    PlayInstallReferrerService(ApplicationProvider.getApplicationContext(), localValueStore)
+
+  @Test
+  fun `parseSurveyId returns id when referrer holds only the survey id`() {
+    assertThat(manager.parseSurveyId("survey_id=$SURVEY_ID")).isEqualTo(SURVEY_ID)
+  }
+
+  @Test
+  fun `parseSurveyId returns id when referrer holds other params`() {
+    assertThat(manager.parseSurveyId("source=ground&survey_id=$SURVEY_ID&medium=email"))
+      .isEqualTo(SURVEY_ID)
+  }
+
+  @Test
+  fun `parseSurveyId returns null for an organic referrer`() {
+    assertThat(manager.parseSurveyId("source=google-play&medium=organic")).isNull()
+  }
+
+  @Test
+  fun `parseSurveyId returns null for an empty referrer`() {
+    assertThat(manager.parseSurveyId("")).isNull()
+  }
+
+  @Test
+  fun `parseSurveyId returns null when the value is missing`() {
+    assertThat(manager.parseSurveyId("survey_id=")).isNull()
+  }
+
+  @Test
+  fun `parseSurveyId returns null when the value is blank`() {
+    assertThat(manager.parseSurveyId("survey_id=%20")).isNull()
+  }
+
+  @Test
+  fun `parseSurveyId ignores keys that merely end with the survey id key`() {
+    assertThat(manager.parseSurveyId("other_survey_id=$SURVEY_ID")).isNull()
+  }
+
+  @Test
+  fun `parseSurveyId returns null when a param has no value delimiter`() {
+    assertThat(manager.parseSurveyId("survey_id")).isNull()
+  }
+
+  @Test
+  fun `parseSurveyId ignores params with an empty key`() {
+    assertThat(manager.parseSurveyId("=ignored&survey_id=$SURVEY_ID")).isEqualTo(SURVEY_ID)
+  }
+
+  @Test
+  fun `getDeferredSurveyId returns null once the referrer has been consumed`() = runTest {
+    whenever(localValueStore.isDeferredDeeplinkConsumed).thenReturn(true)
+
+    assertThat(manager.getDeferredSurveyId()).isNull()
+  }
+
+  @Test
+  fun `getDeferredSurveyId returns null when the referrer cannot be read`() = runTest {
+    whenever(localValueStore.isDeferredDeeplinkConsumed).thenReturn(false)
+
+    assertThat(manager.getDeferredSurveyId()).isNull()
+  }
+
+  companion object {
+    private const val SURVEY_ID = "survey_123"
+  }
+}

--- a/app/src/test/java/org/groundplatform/android/system/deeplink/PlayInstallReferrerServiceTest.kt
+++ b/app/src/test/java/org/groundplatform/android/system/deeplink/PlayInstallReferrerServiceTest.kt
@@ -15,13 +15,29 @@
  */
 package org.groundplatform.android.system.deeplink
 
+import android.content.Context
+import android.os.RemoteException
 import androidx.test.core.app.ApplicationProvider
+import com.android.installreferrer.api.InstallReferrerClient
+import com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse
+import com.android.installreferrer.api.InstallReferrerStateListener
+import com.android.installreferrer.api.ReferrerDetails
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.groundplatform.android.data.local.LocalValueStore
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.never
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
@@ -29,67 +45,204 @@ import org.robolectric.RobolectricTestRunner
 class PlayInstallReferrerServiceTest {
 
   private val localValueStore: LocalValueStore = mock()
-  private val manager =
-    PlayInstallReferrerService(ApplicationProvider.getApplicationContext(), localValueStore)
+  private val client: InstallReferrerClient = mock()
+  private val builder: InstallReferrerClient.Builder = mock()
+  private lateinit var staticClient: MockedStatic<InstallReferrerClient>
+  private lateinit var service: PlayInstallReferrerService
 
-  @Test
-  fun `parseSurveyId returns id when referrer holds only the survey id`() {
-    assertThat(manager.parseSurveyId("survey_id=$SURVEY_ID")).isEqualTo(SURVEY_ID)
+  @Before
+  fun setUp() {
+    staticClient = mockStatic(InstallReferrerClient::class.java)
+    staticClient
+      .`when`<InstallReferrerClient.Builder> { InstallReferrerClient.newBuilder(any<Context>()) }
+      .thenReturn(builder)
+    whenever(builder.build()).thenReturn(client)
+    whenever(localValueStore.isDeferredDeeplinkConsumed).thenReturn(false)
+    service =
+      PlayInstallReferrerService(ApplicationProvider.getApplicationContext(), localValueStore)
+  }
+
+  @After
+  fun tearDown() {
+    staticClient.close()
   }
 
   @Test
-  fun `parseSurveyId returns id when referrer holds other params`() {
-    assertThat(manager.parseSurveyId("source=ground&survey_id=$SURVEY_ID&medium=email"))
+  fun `parseSurveyId returns survey id when referrer holds only the survey id`() {
+    assertThat(service.parseSurveyId("survey_id=$SURVEY_ID")).isEqualTo(SURVEY_ID)
+  }
+
+  @Test
+  fun `parseSurveyId returns survey id even when referrer holds other params`() {
+    assertThat(service.parseSurveyId("source=ground&survey_id=$SURVEY_ID&medium=email"))
       .isEqualTo(SURVEY_ID)
   }
 
   @Test
-  fun `parseSurveyId returns null for an organic referrer`() {
-    assertThat(manager.parseSurveyId("source=google-play&medium=organic")).isNull()
+  fun `parseSurveyId decodes percent encoded values`() {
+    assertThat(service.parseSurveyId("survey_id=survey%20123")).isEqualTo("survey 123")
   }
 
   @Test
   fun `parseSurveyId returns null for an empty referrer`() {
-    assertThat(manager.parseSurveyId("")).isNull()
+    assertThat(service.parseSurveyId("")).isNull()
   }
 
   @Test
   fun `parseSurveyId returns null when the value is missing`() {
-    assertThat(manager.parseSurveyId("survey_id=")).isNull()
+    assertThat(service.parseSurveyId("survey_id=")).isNull()
   }
 
   @Test
   fun `parseSurveyId returns null when the value is blank`() {
-    assertThat(manager.parseSurveyId("survey_id=%20")).isNull()
+    assertThat(service.parseSurveyId("survey_id=%20")).isNull()
   }
 
   @Test
-  fun `parseSurveyId ignores keys that merely end with the survey id key`() {
-    assertThat(manager.parseSurveyId("other_survey_id=$SURVEY_ID")).isNull()
+  fun `parseSurveyId ignores keys that merely end with the survey_id key`() {
+    assertThat(service.parseSurveyId("other_survey_id=$SURVEY_ID")).isNull()
   }
 
   @Test
   fun `parseSurveyId returns null when a param has no value delimiter`() {
-    assertThat(manager.parseSurveyId("survey_id")).isNull()
+    assertThat(service.parseSurveyId("survey_id")).isNull()
   }
 
   @Test
-  fun `parseSurveyId ignores params with an empty key`() {
-    assertThat(manager.parseSurveyId("=ignored&survey_id=$SURVEY_ID")).isEqualTo(SURVEY_ID)
+  fun `parseSurveyId ignores other params except for survey_id`() {
+    assertThat(service.parseSurveyId("=ignored&survey_id=$SURVEY_ID")).isEqualTo(SURVEY_ID)
+  }
+
+  @Test
+  fun `getDeferredSurveyId returns the survey id and marks the referrer consumed`() = runTest {
+    setUpReferrer("survey_id=$SURVEY_ID")
+
+    assertThat(service.getDeferredSurveyId()).isEqualTo(SURVEY_ID)
+
+    verify(localValueStore).isDeferredDeeplinkConsumed = true
+  }
+
+  @Test
+  fun `getDeferredSurveyId marks the referrer consumed even when it holds no survey id`() =
+    runTest {
+      setUpReferrer("utm_source=google-play&utm_medium=organic")
+
+      assertThat(service.getDeferredSurveyId()).isNull()
+
+      verify(localValueStore).isDeferredDeeplinkConsumed = true
+    }
+
+  @Test
+  fun `getDeferredSurveyId marks the referrer consumed when it is empty`() = runTest {
+    setUpReferrer("")
+
+    assertThat(service.getDeferredSurveyId()).isNull()
+
+    verify(localValueStore).isDeferredDeeplinkConsumed = true
+  }
+
+  @Test
+  fun `getDeferredSurveyId marks the referrer consumed when the feature isn't supported`() =
+    runTest {
+      setUpSetupFinished(InstallReferrerResponse.FEATURE_NOT_SUPPORTED)
+
+      assertThat(service.getDeferredSurveyId()).isNull()
+
+      verify(localValueStore).isDeferredDeeplinkConsumed = true
+    }
+
+  @Test
+  fun `getDeferredSurveyId keeps the referrer eligible when the service is unavailable`() =
+    runTest {
+      setUpSetupFinished(InstallReferrerResponse.SERVICE_UNAVAILABLE)
+
+      assertThat(service.getDeferredSurveyId()).isNull()
+
+      verify(localValueStore, never()).isDeferredDeeplinkConsumed = true
+    }
+
+  @Test
+  fun `getDeferredSurveyId keeps the referrer eligible when setup reports a developer error`() =
+    runTest {
+      setUpSetupFinished(InstallReferrerResponse.DEVELOPER_ERROR)
+
+      assertThat(service.getDeferredSurveyId()).isNull()
+
+      verify(localValueStore, never()).isDeferredDeeplinkConsumed = true
+    }
+
+  @Test
+  fun `getDeferredSurveyId returns null when reading the referrer throws`() = runTest {
+    setUpSetupFinished(InstallReferrerResponse.OK)
+    whenever(client.installReferrer).thenThrow(RemoteException())
+
+    assertThat(service.getDeferredSurveyId()).isNull()
+
+    verify(localValueStore, never()).isDeferredDeeplinkConsumed = true
+  }
+
+  @Test
+  fun `getDeferredSurveyId returns null when starting the connection throws`() = runTest {
+    doThrow(SecurityException("no play store")).whenever(client).startConnection(any())
+
+    assertThat(service.getDeferredSurveyId()).isNull()
+
+    verify(localValueStore, never()).isDeferredDeeplinkConsumed = true
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun `getDeferredSurveyId gives up on the query after three seconds`() = runTest {
+    doAnswer {}.whenever(client).startConnection(any())
+    val start = testScheduler.currentTime
+
+    service.getDeferredSurveyId()
+
+    assertThat(testScheduler.currentTime - start).isEqualTo(3000L)
+  }
+
+  @Test
+  fun `getDeferredSurveyId closes the connection after a successful read`() = runTest {
+    setUpReferrer("survey_id=$SURVEY_ID")
+
+    service.getDeferredSurveyId()
+
+    verify(client).endConnection()
+  }
+
+  @Test
+  fun `getDeferredSurveyId closes the connection after a timeout`() = runTest {
+    doAnswer {}.whenever(client).startConnection(any())
+
+    service.getDeferredSurveyId()
+
+    verify(client).endConnection()
   }
 
   @Test
   fun `getDeferredSurveyId returns null once the referrer has been consumed`() = runTest {
     whenever(localValueStore.isDeferredDeeplinkConsumed).thenReturn(true)
 
-    assertThat(manager.getDeferredSurveyId()).isNull()
+    assertThat(service.getDeferredSurveyId()).isNull()
+    verify(client, never()).startConnection(any())
+    staticClient.verify({ InstallReferrerClient.newBuilder(any<Context>()) }, never())
   }
 
-  @Test
-  fun `getDeferredSurveyId returns null when the referrer cannot be read`() = runTest {
-    whenever(localValueStore.isDeferredDeeplinkConsumed).thenReturn(false)
+  private fun setUpSetupFinished(responseCode: Int) {
+    doAnswer { invocation ->
+        invocation
+          .getArgument<InstallReferrerStateListener>(0)
+          .onInstallReferrerSetupFinished(responseCode)
+      }
+      .whenever(client)
+      .startConnection(any())
+  }
 
-    assertThat(manager.getDeferredSurveyId()).isNull()
+  private fun setUpReferrer(referrer: String) {
+    setUpSetupFinished(InstallReferrerResponse.OK)
+    val details: ReferrerDetails = mock()
+    whenever(details.installReferrer).thenReturn(referrer)
+    whenever(client.installReferrer).thenReturn(details)
   }
 
   companion object {

--- a/app/src/test/java/org/groundplatform/android/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/main/MainViewModelTest.kt
@@ -20,6 +20,7 @@ import androidx.core.content.edit
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.firestore.FirebaseFirestoreException
+import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
 import kotlin.test.assertFailsWith
@@ -30,18 +31,23 @@ import org.groundplatform.android.FakeData
 import org.groundplatform.android.data.local.room.LocalDataStoreException
 import org.groundplatform.android.data.remote.FakeRemoteDataStore
 import org.groundplatform.android.system.auth.FakeAuthenticationManager
+import org.groundplatform.android.system.deeplink.PlayInstallReferrerService
 import org.groundplatform.domain.model.auth.SignInState
 import org.groundplatform.domain.repository.TermsOfServiceRepositoryInterface
 import org.groundplatform.domain.repository.UserRepositoryInterface
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
 class MainViewModelTest : BaseHiltTest() {
+
+  @BindValue @JvmField val playInstallReferrerService: PlayInstallReferrerService = mock()
 
   @Inject lateinit var fakeAuthenticationManager: FakeAuthenticationManager
   @Inject lateinit var fakeRemoteDataStore: FakeRemoteDataStore
@@ -170,5 +176,37 @@ class MainViewModelTest : BaseHiltTest() {
       assertThat(tosRepository.isTermsOfServiceAccepted).isFalse()
       assertThat(awaitItem()).isEqualTo(MainUiState.TosNotAccepted)
     }
+  }
+
+  @Test
+  fun `navigation redirects to deferred deep link survey when install referrer has survey id`() =
+    runWithTestDispatcher {
+      tosRepository.isTermsOfServiceAccepted = true
+      whenever(playInstallReferrerService.getDeferredSurveyId()).thenReturn(SURVEY_ID)
+
+      viewModel.navigationRequests.test {
+        fakeAuthenticationManager.signIn()
+        advanceUntilIdle()
+
+        assertThat(awaitItem()).isEqualTo(MainUiState.ActiveSurveyById(SURVEY_ID))
+      }
+    }
+
+  @Test
+  fun `navigation falls back to survey selector when install referrer has no survey id`() =
+    runWithTestDispatcher {
+      tosRepository.isTermsOfServiceAccepted = true
+      whenever(playInstallReferrerService.getDeferredSurveyId()).thenReturn(null)
+
+      viewModel.navigationRequests.test {
+        fakeAuthenticationManager.signIn()
+        advanceUntilIdle()
+
+        assertThat(awaitItem()).isEqualTo(MainUiState.NoActiveSurvey)
+      }
+    }
+
+  companion object {
+    private const val SURVEY_ID = "survey_123"
   }
 }

--- a/app/src/test/java/org/groundplatform/android/ui/tos/TermsOfServiceScreenTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/tos/TermsOfServiceScreenTest.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.test.runTest
 import org.groundplatform.android.R
 import org.groundplatform.android.getString
 import org.groundplatform.android.system.auth.AuthenticationManager
-import org.groundplatform.android.system.deeplink.InstallReferrerManager
+import org.groundplatform.android.system.deeplink.PlayInstallReferrerService
 import org.groundplatform.domain.model.TermsOfService
 import org.groundplatform.testing.FakeTermsOfServiceRepository
 import org.junit.Before
@@ -51,7 +51,7 @@ class TermsOfServiceScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @Mock lateinit var authManager: AuthenticationManager
-  @Mock lateinit var installReferrerManager: InstallReferrerManager
+  @Mock lateinit var playInstallReferrerService: PlayInstallReferrerService
   private lateinit var fakeRepository: FakeTermsOfServiceRepository
   private lateinit var viewModel: TermsOfServiceViewModel
 
@@ -69,7 +69,7 @@ class TermsOfServiceScreenTest {
     fakeRepository.termsOfService = result
     val savedStateHandle = SavedStateHandle(mapOf("isViewOnly" to isViewOnly))
     viewModel =
-      TermsOfServiceViewModel(authManager, fakeRepository, installReferrerManager, savedStateHandle)
+      TermsOfServiceViewModel(authManager, fakeRepository, playInstallReferrerService, savedStateHandle)
   }
 
   private fun setScreenContent(

--- a/app/src/test/java/org/groundplatform/android/ui/tos/TermsOfServiceScreenTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/tos/TermsOfServiceScreenTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.test.runTest
 import org.groundplatform.android.R
 import org.groundplatform.android.getString
 import org.groundplatform.android.system.auth.AuthenticationManager
+import org.groundplatform.android.system.deeplink.InstallReferrerManager
 import org.groundplatform.domain.model.TermsOfService
 import org.groundplatform.testing.FakeTermsOfServiceRepository
 import org.junit.Before
@@ -50,6 +51,7 @@ class TermsOfServiceScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @Mock lateinit var authManager: AuthenticationManager
+  @Mock lateinit var installReferrerManager: InstallReferrerManager
   private lateinit var fakeRepository: FakeTermsOfServiceRepository
   private lateinit var viewModel: TermsOfServiceViewModel
 
@@ -66,12 +68,13 @@ class TermsOfServiceScreenTest {
   ) {
     fakeRepository.termsOfService = result
     val savedStateHandle = SavedStateHandle(mapOf("isViewOnly" to isViewOnly))
-    viewModel = TermsOfServiceViewModel(authManager, fakeRepository, savedStateHandle)
+    viewModel =
+      TermsOfServiceViewModel(authManager, fakeRepository, installReferrerManager, savedStateHandle)
   }
 
   private fun setScreenContent(
     onNavigateUp: () -> Unit = {},
-    onNavigateToSurveySelector: () -> Unit = {},
+    onNavigateToSurveySelector: (String?) -> Unit = {},
     onError: () -> Unit = {},
   ) {
     composeTestRule.setContent {

--- a/app/src/test/java/org/groundplatform/android/ui/tos/TermsOfServiceViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/tos/TermsOfServiceViewModelTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.groundplatform.android.system.auth.AuthenticationManager
+import org.groundplatform.android.system.deeplink.InstallReferrerManager
 import org.groundplatform.domain.model.TermsOfService
 import org.groundplatform.testing.FakeTermsOfServiceRepository
 import org.junit.After
@@ -35,11 +36,13 @@ import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TermsOfServiceViewModelTest {
 
   @Mock lateinit var authManager: AuthenticationManager
+  @Mock lateinit var installReferrerManager: InstallReferrerManager
   private lateinit var fakeRepository: FakeTermsOfServiceRepository
   private lateinit var viewModel: TermsOfServiceViewModel
 
@@ -60,7 +63,8 @@ class TermsOfServiceViewModelTest {
 
   private fun setupViewModel(isViewOnly: Boolean = false) = runTest {
     val savedStateHandle = SavedStateHandle(mapOf("isViewOnly" to isViewOnly))
-    viewModel = TermsOfServiceViewModel(authManager, fakeRepository, savedStateHandle)
+    viewModel =
+      TermsOfServiceViewModel(authManager, fakeRepository, installReferrerManager, savedStateHandle)
     advanceUntilIdle()
   }
 
@@ -103,6 +107,19 @@ class TermsOfServiceViewModelTest {
   }
 
   @Test
+  fun `onAgreeButtonClicked forwards deferred survey id`() = runTest {
+    whenever(installReferrerManager.getDeferredSurveyId()).thenReturn(DEFERRED_SURVEY_ID)
+    setupViewModel()
+
+    viewModel.events.test {
+      viewModel.onAgreeButtonClicked()
+      val event = awaitItem()
+      assertThat((event as TosEvent.NavigateToSurveySelector).deferredSurveyId)
+        .isEqualTo(DEFERRED_SURVEY_ID)
+    }
+  }
+
+  @Test
   fun `Load failure signs out when not view-only`() = runTest {
     fakeRepository.termsOfService = Result.failure(Exception("Failed to load"))
     setupViewModel(isViewOnly = false)
@@ -141,6 +158,7 @@ class TermsOfServiceViewModelTest {
 
   companion object {
     private const val TERMS_TEXT = "Terms content"
+    private const val DEFERRED_SURVEY_ID = "survey_123"
     private val TEST_TOS = TermsOfService("1", TERMS_TEXT)
   }
 }

--- a/app/src/test/java/org/groundplatform/android/ui/tos/TermsOfServiceViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/tos/TermsOfServiceViewModelTest.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.groundplatform.android.system.auth.AuthenticationManager
-import org.groundplatform.android.system.deeplink.InstallReferrerManager
+import org.groundplatform.android.system.deeplink.PlayInstallReferrerService
 import org.groundplatform.domain.model.TermsOfService
 import org.groundplatform.testing.FakeTermsOfServiceRepository
 import org.junit.After
@@ -42,7 +42,7 @@ import org.mockito.kotlin.whenever
 class TermsOfServiceViewModelTest {
 
   @Mock lateinit var authManager: AuthenticationManager
-  @Mock lateinit var installReferrerManager: InstallReferrerManager
+  @Mock lateinit var playInstallReferrerService: PlayInstallReferrerService
   private lateinit var fakeRepository: FakeTermsOfServiceRepository
   private lateinit var viewModel: TermsOfServiceViewModel
 
@@ -64,7 +64,7 @@ class TermsOfServiceViewModelTest {
   private fun setupViewModel(isViewOnly: Boolean = false) = runTest {
     val savedStateHandle = SavedStateHandle(mapOf("isViewOnly" to isViewOnly))
     viewModel =
-      TermsOfServiceViewModel(authManager, fakeRepository, installReferrerManager, savedStateHandle)
+      TermsOfServiceViewModel(authManager, fakeRepository, playInstallReferrerService, savedStateHandle)
     advanceUntilIdle()
   }
 
@@ -108,7 +108,7 @@ class TermsOfServiceViewModelTest {
 
   @Test
   fun `onAgreeButtonClicked forwards deferred survey id`() = runTest {
-    whenever(installReferrerManager.getDeferredSurveyId()).thenReturn(DEFERRED_SURVEY_ID)
+    whenever(playInstallReferrerService.getDeferredSurveyId()).thenReturn(DEFERRED_SURVEY_ID)
     setupViewModel()
 
     viewModel.events.test {

--- a/app/src/test/java/org/groundplatform/android/usecases/session/ClearUserSessionUseCaseTest.kt
+++ b/app/src/test/java/org/groundplatform/android/usecases/session/ClearUserSessionUseCaseTest.kt
@@ -16,6 +16,7 @@
 package org.groundplatform.android.usecases.session
 
 import kotlinx.coroutines.test.runTest
+import org.groundplatform.android.data.local.LocalValueStore
 import org.groundplatform.android.data.local.room.LocalDatabase
 import org.groundplatform.domain.repository.OfflineAreaRepositoryInterface
 import org.groundplatform.domain.repository.SurveyRepositoryInterface
@@ -24,13 +25,17 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
 class ClearUserSessionUseCaseTest {
   @Mock lateinit var localDatabase: LocalDatabase
+  @Mock lateinit var localValueStore: LocalValueStore
   @Mock lateinit var offlineAreaRepository: OfflineAreaRepositoryInterface
   @Mock lateinit var surveyRepository: SurveyRepositoryInterface
   @Mock lateinit var userRepository: UserRepositoryInterface
@@ -59,5 +64,26 @@ class ClearUserSessionUseCaseTest {
   fun `Clears all tables`() = runTest {
     clearUserSessionUseCase()
     verify(localDatabase, times(1)).clearAllTables()
+  }
+
+  @Test
+  fun `Restores consumed deferred deep link after clearing preferences`() = runTest {
+    whenever(localValueStore.isDeferredDeeplinkConsumed).thenReturn(true)
+
+    clearUserSessionUseCase()
+
+    inOrder(userRepository, localValueStore) {
+      verify(userRepository).clearUserPreferences()
+      verify(localValueStore).isDeferredDeeplinkConsumed = true
+    }
+  }
+
+  @Test
+  fun `Leaves deferred deep link unconsumed when it was never consumed`() = runTest {
+    whenever(localValueStore.isDeferredDeeplinkConsumed).thenReturn(false)
+
+    clearUserSessionUseCase()
+
+    verify(localValueStore, never()).isDeferredDeeplinkConsumed = true
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@
 [versions]
 androidCompileSdk = "37"
 androidCompileSdkMinor = "0"
+androidInstallReferrer = "2.2"
 androidMinSdk = "24"
 androidTargetSdk = "36"
 androidMapsUtilsVersion = "4.5.2"
@@ -83,6 +84,7 @@ uiautomatorVersion = "2.4.0"
 workVersion = "2.11.2"
 
 [libraries]
+android-install-referrer = { module = "com.android.installreferrer:installreferrer", version.ref = "androidInstallReferrer" }
 android-maps-utils = { module = "com.google.maps.android:android-maps-utils", version.ref = "androidMapsUtilsVersion" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompatVersion" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayoutVersion" }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3822

Adds support for opening a specific survey when the app is installed from a Play Store link carrying survey_id.
It also introduces a shared preference flag `isDeferredDeeplinkConsumed` so the link is only consumed once per install. `ClearUserSessionUseCase` deliberately preserves that flag across sign-out so a sign-out followed by a sign-in can't re-consume it.

This recording shows clicking directly in the deferred deeplink url, but Ground platform will integrate this as a redirect in the current flow of joining a survey by link/qr code

https://github.com/user-attachments/assets/b8237dd3-2b77-4e1e-8e9b-439359f18e3b


@shobhitagarwal1612  PTAL?
