### PR TITLE
Fix CursorWindow crash when reading LOIs during a re-sync

### DIFF
--- a/app/src/main/java/org/groundplatform/android/data/local/room/dao/LocationOfInterestDao.kt
+++ b/app/src/main/java/org/groundplatform/android/data/local/room/dao/LocationOfInterestDao.kt
@@ -17,6 +17,7 @@ package org.groundplatform.android.data.local.room.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 import org.groundplatform.android.data.local.room.entity.LocationOfInterestEntity
@@ -36,6 +37,11 @@ interface LocationOfInterestDao : BaseDao<LocationOfInterestEntity> {
   @Query("DELETE FROM location_of_interest WHERE id IN (:ids)")
   suspend fun deleteByIds(ids: List<String>)
 
+  /**
+   * Streams LOIs in the given deletion state. Runs in a transaction to ensure consistent reads
+   * across cursor windows.
+   */
+  @Transaction
   @Query(
     "SELECT * FROM location_of_interest WHERE survey_id = :surveyId AND state = :deletionState"
   )

--- a/app/src/test/java/org/groundplatform/android/data/local/LocalLocationOfInterestStoreTest.kt
+++ b/app/src/test/java/org/groundplatform/android/data/local/LocalLocationOfInterestStoreTest.kt
@@ -264,6 +264,23 @@ class LocalLocationOfInterestStoreTest : BaseHiltTest() {
     }
 
   @Test
+  fun `getValidLois streams the surviving LOIs after a bulk delete`() = runWithTestDispatcher {
+    localUserStore.insertOrUpdateUser(TEST_USER)
+    localSurveyStore.insertOrUpdateSurvey(TEST_SURVEY)
+    val ids = (1..100).map { "loi-$it" }
+    localLoiStore.insertOrUpdateAll(ids.map { testLoi(it) })
+
+    localLoiStore.getValidLois(TEST_SURVEY).test {
+      assertThat(expectMostRecentItem().map { it.id }).containsExactlyElementsIn(ids)
+
+      // Simulate a re-sync dropping most LOIs while the stream is being observed.
+      localLoiStore.deleteNotIn(TEST_SURVEY.id, listOf("loi-1"))
+
+      assertThat(expectMostRecentItem().map { it.id }).containsExactly("loi-1")
+    }
+  }
+
+  @Test
   fun `insertOrUpdate throws exception when attempting to save LOI with empty polygon coordinates`() =
     runWithTestDispatcher {
       localUserStore.insertOrUpdateUser(TEST_USER)


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Fixes #3767 

The LOIs are read from the database through a fixed size cursor window. For small surveys usually all data fits in one cursor window, but for larger surveys this needs to be done in several rounds. If, during this process, a LOI is deleted, then there is a crash since it tries to fetch a row that doesn't exist anymore. This can happen if the map is reading the LOIs from the db while a sync deletes LOIs.

This PR aims to fix that by adding a `@Transaction` notation to the `getByDeletionState` so that the whole read sees a single consisten snapshot of the db even if deletions are happening in parallel.


@shobhitagarwal1612 PTAL?
