### PR TITLE
fix: show add LOI button when zoomed out

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/home/mapcontainer/HomeScreenMapContainerViewModel.kt
@@ -130,10 +130,7 @@ internal constructor(
   /** [Feature] clicked by the user. */
   val featureClicked: MutableStateFlow<Feature?> = MutableStateFlow(null)
 
-  /**
-   * List of [Job]s which allow LOIs to be added during field collection, populated only when zoomed
-   * in far enough.
-   */
+  /** List of [Job]s which allow LOIs to be added during field collection. */
   private val adHocLoiJobs: Flow<List<Job>>
 
   private val showJobSelectionModal = MutableStateFlow(false)
@@ -179,8 +176,8 @@ internal constructor(
         .stateIn(viewModelScope, SharingStarted.Lazily, listOf())
 
     adHocLoiJobs =
-      activeSurvey.combine(isZoomedInFlow) { survey, isZoomedIn ->
-        if (survey == null || !isZoomedIn) listOf()
+      activeSurvey.map { survey ->
+        if (survey == null) listOf()
         else survey.jobs.filter { it.canDataCollectorsAddLois && it.getAddLoiTask() != null }
       }
 

--- a/app/src/test/java/org/groundplatform/android/ui/home/mapcontainer/HomeScreenMapContainerViewModelTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/home/mapcontainer/HomeScreenMapContainerViewModelTest.kt
@@ -35,6 +35,7 @@ import org.groundplatform.android.FakeData.LOCATION_OF_INTEREST_LOI_REPORT
 import org.groundplatform.android.FakeData.SURVEY
 import org.groundplatform.android.FakeData.USER
 import org.groundplatform.android.R
+import org.groundplatform.android.common.Constants.CLUSTERING_ZOOM_THRESHOLD
 import org.groundplatform.android.data.remote.FakeRemoteDataStore
 import org.groundplatform.android.di.LocationOfInterestRepositoryModule
 import org.groundplatform.android.system.auth.FakeAuthenticationManager
@@ -157,6 +158,20 @@ class HomeScreenMapContainerViewModelTest : BaseHiltTest() {
       val addLoiState = state as JobMapComponentState.AddLoiButton
       assertThat(addLoiState.jobs.map { it.job }).containsExactly(ADHOC_JOB)
     }
+
+  @Test
+  fun `job component state is AddLoiButton below clustering threshold`() = runWithTestDispatcher {
+    viewModel.onMapCameraMoved(
+      CAMERA_POSITION.copy(zoomLevel = CLUSTERING_ZOOM_THRESHOLD - 1f)
+    )
+    advanceUntilIdle()
+
+    val state = viewModel.processJobMapComponentState().first()
+
+    assertThat(state).isInstanceOf(JobMapComponentState.AddLoiButton::class.java)
+    assertThat((state as JobMapComponentState.AddLoiButton).jobs.map { it.job })
+      .containsExactly(ADHOC_JOB)
+  }
 
   @Test
   fun `setJobSelectionModalVisibility hides map actions when modal is shown`() =


### PR DESCRIPTION
Fixes #3553

- Keep the Add LOI FAB available regardless of map zoom level.
- Preserve zoom-dependent LOI viewport filtering and map clustering behavior.
- Add focused coverage for the below-clustering-threshold case.

## Verification

- `./gradlew checkCode`
- `./gradlew :app:ktfmtCheck :app:testLocalDebugUnitTest --tests 'org.groundplatform.android.ui.home.mapcontainer.HomeScreenMapContainerViewModelTest'`
- `git diff --check`

## Limitations

- The behavior was not visually exercised on a device; the affected ViewModel state is covered by Robolectric.
