### PR TITLE
Update domain classes to include map data for PDF rendering

### DIFF
--- a/app/src/main/java/org/groundplatform/android/di/PdfModule.kt
+++ b/app/src/main/java/org/groundplatform/android/di/PdfModule.kt
@@ -27,6 +27,7 @@ import org.groundplatform.android.BuildConfig
 import org.groundplatform.android.R
 import org.groundplatform.android.di.coroutines.DefaultDispatcher
 import org.groundplatform.android.di.coroutines.IoDispatcher
+import org.groundplatform.domain.usecases.user.GetUserSettingsUseCase
 import org.groundplatform.feature.pdf.AndroidPdfImageProvider
 import org.groundplatform.feature.pdf.AndroidPdfOutputProvider
 import org.groundplatform.feature.pdf.AndroidPdfRenderer
@@ -74,11 +75,13 @@ object PdfModule {
     taskValueMapper: TaskValueMapper,
     strings: StringResolver,
     dateFormatter: DateFormatter,
+    getUserSettingsUseCase: GetUserSettingsUseCase,
   ): LoiReportMapper =
     LoiReportMapper(
       taskValueMapper = taskValueMapper,
       strings = strings,
       dateFormatter = dateFormatter,
+      getUserSettings = getUserSettingsUseCase,
     )
 
   @Provides

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionScreenPreviews.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/DataCollectionScreenPreviews.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.serialization.json.JsonObject
 import org.groundplatform.android.ui.common.ExcludeFromJacocoGeneratedReport
+import org.groundplatform.domain.model.geometry.Coordinates
+import org.groundplatform.domain.model.geometry.Point
 import org.groundplatform.domain.model.job.Job
 import org.groundplatform.domain.model.locationofinterest.LoiReport
 import org.groundplatform.ui.theme.AppTheme
@@ -114,6 +116,8 @@ private fun DataCollectionContentCompletePreview() {
                   userName = "John Doe",
                   userEmail = "john.doe@example.com",
                   submissions = emptyList(),
+                  geometry = Point(Coordinates(0.0, 0.0)),
+                  style = null,
                 ),
             )
         ),

--- a/app/src/main/java/org/groundplatform/android/ui/datacollection/DataSubmissionConfirmationScreen.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/datacollection/DataSubmissionConfirmationScreen.kt
@@ -57,6 +57,8 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.groundplatform.android.R
 import org.groundplatform.android.ui.common.ExcludeFromJacocoGeneratedReport
+import org.groundplatform.domain.model.geometry.Coordinates
+import org.groundplatform.domain.model.geometry.Point
 import org.groundplatform.domain.model.locationofinterest.LoiReport
 import org.groundplatform.ui.components.loireport.LoiReportAction
 import org.groundplatform.ui.components.loireport.SubmissionPdfItem
@@ -214,6 +216,8 @@ private val testLoiReport =
         userName = "John Doe",
         userEmail = "john.doe@example.com",
         submissions = emptyList(),
+        geometry = Point(Coordinates(0.0, 0.0)),
+        style = null,
       ),
   )
 

--- a/app/src/main/java/org/groundplatform/android/ui/home/mapcontainer/jobs/ShareLocationModal.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/home/mapcontainer/jobs/ShareLocationModal.kt
@@ -50,6 +50,8 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.groundplatform.android.R
+import org.groundplatform.domain.model.geometry.Coordinates
+import org.groundplatform.domain.model.geometry.Point
 import org.groundplatform.domain.model.locationofinterest.LoiReport
 import org.groundplatform.ui.components.loireport.LoiReportAction
 import org.groundplatform.ui.components.loireport.SubmissionPdfItem
@@ -152,6 +154,8 @@ private fun ShareLocationModalPreview() {
           userName = "John Doe",
           userEmail = "john.doe@example.com",
           submissions = emptyList(),
+          geometry = Point(Coordinates(0.0, 0.0)),
+          style = null,
         ),
     )
 

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/locationofinterest/LoiReport.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/locationofinterest/LoiReport.kt
@@ -31,10 +31,6 @@ data class LoiReport(
     val userName: String,
     val userEmail: String,
     val submissions: List<Submission>,
-    val plot: Plot?,
-  )
-
-  data class Plot(
     val geometry: Geometry,
     val style: Style?,
   )

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/locationofinterest/LoiReport.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/locationofinterest/LoiReport.kt
@@ -16,6 +16,8 @@
 package org.groundplatform.domain.model.locationofinterest
 
 import kotlinx.serialization.json.JsonObject
