### PR TITLE
Fix survey title in sync status

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/syncstatus/SyncStatusViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/syncstatus/SyncStatusViewModel.kt
@@ -81,7 +81,7 @@ internal constructor(
             status = status,
             label = locationOfInterestHelper.getJobName(loi) ?: "",
             subtitle = locationOfInterestHelper.getDisplayLoiName(loi),
-            description = surveyRepository.getOfflineSurvey(mutation.surveyId)?.description ?: "",
+            description = surveyRepository.getOfflineSurvey(mutation.surveyId)?.title ?: "",
           )
         }
       }

--- a/app/src/test/java/org/groundplatform/android/ui/syncstatus/SyncStatusFragmentTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/syncstatus/SyncStatusFragmentTest.kt
@@ -91,7 +91,8 @@ class SyncStatusFragmentTest : BaseHiltTest() {
     composeTestRule.onNodeWithTag("sync list").assertIsDisplayed()
     composeTestRule.onNodeWithText("Job • Test LOI Name").assertIsDisplayed()
     composeTestRule.onNodeWithText("Pending").assertIsDisplayed() // Status
-    composeTestRule.onNodeWithText("Test survey description").assertIsDisplayed() // Description
+    composeTestRule.onNodeWithText("Survey title").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Test survey description").assertDoesNotExist()
   }
 
   @Test


### PR DESCRIPTION
Fixes #3762

- [x] Display the survey title for location-of-interest rows in the sync status screen.
- [x] Keep submission-row presentation unchanged to avoid duplicating the title.
- [x] Update the existing Sync Status regression test to verify the title is shown and the description is absent.

## Verification

- `./gradlew :app:testLocalDebugUnitTest --tests 'org.groundplatform.android.ui.syncstatus.SyncStatusFragmentTest'`
- `python3 .agent/skills/verify_changes/scripts/verify.py`
- `./gradlew checkCode`
- `./gradlew assembleLocalDebug`
- `git diff --check`

## Limitations

- The updated screen was not launched on an emulator or physical device; the behavior is covered by the existing Hilt/Robolectric fragment test.
