### PR TITLE
Refactor format area logic

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/tasks/polygon/DrawAreaTaskViewModel.kt
@@ -43,7 +43,6 @@ import org.groundplatform.android.ui.map.Feature
 import org.groundplatform.android.ui.util.LocaleAwareMeasureFormatter
 import org.groundplatform.android.ui.util.VibrationHelper
 import org.groundplatform.android.ui.util.getDefaultColor
-import org.groundplatform.android.ui.util.getFormattedArea
 import org.groundplatform.android.util.distanceTo
 import org.groundplatform.android.util.penult
 import org.groundplatform.domain.model.geometry.Coordinates
@@ -58,6 +57,7 @@ import org.groundplatform.domain.model.submission.TaskData
 import org.groundplatform.domain.model.task.Task
 import org.groundplatform.domain.usecases.user.GetUserSettingsUseCase
 import org.groundplatform.domain.util.calculateShoelacePolygonArea
+import org.groundplatform.ui.util.getFormattedArea
 import org.jetbrains.annotations.VisibleForTesting
 import timber.log.Timber
 

--- a/app/src/main/java/org/groundplatform/android/ui/offlineareas/OfflineAreasViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/offlineareas/OfflineAreasViewModel.kt
@@ -25,10 +25,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import org.groundplatform.android.ui.common.AbstractViewModel
-import org.groundplatform.android.ui.util.toMbString
 import org.groundplatform.domain.model.imagery.OfflineArea
 import org.groundplatform.domain.model.util.toMb
 import org.groundplatform.domain.repository.OfflineAreaRepositoryInterface