+import org.groundplatform.domain.model.geometry.Geometry
+import org.groundplatform.domain.model.job.Style
 import org.groundplatform.domain.model.submission.Submission
 
 /** Represents the data collected for a specific LOI which can be downloaded and shared. */
@@ -29,5 +31,11 @@ data class LoiReport(
     val userName: String,
     val userEmail: String,
     val submissions: List<Submission>,
+    val plot: Plot?,
+  )
+
+  data class Plot(
+    val geometry: Geometry,
+    val style: Style?,
   )
 }

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
@@ -63,7 +63,8 @@ class GetLoiReportUseCase(
       submissionRepositoryInterface.getSubmissions(loi).sortedByDescending {
         it.lastModified.clientTimestamp
       }
-    val surveyName = surveyRepositoryInterface.getOfflineSurvey(surveyId)?.title.orEmpty()
+    val survey = surveyRepositoryInterface.getOfflineSurvey(surveyId)
+    val surveyName = survey?.title.orEmpty()
     val submissionDetails =
       if (submissions.isNotEmpty()) {
         val user = userRepositoryInterface.getAuthenticatedUser()
@@ -72,6 +73,11 @@ class GetLoiReportUseCase(
           userName = user.displayName,
           userEmail = user.email,
           submissions = submissions,
+          plot =
+            LoiReport.Plot(
+              geometry = loi.geometry,
+              style = loi.job.style,
+            ),
         )
       } else null
 

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCase.kt
@@ -73,11 +73,8 @@ class GetLoiReportUseCase(
           userName = user.displayName,
           userEmail = user.email,
           submissions = submissions,
-          plot =
-            LoiReport.Plot(
-              geometry = loi.geometry,
-              style = loi.job.style,
-            ),
+          geometry = loi.geometry,
+          style = loi.job.style,
         )
       } else null
 

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
@@ -30,6 +30,7 @@ import org.groundplatform.domain.model.geometry.LinearRing
 import org.groundplatform.domain.model.geometry.MultiPolygon
 import org.groundplatform.domain.model.geometry.Point
 import org.groundplatform.domain.model.geometry.Polygon
+import org.groundplatform.domain.model.job.Style
 import org.groundplatform.domain.model.locationofinterest.AuditInfo
 import org.groundplatform.domain.model.locationofinterest.LoiProperties
 import org.groundplatform.domain.model.locationofinterest.LoiReport
