### PR TITLE
Add overlay components for the PDF map 

### DIFF
--- a/core/ui/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-es/strings.xml
@@ -35,5 +35,4 @@
   <string name="pdf_data_collector">Recolector de datos</string>
   <string name="retry">Reintentar</string>
   <string name="area">Área</string>
-  <string name="scale">Escala</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-fr/strings.xml
@@ -34,5 +34,4 @@
   <string name="pdf_data_collector">Collecteur de données</string>
   <string name="retry">Réessayer</string>
   <string name="area">Surface</string>
-  <string name="scale">Échelle</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-km/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-km/strings.xml
@@ -34,5 +34,4 @@
   <string name="pdf_data_collector">អ្នកប្រមូលទិន្នន័យ</string>
   <string name="retry">ព្យាយាមឡើងវិញ</string>
   <string name="area">ផ្ទៃក្រឡា</string>
-  <string name="scale">មាត្រដ្ឋាន</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-lo/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-lo/strings.xml
@@ -34,5 +34,4 @@
   <string name="pdf_data_collector">ຜູ້ເກັບຂໍ້ມູນ</string>
   <string name="retry">ລອງໃໝ່</string>
   <string name="area">ພື້ນທີ່</string>
-  <string name="scale">ມາດຕາສ່ວນ</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-pt/strings.xml
@@ -35,5 +35,4 @@
   <string name="pdf_data_collector">Coletor de dados</string>
   <string name="retry">Tentar novamente</string>
   <string name="area">Área</string>
-  <string name="scale">Escala</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-th/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-th/strings.xml
@@ -34,5 +34,4 @@
   <string name="pdf_data_collector">ผู้เก็บข้อมูล</string>
   <string name="retry">ลองใหม่</string>
   <string name="area">พื้นที่</string>
-  <string name="scale">มาตราส่วน</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values-vi/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-vi/strings.xml
@@ -34,5 +34,4 @@
   <string name="pdf_data_collector">Người thu thập dữ liệu</string>
   <string name="retry">Thử lại</string>
   <string name="area">Diện tích</string>
-  <string name="scale">Tỷ lệ</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -35,5 +35,4 @@
   <string name="pdf_data_collector">Data collector</string>
   <string name="retry">Retry</string>
   <string name="area">Area</string>
-  <string name="scale">Scale</string>
 </resources>

--- a/feature/pdf/src/androidHostTest/kotlin/org/groundplatform/feature/pdf/render/DocumentPdfCanvasTest.kt
+++ b/feature/pdf/src/androidHostTest/kotlin/org/groundplatform/feature/pdf/render/DocumentPdfCanvasTest.kt
@@ -54,4 +54,24 @@ class DocumentPdfCanvasTest {
   fun `finishPage with no page open does nothing`() {
     canvas.finishPage()
   }
+
+  @Test
+  fun `drawMapOverlay before a page is started fails`() {
+    assertFailsWith<IllegalStateException> {
+      canvas.drawMapOverlay(COMPASS_OVERLAY, darkBasemap = false)
+    }
+    assertFailsWith<IllegalStateException> {
+      canvas.drawMapOverlay(LINE_OVERLAY, darkBasemap = false)
+    }
+    assertFailsWith<IllegalStateException> {
+      canvas.drawMapOverlay(TEXT_OVERLAY, darkBasemap = false)
+    }
+  }
+
+  private companion object {
+    val COMPASS_OVERLAY =
+      MapOverlay.Polygon(listOf(PdfOffset(0f, 0f), PdfOffset(10f, 0f), PdfOffset(5f, 10f)))
+    val LINE_OVERLAY = MapOverlay.Line(PdfLine(0f, 0f, 10f, 0f))
+    val TEXT_OVERLAY = MapOverlay.Text("N", boxWidth = 50, offset = PdfOffset(0f, 0f))
+  }
 }

