### PR TITLE
Fix instrumented tests failing on forks after checkout v7 update

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -21,7 +21,7 @@
 # Same-repo PRs are routed via pull_request (head's workflow file applies);
 # fork PRs are routed via pull_request_target (base's workflow file applies,
 # secrets gated by the e2e-approval environment in test-e2e.yml).
-name: CI
+name: E2E Dispatch
 
 on:
   pull_request:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -59,6 +59,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          # Safe because this job only runs after maintainer approval.
+          allow-unsafe-pr-checkout: true
 
       - name: Run Android tests on e2eTest module
         uses: ./.github/actions/submit-test

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          # Safe because this job only runs after maintainer approval.
+          # Gated by the request-approval job (environment: e2e-approval) before fork code runs.
           allow-unsafe-pr-checkout: true
 
       - name: Run Android tests on e2eTest module


### PR DESCRIPTION
`actions/checkout` v7 added a runtime guard that refuses to check out fork PR code when the triggering event is `pull_request_target`. That blocks checking out code from fork pull requests in our integration tests workflow. 

This PR adds `allow-unsafe-pr-checkout: true` to re-enable it, which should be safe as fork PRs integration tests still only run after manual approval.

@shobhitagarwal1612 @gino-m PTAL?