@@ -420,6 +421,41 @@ class GetLoiReportUseCaseTest {
       getLoiReportUseCase.invoke(loiName = "loiName", loiId = "loiId", surveyId = "surveyId")!!
 
     assertNull(loiReport.submissionDetails)
+  }
+
+  @Test
+  fun `Should populate map snapshot with the LOI geometry and job style`() = runTest {
+    val geometry = Point(Coordinates(lat = 41.0, lng = -89.0))
+    loiRepository.offlineLoi =
+      loiRepository.offlineLoi.copy(
+        geometry = geometry,
+        job = FakeDataGenerator.newJob(style = Style("#4169E1")),
+      )
+    submissionRepository.submissions = listOf(FakeDataGenerator.newSubmission())
+
+    val loiReport =
+      getLoiReportUseCase.invoke(loiName = "loiName", loiId = "loiId", surveyId = "surveyId")!!
+
+    assertEquals(
+      geometry,
+      loiReport.submissionDetails!!.plot!!.geometry,
+    )
+    assertEquals(
+      Style("#4169E1"),
+      loiReport.submissionDetails.plot.style,
+    )
+  }
+
+  @Test
+  fun `Should populate map snapshot with a null style when the job has no style`() = runTest {
+    loiRepository.offlineLoi =
+      loiRepository.offlineLoi.copy(job = FakeDataGenerator.newJob().copy(style = null))
+    submissionRepository.submissions = listOf(FakeDataGenerator.newSubmission())
+
+    val loiReport =
+      getLoiReportUseCase.invoke(loiName = "loiName", loiId = "loiId", surveyId = "surveyId")!!
+
+    assertNull(loiReport.submissionDetails!!.plot!!.style)
   }
 
   private suspend fun invokeUseCase(

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
@@ -436,14 +436,8 @@ class GetLoiReportUseCaseTest {
     val loiReport =
       getLoiReportUseCase.invoke(loiName = "loiName", loiId = "loiId", surveyId = "surveyId")!!
 
-    assertEquals(
-      geometry,
-      loiReport.submissionDetails!!.geometry,
-    )
-    assertEquals(
-      Style("#4169E1"),
-      loiReport.submissionDetails.style,
-    )
+    assertEquals(geometry, loiReport.submissionDetails!!.geometry)
+    assertEquals(Style("#4169E1"), loiReport.submissionDetails.style)
   }
 
   @Test

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/usecases/GetLoiReportUseCaseTest.kt
@@ -438,11 +438,11 @@ class GetLoiReportUseCaseTest {
 
     assertEquals(
       geometry,
-      loiReport.submissionDetails!!.plot!!.geometry,
+      loiReport.submissionDetails!!.geometry,
     )
     assertEquals(
       Style("#4169E1"),
-      loiReport.submissionDetails.plot.style,
+      loiReport.submissionDetails.style,
     )
   }
 
@@ -455,7 +455,7 @@ class GetLoiReportUseCaseTest {
     val loiReport =
       getLoiReportUseCase.invoke(loiName = "loiName", loiId = "loiId", surveyId = "surveyId")!!
 
-    assertNull(loiReport.submissionDetails!!.plot!!.style)
+    assertNull(loiReport.submissionDetails!!.style)
   }
 
   private suspend fun invokeUseCase(

--- a/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
+++ b/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
@@ -249,13 +249,20 @@ object FakeDataGenerator {
     userName: String = "user",
     userEmail: String = "user@email.com",
     submissions: List<Submission> = listOf(newSubmission()),
+    mapSnapshot: LoiReport.Plot = newLoiReportPlot(),
   ): LoiReport.SubmissionDetails =
     LoiReport.SubmissionDetails(
       surveyName = surveyName,
       userName = userName,
       userEmail = userEmail,
       submissions = submissions,
+      plot = mapSnapshot,
     )
+
+  fun newLoiReportPlot(
+    geometry: Geometry = Point(Coordinates(0.0, 0.0)),
+    style: Style? = Style("#4169E1"),
+  ): LoiReport.Plot = LoiReport.Plot(geometry = geometry, style = style)
 
   fun newLoiReport(
     loiName: String = "loi",

--- a/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
+++ b/core/testing/src/commonMain/kotlin/org/groundplatform/testing/FakeDataGenerator.kt
@@ -249,20 +249,17 @@ object FakeDataGenerator {
     userName: String = "user",
     userEmail: String = "user@email.com",
     submissions: List<Submission> = listOf(newSubmission()),
-    mapSnapshot: LoiReport.Plot = newLoiReportPlot(),
+    geometry: Geometry = Point(Coordinates(0.0, 0.0)),
+    style: Style? = Style("#4169E1"),
   ): LoiReport.SubmissionDetails =
     LoiReport.SubmissionDetails(
       surveyName = surveyName,
       userName = userName,
       userEmail = userEmail,
       submissions = submissions,
-      plot = mapSnapshot,
+      geometry = geometry,
+      style = style,
     )
-
-  fun newLoiReportPlot(
-    geometry: Geometry = Point(Coordinates(0.0, 0.0)),
-    style: Style? = Style("#4169E1"),
-  ): LoiReport.Plot = LoiReport.Plot(geometry = geometry, style = style)
 
   fun newLoiReport(
     loiName: String = "loi",

--- a/core/ui/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-es/strings.xml
@@ -34,4 +34,6 @@
   <string name="job">Trabajo</string>
   <string name="pdf_data_collector">Recolector de datos</string>
   <string name="retry">Reintentar</string>
+  <string name="area">Área</string>
+  <string name="scale">Escala</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-fr/strings.xml
@@ -33,4 +33,6 @@
   <string name="job">Mission</string>
   <string name="pdf_data_collector">Collecteur de données</string>
   <string name="retry">Réessayer</string>
+  <string name="area">Surface</string>
+  <string name="scale">Échelle</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-km/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-km/strings.xml
@@ -33,4 +33,6 @@
   <string name="job">ការងារ</string>
   <string name="pdf_data_collector">អ្នកប្រមូលទិន្នន័យ</string>
   <string name="retry">ព្យាយាមឡើងវិញ</string>
+  <string name="area">ផ្ទៃក្រឡា</string>
+  <string name="scale">មាត្រដ្ឋាន</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-lo/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-lo/strings.xml
@@ -33,4 +33,6 @@
   <string name="job">ພາລະກິດ</string>
   <string name="pdf_data_collector">ຜູ້ເກັບຂໍ້ມູນ</string>
   <string name="retry">ລອງໃໝ່</string>
+  <string name="area">ພື້ນທີ່</string>
+  <string name="scale">ມາດຕາສ່ວນ</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-pt/strings.xml
@@ -34,4 +34,6 @@
   <string name="job">Tarefa</string>
   <string name="pdf_data_collector">Coletor de dados</string>
   <string name="retry">Tentar novamente</string>
+  <string name="area">Área</string>
+  <string name="scale">Escala</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-th/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-th/strings.xml
@@ -33,4 +33,6 @@
   <string name="job">งาน</string>
   <string name="pdf_data_collector">ผู้เก็บข้อมูล</string>
   <string name="retry">ลองใหม่</string>
+  <string name="area">พื้นที่</string>
+  <string name="scale">มาตราส่วน</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-vi/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-vi/strings.xml
@@ -33,4 +33,6 @@
   <string name="job">Công việc</string>
   <string name="pdf_data_collector">Người thu thập dữ liệu</string>
   <string name="retry">Thử lại</string>
+  <string name="area">Diện tích</string>
+  <string name="scale">Tỷ lệ</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -34,4 +34,6 @@
   <string name="job">Job</string>
   <string name="pdf_data_collector">Data collector</string>
   <string name="retry">Retry</string>
+  <string name="area">Area</string>
+  <string name="scale">Scale</string>
 </resources>

--- a/feature/pdf/src/androidHostTest/kotlin/org/groundplatform/feature/pdf/render/PdfWriterTest.kt
+++ b/feature/pdf/src/androidHostTest/kotlin/org/groundplatform/feature/pdf/render/PdfWriterTest.kt
@@ -267,6 +267,7 @@ class PdfWriterTest {
         qrBlock = QR_BLOCK,
         footer = FOOTER,
         table = TABLE,
+        mapBlock = null,
       )
 
     val SINGLE_PAGE_DOCUMENT =
@@ -288,6 +289,7 @@ class PdfWriterTest {
                 ),
               )
           ),
+        mapBlock = null,
       )
 
     val TEST_PDF_DOCUMENT =
@@ -305,6 +307,7 @@ class PdfWriterTest {
                 )
               }
           ),