--- a/feature/pdf/src/androidHostTest/kotlin/org/groundplatform/feature/pdf/render/FakePdfCanvas.kt
+++ b/feature/pdf/src/androidHostTest/kotlin/org/groundplatform/feature/pdf/render/FakePdfCanvas.kt
@@ -25,6 +25,7 @@ internal class FakePdfCanvas : PdfCanvas {
   val drawnText = mutableListOf<String>()
   val drawnImages = mutableListOf<PdfImage>()
   val drawnLines = mutableListOf<PdfLine>()
+  val drawnOverlays = mutableListOf<Pair<MapOverlay, Boolean>>()
 
   override fun startPage(pageNumber: Int) {
     startedPages += pageNumber
@@ -44,5 +45,9 @@ internal class FakePdfCanvas : PdfCanvas {
 
   override fun drawLine(x1: Float, y1: Float, x2: Float, y2: Float) {
     drawnLines += PdfLine(x1, y1, x2, y2)
+  }
+
+  override fun drawMapOverlay(overlay: MapOverlay, darkBasemap: Boolean) {
+    drawnOverlays += overlay to darkBasemap
   }
 }

--- a/feature/pdf/src/androidMain/kotlin/org/groundplatform/feature/pdf/render/DocumentPdfCanvas.kt
+++ b/feature/pdf/src/androidMain/kotlin/org/groundplatform/feature/pdf/render/DocumentPdfCanvas.kt
@@ -16,11 +16,16 @@
 package org.groundplatform.feature.pdf.render
 
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.RectF
 import android.graphics.pdf.PdfDocument
+import android.text.Layout
 import android.text.StaticLayout
 import androidx.core.graphics.withTranslation
+import org.groundplatform.feature.pdf.render.PdfConfig.LINE_SPACING
+import org.groundplatform.feature.pdf.render.PdfConfig.OVERLAY_LINE_WIDTH
 import org.groundplatform.feature.pdf.render.image.PdfImage
 import org.groundplatform.feature.pdf.render.layout.TableLayout
 
@@ -44,6 +49,21 @@ internal class DocumentPdfCanvas(private val pdf: PdfDocument) : PdfCanvas {
       isAntiAlias = true
       isDither = true
     }
+
+  private val mapOverlayFillPaint =
+    Paint().apply {
+      style = Paint.Style.FILL
+      isAntiAlias = true
+    }
+
+  private val mapOverlayLinePaint =
+    Paint().apply {
+      style = Paint.Style.STROKE
+      strokeWidth = OVERLAY_LINE_WIDTH
+      isAntiAlias = true
+    }
+
+  private val mapOverlayTextPaint = PdfTextPaints().mapOverlay
 
   override fun startPage(pageNumber: Int) {
     val info =
@@ -69,4 +89,40 @@ internal class DocumentPdfCanvas(private val pdf: PdfDocument) : PdfCanvas {
   }
 
   private fun canvas(): Canvas = currentPage?.canvas ?: error("draw called with no page open")
+
+  override fun drawMapOverlay(overlay: MapOverlay, darkBasemap: Boolean) {
+    val ink = if (darkBasemap) Color.WHITE else Color.BLACK
+    when (overlay) {
+      is MapOverlay.Polygon -> fillOverlayPolygon(overlay.points, ink)
+      is MapOverlay.Line -> drawOverlayLine(overlay.line, ink)
+      is MapOverlay.Text -> drawOverlayText(overlay.text, overlay.boxWidth, overlay.offset, ink)
+    }
+  }
+
+  private fun fillOverlayPolygon(points: List<PdfOffset>, ink: Int) {
+    mapOverlayFillPaint.color = ink
+    val path =
+      Path().apply {
+        points.forEachIndexed { index, point ->
+          if (index == 0) moveTo(point.x, point.y) else lineTo(point.x, point.y)
+        }
+        close()
+      }
+    canvas().drawPath(path, mapOverlayFillPaint)
+  }
+
+  private fun drawOverlayLine(line: PdfLine, ink: Int) {
+    mapOverlayLinePaint.color = ink
+    canvas().drawLine(line.startX, line.startY, line.endX, line.endY, mapOverlayLinePaint)
+  }
+
+  private fun drawOverlayText(text: String, boxWidth: Int, offset: PdfOffset, ink: Int) {
+    mapOverlayTextPaint.color = ink
+    val layout =
+      StaticLayout.Builder.obtain(text, 0, text.length, mapOverlayTextPaint, boxWidth)
+        .setAlignment(Layout.Alignment.ALIGN_CENTER)
+        .setLineSpacing(LINE_SPACING, 1f)
+        .build()
+    drawStaticLayout(layout = layout, x = offset.x, y = offset.y)
+  }
 }

--- a/feature/pdf/src/androidMain/kotlin/org/groundplatform/feature/pdf/render/PdfCanvas.kt
+++ b/feature/pdf/src/androidMain/kotlin/org/groundplatform/feature/pdf/render/PdfCanvas.kt
@@ -30,6 +30,8 @@ internal interface PdfCanvas {
   fun drawImage(image: PdfImage, frame: RectF, smoothScaling: Boolean)
 
   fun drawLine(x1: Float, y1: Float, x2: Float, y2: Float)
+
+  fun drawMapOverlay(overlay: MapOverlay, darkBasemap: Boolean)
 }
 
 /** Used during the page-counting phase. Drops every drawing call. */
@@ -43,4 +45,6 @@ internal object MeasurementPdfCanvas : PdfCanvas {
   override fun drawImage(image: PdfImage, frame: RectF, smoothScaling: Boolean) = Unit
 
   override fun drawLine(x1: Float, y1: Float, x2: Float, y2: Float) = Unit
+
+  override fun drawMapOverlay(overlay: MapOverlay, darkBasemap: Boolean) = Unit
 }

--- a/feature/pdf/src/androidMain/kotlin/org/groundplatform/feature/pdf/render/PdfTextPaints.kt
+++ b/feature/pdf/src/androidMain/kotlin/org/groundplatform/feature/pdf/render/PdfTextPaints.kt
@@ -28,6 +28,7 @@ internal class PdfTextPaints {
   val metaLabel: TextPaint = textPaint(CAPTION_SIZE, bold = true, textColor = Color.GRAY)
   val meta: TextPaint = textPaint(CAPTION_SIZE, bold = false, textColor = Color.GRAY)
   val caption: TextPaint = textPaint(CAPTION_SIZE, bold = false)
+  val mapOverlay: TextPaint = textPaint(CAPTION_SIZE, bold = true, textColor = Color.WHITE)
 
   private fun textPaint(size: Float, bold: Boolean, textColor: Int = Color.BLACK): TextPaint =
     TextPaint().apply {

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapper.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapper.kt
@@ -19,7 +19,6 @@ import ground_android.core.ui.generated.resources.Res
 import ground_android.core.ui.generated.resources.area
 import ground_android.core.ui.generated.resources.job
 import ground_android.core.ui.generated.resources.pdf_data_collector
-import ground_android.core.ui.generated.resources.scale
 import ground_android.core.ui.generated.resources.scan_this_qr_to_download_geojson
 import ground_android.core.ui.generated.resources.submission
 import ground_android.core.ui.generated.resources.survey
@@ -130,7 +129,6 @@ class LoiReportMapper(
             value = getFormattedArea(areaInSquareMeters, getUserSettings().measurementUnits),
           )
         },
-      scaleLabel = strings.resolve(Res.string.scale),
     )
   }
 

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/model/SubmissionPdfDocument.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/model/SubmissionPdfDocument.kt
@@ -60,7 +60,6 @@ data class SubmissionPdfDocument(
     val geometry: Geometry,
     val style: Style?,
     val area: Area?,
-    val scaleLabel: String,
   )
 
   data class Area(val label: String, val value: String?)

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/model/SubmissionPdfDocument.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/model/SubmissionPdfDocument.kt
@@ -20,7 +20,7 @@ import org.groundplatform.domain.model.job.Style
 
 /**
  * UI model for a submission PDF. Each property corresponds to a distinct visual section so that
- * platform renderers (Android, iOS) can lay them out independently:
+ * platform renderers (Android, iOS) can lay them out independently.
  */
 data class SubmissionPdfDocument(
   val header: Header,
@@ -56,11 +56,7 @@ data class SubmissionPdfDocument(
     val userEmail: String,
   )
 
-  data class MapBlock(
-    val geometry: Geometry,
-    val style: Style?,
-    val area: Area?,
-  )
+  data class MapBlock(val geometry: Geometry, val style: Style?, val area: Area?)
 
   data class Area(val label: String, val value: String?)
 

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/MapOverlay.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/MapOverlay.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.feature.pdf.render
+
+internal sealed interface MapOverlay {
+  /** A filled polygon, such as the north arrow's triangle. */
+  data class Polygon(val points: List<PdfOffset>) : MapOverlay
+
+  /** A stroked line, such as the scale bar. */
+  data class Line(val line: PdfLine) : MapOverlay
+
+  /** [text] laid out centered within [boxWidth] points, its top-left corner at [offset]. */
+  data class Text(val text: String, val boxWidth: Int, val offset: PdfOffset) : MapOverlay
+}

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/PdfConfig.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/PdfConfig.kt
@@ -48,4 +48,7 @@ internal object PdfConfig {
 
   /** Resolution in dots-per-inch used when rasterizing images for the PDF. */
   const val IMAGE_RENDER_DPI = 300f
+
+  /** Thickness of the lines in drawn map overlays. */
+  const val OVERLAY_LINE_WIDTH = 1.5f
 }

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/layout/map/NorthArrowLayout.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/layout/map/NorthArrowLayout.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.feature.pdf.render.layout.map
+
+import org.groundplatform.feature.pdf.render.PdfOffset
+import org.groundplatform.feature.pdf.render.PdfRect
+
+/**
+ * Pre-computed layout for the north arrow overlaid on the map snapshot: an "N" label above a solid
+ * arrow, at the image's top-right corner. The snapshots are always captured north-up, so the arrow
+ * direction is fixed.
+ *
+ * @param labelOffset Top-left position of the "N" label, laid out centered within [LABEL_WIDTH].
+ * @param arrow The arrow triangle, listed clockwise from the tip: tip, right base corner, left base
+ *   corner.
+ */
+internal data class NorthArrowLayout(val labelOffset: PdfOffset, val arrow: List<PdfOffset>) {
+  companion object {
+    const val LABEL = "N"
+    const val LABEL_WIDTH = 14
+    const val ARROW_WIDTH = 11f
+    const val ARROW_HEIGHT = 20f
+
+    /** Gap between the map's edges and the arrow block. */
+    const val MARGIN = 8f
+
+    /** Vertical gap between the label and the arrow's tip. */
+    const val LABEL_GAP = 1f
+
+    fun height(labelHeight: Float): Float = labelHeight + LABEL_GAP + ARROW_HEIGHT
+
+    fun compute(imageFrame: PdfRect, labelHeight: Float): NorthArrowLayout {
+      val halfWidth = ARROW_WIDTH / 2f
+      val centerX = imageFrame.right - MARGIN - halfWidth
+      val top = imageFrame.y + MARGIN
+      val tipY = top + labelHeight + LABEL_GAP
+      val baseY = tipY + ARROW_HEIGHT
+      return NorthArrowLayout(
+        labelOffset = PdfOffset(centerX - LABEL_WIDTH / 2f, top),
+        arrow =
+          listOf(
+            PdfOffset(centerX, tipY),
+            PdfOffset(centerX + halfWidth, baseY),
+            PdfOffset(centerX - halfWidth, baseY),
+          ),
+      )
+    }
+  }
+}

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/layout/map/NorthArrowLayout.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/layout/map/NorthArrowLayout.kt
@@ -40,8 +40,6 @@ internal data class NorthArrowLayout(val labelOffset: PdfOffset, val arrow: List
     /** Vertical gap between the label and the arrow's tip. */
     const val LABEL_GAP = 1f
 
-    fun height(labelHeight: Float): Float = labelHeight + LABEL_GAP + ARROW_HEIGHT
-
     fun compute(imageFrame: PdfRect, labelHeight: Float): NorthArrowLayout {
       val halfWidth = ARROW_WIDTH / 2f
       val centerX = imageFrame.right - MARGIN - halfWidth

--- a/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/layout/map/ScaleBarLayout.kt
+++ b/feature/pdf/src/commonMain/kotlin/org/groundplatform/feature/pdf/render/layout/map/ScaleBarLayout.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.feature.pdf.render.layout.map
+
+import kotlin.math.floor
+import kotlin.math.log10
+import kotlin.math.pow
+import kotlin.math.roundToLong
+import org.groundplatform.feature.pdf.render.PdfLine
+import org.groundplatform.feature.pdf.render.PdfOffset
+import org.groundplatform.feature.pdf.render.PdfRect
+
+/**
+ * Pre-computed layout for the line scale overlaid on the map snapshot: a horizontal line showing a
+ * fixed ground distance, with that distance labeled above it. It lives inside the image's
+ * bottom-right corner.
+ *
+ * @param line The scale line itself, running left to right.
+ * @param labelOffset Top-left position of the distance label, laid out centered horizontally over
+ *   the line.
+ */
+internal data class ScaleBarLayout(val line: PdfLine, val labelOffset: PdfOffset) {
+  /**
+   * A scale bar sized for one particular snapshot, before it has been placed on the page.
+   *
+   * @param lengthPoints How long the bar runs on the page.
+   * @param label The distance it spans, already formatted (e.g. "200 m").
+   */
+  data class Bar(val lengthPoints: Float, val label: String)
+
+  companion object {
+    const val MARGIN = 8f
+    const val LABEL_GAP = 1f
+    private const val MAX_WIDTH_FRACTION = 0.25f
+    private val ROUND_MULTIPLES = listOf(1.0, 2.0, 5.0)
+
+    fun measure(groundWidthMeters: Double, imageWidthPoints: Float): Bar? {
+      val metersPerPoint =
+        (groundWidthMeters / imageWidthPoints).takeIf { it.isFinite() && it > 0.0 } ?: return null
+      val distanceMeters = roundDistanceDown(imageWidthPoints * MAX_WIDTH_FRACTION * metersPerPoint)
+      return distanceMeters?.let {
+        Bar(lengthPoints = (it / metersPerPoint).toFloat(), label = formatDistance(it))
+      }
+    }
+
+    fun compute(imageFrame: PdfRect, lengthPoints: Float, labelHeight: Float): ScaleBarLayout {
+      val right = imageFrame.right - MARGIN
+      val left = right - lengthPoints
+      val y = imageFrame.bottom - MARGIN
+      return ScaleBarLayout(
+        line = PdfLine(left, y, right, y),
+        labelOffset = PdfOffset(left, y - LABEL_GAP - labelHeight),
+      )
+    }
+
+    private fun roundDistanceDown(meters: Double): Double? {
+      if (meters < 1) return null
+      val magnitude = 10.0.pow(floor(log10(meters)))
+      return ROUND_MULTIPLES.map { it * magnitude }.last { it <= meters }
+    }
+
+    private fun formatDistance(meters: Double): String =
+      if (meters >= 1000) "${(meters / 1000).roundToLong()} km" else "${meters.roundToLong()} m"
+  }
+}

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapperTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/mapper/LoiReportMapperTest.kt
@@ -189,7 +189,6 @@ class LoiReportMapperTest {
 
       assertEquals(SQUARE_POLYGON, mapBlock.geometry)
       assertEquals(style, mapBlock.style)
-      assertEquals("scale", mapBlock.scaleLabel)
       val area = mapBlock.area!!
       assertEquals("area", area.label)
       assertEquals("1.00 ha", area.value)

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/render/layout/map/NorthArrowLayoutTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/render/layout/map/NorthArrowLayoutTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.feature.pdf.render.layout.map
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.groundplatform.feature.pdf.render.PdfRect
+
+class NorthArrowLayoutTest {
+
+  @Test
+  fun `label is centered on the arrow axis, inset from the frame's top-right corner`() {
+    assertEquals(379.5f, layout.labelOffset.x)
+    assertEquals(200f, layout.labelOffset.y)
+  }
+
+  @Test
+  fun `arrow is a triangle pointing up, symmetric about the arrow axis`() {
+    val (tip, rightBase, leftBase) = layout.arrow
+
+    assertEquals(386.5f, tip.x)
+    assertEquals(210f, tip.y)
+    assertEquals(392f, rightBase.x)
+    assertEquals(381f, leftBase.x)
+    assertEquals(230f, rightBase.y)
+    assertEquals(230f, leftBase.y)
+  }
+
+  @Test
+  fun `the whole arrow block stays inside the plot image`() {
+    val points = layout.arrow + layout.labelOffset
+
+    assertTrue(points.all { it.x >= frame.x && it.x <= frame.right })
+    assertTrue(points.all { it.y >= frame.y && it.y <= frame.bottom })
+    assertTrue(layout.labelOffset.x + NorthArrowLayout.LABEL_WIDTH <= frame.right)
+  }
+
+  @Test
+  fun `height covers the label, gap, and arrow`() {
+    val top = layout.labelOffset.y
+    val bottom = layout.arrow.maxOf { it.y }
+
+    assertEquals(NorthArrowLayout.height(LABEL_HEIGHT), bottom - top)
+  }
+
+  private companion object {
+    const val LABEL_HEIGHT = 9f
+    private val frame = PdfRect(x = 100f, y = 192f, width = 300f, height = 300f)
+    private val layout = NorthArrowLayout.compute(frame, LABEL_HEIGHT)
+  }
+}

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/render/layout/map/NorthArrowLayoutTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/render/layout/map/NorthArrowLayoutTest.kt
@@ -49,14 +49,6 @@ class NorthArrowLayoutTest {
     assertTrue(layout.labelOffset.x + NorthArrowLayout.LABEL_WIDTH <= frame.right)
   }
 
-  @Test
-  fun `height covers the label, gap, and arrow`() {
-    val top = layout.labelOffset.y
-    val bottom = layout.arrow.maxOf { it.y }
-
-    assertEquals(NorthArrowLayout.height(LABEL_HEIGHT), bottom - top)
-  }
-
   private companion object {
     const val LABEL_HEIGHT = 9f
     private val frame = PdfRect(x = 100f, y = 192f, width = 300f, height = 300f)

--- a/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/render/layout/map/ScaleBarLayoutTest.kt
+++ b/feature/pdf/src/commonTest/kotlin/org/groundplatform/feature/pdf/render/layout/map/ScaleBarLayoutTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.feature.pdf.render.layout.map
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.groundplatform.feature.pdf.render.PdfRect
+
+class ScaleBarLayoutTest {
+
+  @Test
+  fun `line is horizontal and spans the given width`() {
+    assertEquals(layout.line.startY, layout.line.endY)
+    assertEquals(BAR_WIDTH, layout.line.endX - layout.line.startX)
+  }
+
+  @Test
+  fun `line is inset from the frame's bottom-right corner`() {
+    assertEquals(332f, layout.line.startX)
+    assertEquals(392f, layout.line.endX)
+    assertEquals(492f, layout.line.endY)
+  }
+
+  @Test
+  fun `label sits directly above the line, aligned with its left end`() {
+    assertEquals(332f, layout.labelOffset.x)
+    assertEquals(481f, layout.labelOffset.y)
+  }
+
+  @Test
+  fun `the whole line scale block stays inside the plot image`() {
+    assertTrue(layout.labelOffset.y >= frame.y)
+    assertTrue(layout.line.startX >= frame.x)
+    assertTrue(layout.line.endX <= frame.right)
+    assertTrue(layout.line.endY <= frame.bottom)
+  }
+
+  @Test
+  fun `measure picks a round distance that exactly fills the quarter-width a bar may occupy`() {
+    // 400 m over 400 points is 1 m per point, so the 100-point quarter is exactly 100 m.
+    val bar = ScaleBarLayout.measure(groundWidthMeters = 400.0, imageWidthPoints = 400f)
+
+    assertEquals("100 m", bar?.label)
+    assertEquals(100f, bar?.lengthPoints)
+  }
+
+  @Test
+  fun `measure rounds the distance down so the bar fits within that quarter`() {
+    // 1 m per point again, but 170 points to play with: 100 m is the longest round distance
+    // fitting.
+    val bar = ScaleBarLayout.measure(groundWidthMeters = 680.0, imageWidthPoints = 680f)
+
+    assertEquals("100 m", bar?.label)
+    assertEquals(100f, bar?.lengthPoints)
+  }
+
+  @Test
+  fun `measure uses the 2 and 5 steps between powers of ten`() {
+    // 1 m per point over a 250-point quarter rounds to 200 m; 2.4 m per point over the same
+    // quarter gives 600 m of room, which rounds to 500 m.
+    assertEquals(
+      "200 m",
+      ScaleBarLayout.measure(groundWidthMeters = 1000.0, imageWidthPoints = 1000f)?.label,
+    )
+    assertEquals(
+      "500 m",
+      ScaleBarLayout.measure(groundWidthMeters = 2400.0, imageWidthPoints = 1000f)?.label,
+    )
+  }
+
+  @Test
+  fun `measure labels distances of a kilometre and up in kilometres`() {
+    // 10 m per point over a 250-point quarter: 2000 m fits and reads as "2 km".
+    val bar = ScaleBarLayout.measure(groundWidthMeters = 10_000.0, imageWidthPoints = 1000f)
+
+    assertEquals("2 km", bar?.label)
+    assertEquals(200f, bar?.lengthPoints)
+  }
+
+  @Test
+  fun `measure never returns a bar wider than a quarter of the image`() {
+    val imageWidth = 515f
+    val groundWidths = listOf(40.0, 137.0, 999.0, 5_000.0, 87_000.0)
+
+    groundWidths.forEach { groundWidth ->
+      val bar = ScaleBarLayout.measure(groundWidth, imageWidth)
+
+      assertTrue(bar != null && bar.lengthPoints <= imageWidth / 4f, "overran for $groundWidth m")
+    }
+  }
+
+  @Test
+  fun `measure returns null for non-positive inputs`() {
+    assertNull(ScaleBarLayout.measure(groundWidthMeters = 0.0, imageWidthPoints = 400f))
+    assertNull(ScaleBarLayout.measure(groundWidthMeters = 400.0, imageWidthPoints = 0f))
+  }
+
+  private companion object {
+    val frame = PdfRect(x = 100f, y = 200f, width = 300f, height = 300f)
+    const val BAR_WIDTH = 60f
+    const val LABEL_HEIGHT = 10f
+
+    val layout = ScaleBarLayout.compute(frame, BAR_WIDTH, LABEL_HEIGHT)
+  }
+}


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #3839 

This PR introduces the overlay components for the map which will be included in the PDF report:
- `NorthArrowLayout`: a triangle with a 'N' label, to be displayed on the map top right corner
- `ScaleBarLayout`: a scale bar with a distance displayed centered above. The `scaleLabel` which was introduced in a previous PR has been removed from the `MapBlock` as it's not needed since the chosen approach is to display the scale as a bar in the map snapshot
- Added to `PdfCanvas` the `drawMapOverlay` method to draw the new components

@shobhitagarwal1612 PTAL?
