### PR TITLE
Fix unable to complete draw area due to wrong initial vertices

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/PolygonDrawingSessionImpl.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/PolygonDrawingSessionImpl.kt
@@ -23,6 +23,13 @@ import org.groundplatform.domain.model.geometry.LineString
 import org.groundplatform.domain.util.isSelfIntersecting
 
 class PolygonDrawingSessionImpl : PolygonDrawingSession {
+  private var committedVertices: List<Coordinates> = listOf()
+
+  /**
+   * Tentative vertex that follows the map center when drawing, `null` if the user hasn't started.
+   */
+  private var cursor: Coordinates? = null
+
   private var _isTooClose: Boolean = false
   private var _isMarkedComplete: Boolean = false
 
@@ -31,80 +38,66 @@ class PolygonDrawingSessionImpl : PolygonDrawingSession {
       PolygonDrawingSession.State(
         isTooClose = _isTooClose,
         isMarkedComplete = _isMarkedComplete,
-        isClosed = LineString(_vertices).isClosed(),
+        isClosed = LineString(vertices).isClosed(),
         canRedo = redoVertexStack.isNotEmpty(),
-        hasSelfIntersection = isSelfIntersecting(_vertices),
+        hasSelfIntersection = isSelfIntersecting(vertices),
       )
 
-  private var _vertices: List<Coordinates> = listOf()
-
   override val vertices: List<Coordinates>
-    get() = _vertices
+    get() = cursor?.let { committedVertices + it } ?: committedVertices
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal val redoVertexStack = mutableListOf<Coordinates>()
 
   override val hasSelfIntersection: Boolean
-    get() = isSelfIntersecting(_vertices)
+    get() = isSelfIntersecting(vertices)
 
-  private fun addVertex(vertex: Coordinates, shouldOverwriteLastVertex: Boolean) {
-    val updatedVertices = _vertices.toMutableList()
-
-    if (shouldOverwriteLastVertex && updatedVertices.isNotEmpty()) {
-      updatedVertices.removeAt(updatedVertices.lastIndex)
-    }
-
-    updatedVertices.add(vertex)
-
-    _vertices = updatedVertices.toImmutableList()
+  private fun setGeometry(points: List<Coordinates>) {
+    committedVertices = points.dropLast(1).toImmutableList()
+    cursor = points.lastOrNull()
   }
 
   override fun setVertices(newVertices: List<Coordinates>) {
-    _vertices = newVertices.toImmutableList()
+    setGeometry(newVertices)
   }
 
   override fun updateTentativeVertex(
     target: Coordinates,
     calculateDistance: (Coordinates, Coordinates) -> Double,
   ) {
-    val firstVertex = _vertices.firstOrNull()
-    var updatedTarget = target
-    if (firstVertex != null && _vertices.size > 2) {
-      val distance = calculateDistance(firstVertex, target)
+    val firstVertex = vertices.firstOrNull()
+    val shouldSnapToClose =
+      firstVertex != null &&
+        vertices.size > 2 &&
+        calculateDistance(firstVertex, target) <= DISTANCE_THRESHOLD_DP
+    cursor = if (shouldSnapToClose) firstVertex else target
 
-      if (distance <= DISTANCE_THRESHOLD_DP) {
-        updatedTarget = firstVertex
-      }
-    }
-
-    val prev = _vertices.dropLast(1).lastOrNull()
+    val lastCommitted = committedVertices.lastOrNull()
     _isTooClose =
-      _vertices.size > 1 &&
-        prev?.let { calculateDistance(it, target) <= DISTANCE_THRESHOLD_DP } == true
-
-    addVertex(updatedTarget, true)
+      lastCommitted != null && calculateDistance(lastCommitted, target) <= DISTANCE_THRESHOLD_DP
   }
 
   override fun commitTentativeVertex(currentCameraTarget: Coordinates?): List<Coordinates>? {
     redoVertexStack.clear()
-    val vertex = _vertices.lastOrNull() ?: currentCameraTarget
-    return vertex?.let {
-      _isTooClose = _vertices.size > 1
-      addVertex(it, false)
-      _vertices
-    }
+    // If the user taps "Add" before moving the map there is no cursor yet, so  fall back to the
+    // current map center.
+    val point = cursor ?: currentCameraTarget ?: return null
+    committedVertices = committedVertices + point
+    cursor = point
+    _isTooClose = true
+    return vertices
   }
 
   override fun checkVertexIntersection(): Boolean {
-    val intersected = isSelfIntersecting(_vertices)
+    val intersected = isSelfIntersecting(vertices)
     if (intersected) {
-      _vertices = _vertices.dropLast(1).toImmutableList()
+      setGeometry(vertices.dropLast(1))
     }
     return intersected
   }
 
   override fun isValidPolygon(): Boolean =
-    LineString(_vertices).isClosed() && !isSelfIntersecting(_vertices)
+    LineString(vertices).isClosed() && !isSelfIntersecting(vertices)
 
   override fun complete() {
     check(isValidPolygon()) { "Polygon is not valid" }
@@ -113,11 +106,12 @@ class PolygonDrawingSessionImpl : PolygonDrawingSession {
   }
 
   override fun removeLastVertex(): Boolean {
-    if (_vertices.isEmpty()) return false
+    val currentVertices = vertices
+    if (currentVertices.isEmpty()) return false
 
     _isMarkedComplete = false
-    redoVertexStack.add(_vertices.last())
-    _vertices = _vertices.dropLast(1).toImmutableList()
+    redoVertexStack.add(currentVertices.last())
+    setGeometry(currentVertices.dropLast(1))
     return true
   }
 
@@ -126,7 +120,7 @@ class PolygonDrawingSessionImpl : PolygonDrawingSession {
 
     _isMarkedComplete = false
     val redoVertex = redoVertexStack.removeAt(redoVertexStack.lastIndex)
-    _vertices = (_vertices + redoVertex).toImmutableList()
+    setGeometry(vertices + redoVertex)
     return redoVertex
   }
 }

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModelTest.kt
@@ -357,12 +357,11 @@ class DrawAreaTaskViewModelTest : BaseHiltTest() {
     }
 
   @Test
-  fun `isTooClose is false if only one vertex`() {
+  fun `isTooClose is true after committing a vertex until the map is moved`() {
     setupViewModel()
     updateLastVertexAndAdd(COORDINATE_1)
 
-    // Only 1 vertex.
-    assertThat(viewModel.sessionState.value.isTooClose).isFalse()
+    assertThat(viewModel.sessionState.value.isTooClose).isTrue()
   }
 
   @Test
@@ -494,6 +493,21 @@ class DrawAreaTaskViewModelTest : BaseHiltTest() {
       with(requireNotNull(states.find { it.action == ButtonAction.REDO })) {
         assertTrue(isVisible)
         assertTrue(isEnabled)
+      }
+    }
+
+  @Test
+  fun `ADD_POINT is disabled right after committing a vertex and before moving the map`() =
+    runWithTestDispatcher {
+      setupViewModel()
+      viewModel.onCameraMoved(COORDINATE_1)
+
+      viewModel.addLastVertex()
+      advanceUntilIdle()
+
+      val states = viewModel.taskActionButtonStates.first()
+      with(requireNotNull(states.find { it.action == ButtonAction.ADD_POINT })) {
+        assertFalse(isEnabled)
       }
     }
 

--- a/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/PolygonDrawingSessionTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/datacollection/tasks/polygon/PolygonDrawingSessionTest.kt
@@ -102,15 +102,20 @@ class PolygonDrawingSessionTest {
   }
 
   @Test
-  fun `commitTentativeVertex adds vertex to committed list`() {
+  fun `commitTentativeVertex falls back to the camera target when there is no cursor`() {
     session.commitTentativeVertex(COORDINATE_1)
-    assertThat(session.vertices).containsExactly(COORDINATE_1)
+
+    assertThat(session.vertices).containsExactly(COORDINATE_1, COORDINATE_1)
+    assertThat(session.state.isTooClose).isTrue()
   }
 
   @Test
-  fun `commitTentativeVertex sets isTooClose true when size greater than 1`() {
+  fun `commitTentativeVertex commits the existing cursor and ignores the passed target`() {
     session.setVertices(listOf(COORDINATE_1, COORDINATE_2))
+
     session.commitTentativeVertex(COORDINATE_3)
+
+    assertThat(session.vertices).containsExactly(COORDINATE_1, COORDINATE_2, COORDINATE_2).inOrder()
     assertThat(session.state.isTooClose).isTrue()
   }
 


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Related to #3679

Some users in a Ground training in Lao PDR reported that they were not able to complete polygon drawing because the 'Complete' button was disabled and no error message was displayed. This was caused by an issue where a duplicated first vertex would be created by tapping 'Add point' twice at the start of drawing.
 `commitTentativeVertex` guarded against re-committing the same spot with `_isTooClose = _vertices.size > 1`. But this caused the 'Add point' button to remain enabled after adding 1 vertex, which allowed for the duplication and caused an invalid final geometry which made it impossible to close the polygon.

This fix involves setting `isTooClose` to true after every committed vertex, which sets the 'Add Point` as disabled until the user moves the map again. There is also a small refactor in `PolygonDrawingSessionImpl` to make sure the first vertex does stay in the correct place:
- added a separate class for committed vertices (`committedVertices`) and other for just the tentative vertex following the map center (`cursor`)
- `setGeometry`, `removeLastVertex`, `redoLastVertex`, and `checkVertexIntersection` were simplified to operate through the derived vertices. 

Before

[Screen_recording_20260713_120515.webm](https://github.com/user-attachments/assets/9bc9f287-1b22-4251-92c6-9f68c8007c61)


After

[Screen_recording_20260713_120709.webm](https://github.com/user-attachments/assets/3a7b7455-9a05-4e47-bc83-6d4edfe4f176)


@shobhitagarwal1612 PTAL?