+import org.groundplatform.ui.util.toMbString
 
 /**
  * View model for the offline area manager fragment. Handles the current list of downloaded areas.

--- a/app/src/main/java/org/groundplatform/android/ui/offlineareas/selector/OfflineAreaSelectorViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/offlineareas/selector/OfflineAreaSelectorViewModel.kt
@@ -33,7 +33,6 @@ import org.groundplatform.android.system.SettingsManager
 import org.groundplatform.android.ui.common.BaseMapViewModel
 import org.groundplatform.android.ui.offlineareas.selector.model.OfflineAreaSelectorEvent
 import org.groundplatform.android.ui.offlineareas.selector.model.OfflineAreaSelectorState
-import org.groundplatform.android.ui.util.toMbString
 import org.groundplatform.domain.model.imagery.RemoteMogTileSource
 import org.groundplatform.domain.model.imagery.TileSource
 import org.groundplatform.domain.model.map.Bounds
@@ -43,6 +42,7 @@ import org.groundplatform.domain.repository.LocationOfInterestRepositoryInterfac
 import org.groundplatform.domain.repository.MapStateRepositoryInterface
 import org.groundplatform.domain.repository.OfflineAreaRepositoryInterface
 import org.groundplatform.domain.repository.SurveyRepositoryInterface
+import org.groundplatform.ui.util.toMbString
 import timber.log.Timber
 
 private const val MIN_DOWNLOAD_ZOOM_LEVEL = 9

--- a/app/src/main/java/org/groundplatform/android/ui/offlineareas/viewer/OfflineAreaViewerViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/offlineareas/viewer/OfflineAreaViewerViewModel.kt
@@ -27,13 +27,13 @@ import org.groundplatform.android.system.LocationManager
 import org.groundplatform.android.system.PermissionsManager
 import org.groundplatform.android.system.SettingsManager
 import org.groundplatform.android.ui.common.BaseMapViewModel
-import org.groundplatform.android.ui.util.toMbString
 import org.groundplatform.domain.model.imagery.OfflineArea
 import org.groundplatform.domain.model.util.toMb
 import org.groundplatform.domain.repository.LocationOfInterestRepositoryInterface
 import org.groundplatform.domain.repository.MapStateRepositoryInterface
 import org.groundplatform.domain.repository.OfflineAreaRepositoryInterface
 import org.groundplatform.domain.repository.SurveyRepositoryInterface
+import org.groundplatform.ui.util.toMbString
 import timber.log.Timber
 
 /**

--- a/app/src/test/java/org/groundplatform/android/ui/offlineareas/selector/OfflineAreaSelectorViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/offlineareas/selector/OfflineAreaSelectorViewModelTest.kt
@@ -32,7 +32,6 @@ import org.groundplatform.android.system.PermissionsManager
 import org.groundplatform.android.system.SettingsManager
 import org.groundplatform.android.ui.offlineareas.selector.model.OfflineAreaSelectorEvent
 import org.groundplatform.android.ui.offlineareas.selector.model.OfflineAreaSelectorState
-import org.groundplatform.android.ui.util.toMbString
 import org.groundplatform.domain.model.geometry.Coordinates
 import org.groundplatform.domain.model.map.Bounds
 import org.groundplatform.domain.model.map.CameraPosition
@@ -40,6 +39,7 @@ import org.groundplatform.domain.repository.LocationOfInterestRepositoryInterfac
 import org.groundplatform.domain.repository.MapStateRepositoryInterface
 import org.groundplatform.domain.repository.OfflineAreaRepositoryInterface
 import org.groundplatform.domain.repository.SurveyRepositoryInterface
+import org.groundplatform.ui.util.toMbString
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/util/Constants.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/util/Constants.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.domain.util
+
+object Constants {
+  const val SQUARE_METERS_PER_ACRE = 4046.86
+  const val SQUARE_METERS_PER_HECTARE = 10_000
+  const val SQUARE_FEET_PER_SQUARE_METER = 10.7639
+}

--- a/core/ui/src/androidMain/kotlin/org/groundplatform/ui/util/NumberFormatter.android.kt
+++ b/core/ui/src/androidMain/kotlin/org/groundplatform/ui/util/NumberFormatter.android.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.ui.util
+
+import java.text.NumberFormat
+import java.util.Locale
+
+actual object NumberFormatter {
+  actual fun format(value: Double, decimalPlaces: Int): String =
+    NumberFormat.getNumberInstance(Locale.getDefault())
+      .apply {
+        minimumFractionDigits = decimalPlaces
+        maximumFractionDigits = decimalPlaces
+      }
+      .format(value)
+}

--- a/core/ui/src/androidMain/kotlin/org/groundplatform/ui/util/NumberFormatter.android.kt
+++ b/core/ui/src/androidMain/kotlin/org/groundplatform/ui/util/NumberFormatter.android.kt
@@ -24,6 +24,7 @@ actual object NumberFormatter {
       .apply {
         minimumFractionDigits = decimalPlaces
         maximumFractionDigits = decimalPlaces
+        isGroupingUsed = false
       }
       .format(value)
 }

--- a/core/ui/src/commonMain/kotlin/org/groundplatform/ui/util/NumberFormatter.kt
+++ b/core/ui/src/commonMain/kotlin/org/groundplatform/ui/util/NumberFormatter.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.ui.util
+
+expect object NumberFormatter {
+  fun format(value: Double, decimalPlaces: Int): String
+}

--- a/core/ui/src/commonMain/kotlin/org/groundplatform/ui/util/UiFormatUtil.kt
+++ b/core/ui/src/commonMain/kotlin/org/groundplatform/ui/util/UiFormatUtil.kt
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.groundplatform.android.ui.util
+package org.groundplatform.ui.util
 
-import androidx.annotation.VisibleForTesting
-import java.util.Locale
+import kotlin.math.ceil
 import org.groundplatform.domain.model.settings.MeasurementUnits
 import org.groundplatform.domain.model.util.MegabyteCount
-import kotlin.math.ceil
-
-@VisibleForTesting const val SQUARE_METERS_PER_ACRE = 4046.86
-@VisibleForTesting const val SQUARE_METERS_PER_HECTARE = 10_000
-@VisibleForTesting const val SQUARE_FEET_PER_SQUARE_METER = 10.7639
+import org.groundplatform.domain.util.Constants.SQUARE_FEET_PER_SQUARE_METER
+import org.groundplatform.domain.util.Constants.SQUARE_METERS_PER_ACRE
+import org.groundplatform.domain.util.Constants.SQUARE_METERS_PER_HECTARE
 
 fun getFormattedArea(areaInSquareMeters: Double, measurementUnits: MeasurementUnits): String {
   val (convertedArea, stringUnit) =
@@ -41,7 +38,7 @@ fun getFormattedArea(areaInSquareMeters: Double, measurementUnits: MeasurementUn
           areaInSquareMeters / SQUARE_METERS_PER_ACRE to "ac"
         }
     }
-  val rounded = String.format(Locale.getDefault(), "%.2f", convertedArea)
+  val rounded = NumberFormatter.format(value = convertedArea, decimalPlaces = 2)
   return "$rounded $stringUnit"
 }
 

--- a/core/ui/src/commonTest/kotlin/org/groundplatform/ui/components/util/UiFormatUtilTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/groundplatform/ui/components/util/UiFormatUtilTest.kt
@@ -41,7 +41,7 @@ class UiFormatUtilTest {
   fun `Should display area in square feet if it's below an acre`() {
     val areaInSquareMeters = 2000.0
     val result = getFormattedArea(areaInSquareMeters, MeasurementUnits.IMPERIAL)
-    val expected = "21527.80 ft²"
+    val expected = "21,527.80 ft²"
     assertEquals(expected, result)
   }
 

--- a/core/ui/src/commonTest/kotlin/org/groundplatform/ui/components/util/UiFormatUtilTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/groundplatform/ui/components/util/UiFormatUtilTest.kt
@@ -41,7 +41,7 @@ class UiFormatUtilTest {
   fun `Should display area in square feet if it's below an acre`() {
     val areaInSquareMeters = 2000.0
     val result = getFormattedArea(areaInSquareMeters, MeasurementUnits.IMPERIAL)
-    val expected = "21,527.80 ft²"
+    val expected = "21527.80 ft²"
     assertEquals(expected, result)
   }
 

--- a/core/ui/src/commonTest/kotlin/org/groundplatform/ui/components/util/UiFormatUtilTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/groundplatform/ui/components/util/UiFormatUtilTest.kt
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.groundplatform.android.util
+package org.groundplatform.ui.components.util
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import java.util.Locale
-import org.junit.Test
-import org.groundplatform.android.ui.util.SQUARE_FEET_PER_SQUARE_METER
-import org.groundplatform.android.ui.util.SQUARE_METERS_PER_ACRE
-import org.groundplatform.android.ui.util.SQUARE_METERS_PER_HECTARE
-import org.groundplatform.android.ui.util.getFormattedArea
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import org.groundplatform.domain.model.settings.MeasurementUnits
-import org.junit.Assert.assertEquals
-import org.junit.runner.RunWith
+import org.groundplatform.domain.util.Constants.SQUARE_METERS_PER_ACRE
+import org.groundplatform.domain.util.Constants.SQUARE_METERS_PER_HECTARE
+import org.groundplatform.ui.util.getFormattedArea
 
-@RunWith(AndroidJUnit4::class)
 class UiFormatUtilTest {
   @Test
   fun `Should display area in square meters if it's below an hectare`() {
@@ -46,12 +41,7 @@ class UiFormatUtilTest {
   fun `Should display area in square feet if it's below an acre`() {
     val areaInSquareMeters = 2000.0
     val result = getFormattedArea(areaInSquareMeters, MeasurementUnits.IMPERIAL)
-    val expected =
-      String.format(
-        Locale.getDefault(),
-        "%.2f ft²",
-        areaInSquareMeters * SQUARE_FEET_PER_SQUARE_METER,
-      )
+    val expected = "21527.80 ft²"
     assertEquals(expected, result)
   }
 

--- a/core/ui/src/iosMain/kotlin/org/groundplatform/ui/util/NumberFormatter.ios.kt
+++ b/core/ui/src/iosMain/kotlin/org/groundplatform/ui/util/NumberFormatter.ios.kt
@@ -29,6 +29,7 @@ actual object NumberFormatter {
         locale = NSLocale.currentLocale
         minimumFractionDigits = decimalPlaces.toULong()
         maximumFractionDigits = decimalPlaces.toULong()
+        usesGroupingSeparator = false
       }
 
     return formatter.stringFromNumber(NSNumber(value)) ?: value.toString()

--- a/core/ui/src/iosMain/kotlin/org/groundplatform/ui/util/NumberFormatter.ios.kt
+++ b/core/ui/src/iosMain/kotlin/org/groundplatform/ui/util/NumberFormatter.ios.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.ui.util
+
+import platform.Foundation.NSLocale
+import platform.Foundation.NSNumber
+import platform.Foundation.NSNumberFormatter
+import platform.Foundation.NSNumberFormatterDecimalStyle
+import platform.Foundation.currentLocale
+
+actual object NumberFormatter {
+  actual fun format(value: Double, decimalPlaces: Int): String {
+    val formatter =
+      NSNumberFormatter().apply {
+        numberStyle = NSNumberFormatterDecimalStyle
+        locale = NSLocale.currentLocale
+        minimumFractionDigits = decimalPlaces.toULong()
+        maximumFractionDigits = decimalPlaces.toULong()
+      }
+
+    return formatter.stringFromNumber(NSNumber(value)) ?: value.toString()
+  }
+}


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #3839

This PR focuses on an initial refactor to make the `formatArea` accessible for the `feature:pdf` module, so that we can later display the area in the PDF. In order to do this, the `UiFormatUtil` was moved to `core:ui` and a new class was introduced `NumberFormat`, in order to be able to format numbers based in a specific locale. Since Locale is a java method, this class had to be implemented using expect/actual and specific logic for android and iOS.

@shobhitagarwal1612 PTAL?
