### PR TITLE
Fix missing placeholder in string

### DIFF
--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -186,7 +186,7 @@
   <string name="polygon_vertex_add_dialog_positive_button">យល់ព្រម</string>
   <string name="clear">សម្អាត</string>
   <string name="text_task_data_character_limit">អតិបរមា 255 តួអក្សរ</string>
-  <string name="area_message">ផ្ទៃក្រឡា៖</string>
+  <string name="area_message">ផ្ទៃក្រឡា៖ %s</string>
   <string name="access_restricted">មានការកំណត់</string>
   <string name="access_unlisted">មិនមានក្នុងបញ្ជី</string>
   <string name="access_public">ជាសាធារណៈ</string>

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -47,6 +47,7 @@
   <issue id="RtlHardcoded" severity="error" />
   <issue id="SetTextI18n" severity="error" />
   <issue id="SpUsage" severity="error" />
+  <issue id="StringFormatCount" severity="error" />
   <issue id="TypographyEllipsis" severity="error" />
   <issue id="TypographyQuotes" severity="error" />
   <issue id="Typos" severity="error" />


### PR DESCRIPTION
The translation for the `area_message` in Khmer was missing the placeholder. This PR adds it and a lint rule to prevent this cases in the future.

@shobhitagarwal1612  PTAL?