+        mapBlock = null,
       )
   }
 }

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapper.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapper.kt
@@ -113,7 +113,9 @@ class LoiReportMapper(
         }
       }
 
-  private suspend fun buildMapBlock(submissionDetails: LoiReport.SubmissionDetails): SubmissionPdfDocument.MapBlock {
+  private suspend fun buildMapBlock(
+    submissionDetails: LoiReport.SubmissionDetails
+  ): SubmissionPdfDocument.MapBlock {
     val areaInSquareMeters =
       (submissionDetails.geometry as? Polygon)?.let { geometry ->
         calculateShoelacePolygonArea(geometry.shell.coordinates).takeIf { it > 0.0 }

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapper.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapper.kt
@@ -16,13 +16,18 @@
 package org.groundplatform.feature.pdf.mapper
 
 import ground_android.core.ui.generated.resources.Res
+import ground_android.core.ui.generated.resources.area
 import ground_android.core.ui.generated.resources.job
 import ground_android.core.ui.generated.resources.pdf_data_collector
+import ground_android.core.ui.generated.resources.scale
 import ground_android.core.ui.generated.resources.scan_this_qr_to_download_geojson
 import ground_android.core.ui.generated.resources.submission
 import ground_android.core.ui.generated.resources.survey
+import org.groundplatform.domain.model.geometry.Polygon
 import org.groundplatform.domain.model.locationofinterest.LoiReport
 import org.groundplatform.domain.model.submission.Submission
+import org.groundplatform.domain.usecases.user.GetUserSettingsUseCase
+import org.groundplatform.domain.util.calculateShoelacePolygonArea
 import org.groundplatform.feature.pdf.PdfExportService
 import org.groundplatform.feature.pdf.model.SubmissionPdfDocument
 import org.groundplatform.feature.pdf.model.SubmissionPdfDocument.Footer
@@ -32,12 +37,14 @@ import org.groundplatform.feature.pdf.model.SubmissionPdfDocument.Row
 import org.groundplatform.feature.pdf.model.SubmissionPdfDocument.Table
 import org.groundplatform.ui.util.DateFormatter
 import org.groundplatform.ui.util.StringResolver
+import org.groundplatform.ui.util.getFormattedArea
 
 /** Maps an [LoiReport] and its [Submission] to a [PdfExportService.Request]. */
 class LoiReportMapper(
   private val taskValueMapper: TaskValueMapper,
   private val strings: StringResolver,
   private val dateFormatter: DateFormatter,
+  private val getUserSettings: GetUserSettingsUseCase,
 ) {
 
   suspend fun map(loiReport: LoiReport, submission: Submission): PdfExportService.Request? {
@@ -54,6 +61,7 @@ class LoiReportMapper(
             loiName = loiReport.loiName,
             rows = rows,
           ),
+        mapBlock = buildMapBlock(details),
       )
     val dateMillis = submission.lastModified.clientTimestamp
     val timestamp =
@@ -104,6 +112,25 @@ class LoiReportMapper(
           Row(question = task.label, answer = taskValueMapper.map(task, value))
         }
       }
+
+  private suspend fun buildMapBlock(submissionDetails: LoiReport.SubmissionDetails): SubmissionPdfDocument.MapBlock {
+    val areaInSquareMeters =
+      (submissionDetails.geometry as? Polygon)?.let { geometry ->
+        calculateShoelacePolygonArea(geometry.shell.coordinates).takeIf { it > 0.0 }
+      }
+    return SubmissionPdfDocument.MapBlock(
+      geometry = submissionDetails.geometry,
+      style = submissionDetails.style,
+      area =
+        areaInSquareMeters?.let {
+          SubmissionPdfDocument.Area(
+            label = strings.resolve(Res.string.area),
+            value = getFormattedArea(areaInSquareMeters, getUserSettings().measurementUnits),
+          )
+        },
+      scaleLabel = strings.resolve(Res.string.scale),
+    )
+  }
 
   /**
    * Allows Unicode letters, digits, combining marks, hyphens, and underscores while rejecting

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/model/SubmissionPdfDocument.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/model/SubmissionPdfDocument.kt
@@ -15,6 +15,9 @@
  */
 package org.groundplatform.feature.pdf.model
 
+import org.groundplatform.domain.model.geometry.Geometry
+import org.groundplatform.domain.model.job.Style
+
 /**
  * UI model for a submission PDF. Each property corresponds to a distinct visual section so that
  * platform renderers (Android, iOS) can lay them out independently:
@@ -24,6 +27,7 @@ data class SubmissionPdfDocument(
   val qrBlock: QrBlock,
   val footer: Footer,
   val table: Table,
+  val mapBlock: MapBlock?,
 ) {
 
   data class Header(
@@ -51,6 +55,15 @@ data class SubmissionPdfDocument(
     val dataCollectorName: String,
     val userEmail: String,
   )
+
+  data class MapBlock(
+    val geometry: Geometry,
+    val style: Style?,
+    val area: Area?,
+    val scaleLabel: String,
+  )
+
+  data class Area(val label: String, val value: String?)
 
   /** The distinct, non-empty photo filenames referenced by the document's table rows. */
   fun photoFilenames(): Set<String> =

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/LoiReportExporterTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/LoiReportExporterTest.kt
@@ -20,12 +20,14 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import org.groundplatform.domain.usecases.user.GetUserSettingsUseCase
 import org.groundplatform.feature.pdf.helpers.FakeDateFormatter
 import org.groundplatform.feature.pdf.helpers.FakePdfExportService
 import org.groundplatform.feature.pdf.helpers.FakeStringResolver
 import org.groundplatform.feature.pdf.mapper.LoiReportMapper
 import org.groundplatform.feature.pdf.mapper.TaskValueMapper
 import org.groundplatform.testing.FakeDataGenerator
+import org.groundplatform.testing.FakeUserRepository
 import org.groundplatform.ui.components.loireport.LoiReportAction
 
 class LoiReportExporterTest {
@@ -36,6 +38,7 @@ class LoiReportExporterTest {
         TaskValueMapper(strings = FakeStringResolver, dateFormatter = FakeDateFormatter),
       strings = FakeStringResolver,
       dateFormatter = FakeDateFormatter,
+      getUserSettings = GetUserSettingsUseCase(FakeUserRepository()),
     )
 
   @Test

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/PdfExportServiceTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/PdfExportServiceTest.kt
@@ -121,6 +121,7 @@ class PdfExportServiceTest {
             loiName = "Loi",
             rows = emptyList(),
           ),
+        mapBlock = null,
       )
 
     val request =

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapperTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapperTest.kt
@@ -19,12 +19,22 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
+import org.groundplatform.domain.model.geometry.Coordinates
+import org.groundplatform.domain.model.geometry.LinearRing
+import org.groundplatform.domain.model.geometry.Point
+import org.groundplatform.domain.model.geometry.Polygon
+import org.groundplatform.domain.model.job.Style
 import org.groundplatform.domain.model.locationofinterest.AuditInfo
+import org.groundplatform.domain.model.settings.MeasurementUnits
+import org.groundplatform.domain.usecases.user.GetUserSettingsUseCase
 import org.groundplatform.feature.pdf.helpers.FakeDateFormatter
 import org.groundplatform.feature.pdf.helpers.FakeStringResolver
 import org.groundplatform.testing.FakeDataGenerator
+import org.groundplatform.testing.FakeUserRepository
 
 class LoiReportMapperTest {
+
+  private val userRepository = FakeUserRepository()
 
   private val mapper =
     LoiReportMapper(
@@ -32,15 +42,8 @@ class LoiReportMapperTest {
         TaskValueMapper(strings = FakeStringResolver, dateFormatter = FakeDateFormatter),
       strings = FakeStringResolver,
       dateFormatter = FakeDateFormatter,
+      getUserSettings = GetUserSettingsUseCase(userRepository),
     )
-
-  /** Submission with a fixed last-modified timestamp so date assertions are deterministic. */
-  private val submission =
-    FakeDataGenerator.newSubmission(
-      lastModified = AuditInfo(FakeDataGenerator.newUser(), clientTimestamp = 0L)
-    )
-
-  private val timestampSegment = "DATE0_TIME0"
 
   @Test
   fun `file name joins survey loi user and timestamp with underscores`() = runTest {
@@ -55,7 +58,7 @@ class LoiReportMapperTest {
         submission = submission,
       )
 
-    assertEquals("Survey_Loi_User_$timestampSegment", request!!.fileName)
+    assertEquals("Survey_Loi_User_$TEST_TIMESTAMP", request!!.fileName)
   }
 
   @Test
@@ -74,7 +77,7 @@ class LoiReportMapperTest {
         submission = submission,
       )
 
-    assertEquals("MySurvey_loiname_useremailcom_$timestampSegment", request!!.fileName)
+    assertEquals("MySurvey_loiname_useremailcom_$TEST_TIMESTAMP", request!!.fileName)
   }
 
   @Test
@@ -90,7 +93,7 @@ class LoiReportMapperTest {
         submission = submission,
       )
 
-    assertEquals("loi_$timestampSegment", request!!.fileName)
+    assertEquals("loi_$TEST_TIMESTAMP", request!!.fileName)
   }
 
   @Test
@@ -106,7 +109,7 @@ class LoiReportMapperTest {
         submission = submission,
       )
 
-    assertEquals("แบบสำรวจ_ເພີ່ມຈຸດສຳຫຼວດ_テスト_$timestampSegment", request!!.fileName)
+    assertEquals("แบบสำรวจ_ເພີ່ມຈຸດສຳຫຼວດ_テスト_$TEST_TIMESTAMP", request!!.fileName)
   }
 
   @Test
@@ -125,7 +128,7 @@ class LoiReportMapperTest {
         submission = submission,
       )
 
-    assertEquals("CaféSãoJosé_ß_Test_$timestampSegment", request!!.fileName)
+    assertEquals("CaféSãoJosé_ß_Test_$TEST_TIMESTAMP", request!!.fileName)
   }
 
   @Test
@@ -164,9 +167,79 @@ class LoiReportMapperTest {
   }
 
   @Test
-  fun `map returns null when submissionDetails are missing`() = runTest {
+  fun `mapper returns null when submissionDetails are missing`() = runTest {
     val report = FakeDataGenerator.newLoiReport(submissionDetails = null)
 
     assertNull(mapper.map(report, submission))
+  }
+
+  @Test
+  fun `mapBlock contains the labels, geometry, style, and the area formatted in the user's metric units`() =
+    runTest {
+      val style = Style("#00FF00")
+      val report =
+        FakeDataGenerator.newLoiReport(
+          submissionDetails =
+            FakeDataGenerator.newSubmissionDetails(geometry = SQUARE_POLYGON, style = style)
+        )
+      userRepository.currentUserSettings =
+        FakeDataGenerator.newUserSettings(measurementUnits = MeasurementUnits.METRIC)
+
+      val mapBlock = mapper.map(report, submission)!!.document.mapBlock!!
+
+      assertEquals(SQUARE_POLYGON, mapBlock.geometry)
+      assertEquals(style, mapBlock.style)
+      assertEquals("scale", mapBlock.scaleLabel)
+      val area = mapBlock.area!!
+      assertEquals("area", area.label)
+      assertEquals("1.00 ha", area.value)
+    }
+
+  @Test
+  fun `mapBlock area is formatted in the user's imperial units`() = runTest {
+    val report =
+      FakeDataGenerator.newLoiReport(
+        submissionDetails = FakeDataGenerator.newSubmissionDetails(geometry = SQUARE_POLYGON)
+      )
+    userRepository.currentUserSettings =
+      FakeDataGenerator.newUserSettings(measurementUnits = MeasurementUnits.IMPERIAL)
+
+    val mapBlock = mapper.map(report, submission)!!.document.mapBlock!!
+
+    assertEquals("2.48 ac", mapBlock.area!!.value)
+  }
+
+  @Test
+  fun `mapBlock has no area when the geometry is not a polygon`() = runTest {
+    val report =
+      FakeDataGenerator.newLoiReport(
+        submissionDetails =
+          FakeDataGenerator.newSubmissionDetails(geometry = Point(Coordinates(0.0, 0.0)))
+      )
+
+    val mapBlock = mapper.map(report, submission)!!.document.mapBlock
+
+    assertNull(mapBlock?.area)
+  }
+
+  private companion object {
+    val SQUARE_POLYGON =
+      Polygon(
+        LinearRing(
+          listOf(
+            Coordinates(0.0, 0.0),
+            Coordinates(0.0, 0.0009),
+            Coordinates(0.0009, 0.0009),
+            Coordinates(0.0009, 0.0),
+            Coordinates(0.0, 0.0),
+          )
+        )
+      )
+    const val TEST_TIMESTAMP = "DATE0_TIME0"
+    /** Submission with a fixed last-modified timestamp so date assertions are deterministic. */
+    val submission =
+      FakeDataGenerator.newSubmission(
+        lastModified = AuditInfo(FakeDataGenerator.newUser(), clientTimestamp = 0L)
+      )
   }
 }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #3839 

This PR focuses on updating domain models to prepare for including a map with the polygon drawn on it in the PDF report:
- `LoiReport` now carries the geometry and the style, so that the polygon can be included in a similar style as the one defined by the job
- `SubmissionPdfDocument` contains a new mapBlock which has all the needed information to be able to render the new component later
- New strings for the area and scale were added

There are no behavior changes in this PR, but the new logic is covered by unit tests.

@shobhitagarwal1612  PTAL?
