### PR TITLE
Implement paginated queries for LOI requests to firebase

### DIFF
--- a/app/src/main/java/org/groundplatform/android/data/remote/RemoteDataStore.kt
+++ b/app/src/main/java/org/groundplatform/android/data/remote/RemoteDataStore.kt
@@ -50,15 +50,15 @@ interface RemoteDataStore {
   suspend fun loadTermsOfService(): TermsOfService?
 
   /** Returns predefined LOIs in the specified survey. Main-safe. */
-  suspend fun loadPredefinedLois(survey: Survey): List<LocationOfInterest>
+  fun loadPredefinedLois(survey: Survey): Flow<List<LocationOfInterest>>
 
   /** Returns LOIs owned by the specified user in the specified survey. Main-safe. */
-  suspend fun loadUserLois(survey: Survey, ownerUserId: String): List<LocationOfInterest>
+  fun loadUserLois(survey: Survey, ownerUserId: String): Flow<List<LocationOfInterest>>
 
   /**
    * Returns LOIs that have been marked as shared for other participants of the specified survey.
    */
-  suspend fun loadSharedLois(survey: Survey): List<LocationOfInterest>
+  fun loadSharedLois(survey: Survey): Flow<List<LocationOfInterest>>
 
   /**
    * Applies the provided mutations to the remote data store in a single batched transaction. If one

--- a/app/src/main/java/org/groundplatform/android/data/remote/firebase/FirestoreDataStore.kt
+++ b/app/src/main/java/org/groundplatform/android/data/remote/firebase/FirestoreDataStore.kt
@@ -26,17 +26,20 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import org.groundplatform.android.BuildConfig.USE_EMULATORS
 import org.groundplatform.android.data.remote.RemoteDataStore
 import org.groundplatform.android.data.remote.firebase.schema.GroundFirestore
+import org.groundplatform.android.data.remote.firebase.schema.LoiCollectionReference
 import org.groundplatform.android.di.coroutines.IoDispatcher
 import org.groundplatform.domain.model.Survey
 import org.groundplatform.domain.model.SurveyListItem
 import org.groundplatform.domain.model.TermsOfService
 import org.groundplatform.domain.model.User
+import org.groundplatform.domain.model.locationofinterest.LocationOfInterest
 import org.groundplatform.domain.model.mutation.LocationOfInterestMutation
 import org.groundplatform.domain.model.mutation.Mutation
 import org.groundplatform.domain.model.mutation.SubmissionMutation
@@ -80,16 +83,21 @@ internal constructor(
     )
   }
 
-  override suspend fun loadPredefinedLois(survey: Survey) =
-    withContext(ioDispatcher) { db().surveys().survey(survey.id).lois().fetchPredefined(survey) }
+  override fun loadPredefinedLois(survey: Survey) =
+    fetchLoiPages(survey) { fetchPredefined(survey) }
 
-  override suspend fun loadUserLois(survey: Survey, ownerUserId: String) =
-    withContext(ioDispatcher) {
-      db().surveys().survey(survey.id).lois().fetchUserDefined(survey, ownerUserId)
-    }
+  override fun loadUserLois(survey: Survey, ownerUserId: String) =
+    fetchLoiPages(survey) { fetchUserDefined(survey, ownerUserId) }
 
-  override suspend fun loadSharedLois(survey: Survey) =
-    withContext(ioDispatcher) { db().surveys().survey(survey.id).lois().fetchSharedLois(survey) }
+  override fun loadSharedLois(survey: Survey) = fetchLoiPages(survey) { fetchSharedLois(survey) }
+
+  /** Emits the pages of LOIs produced by [fetch] against the given survey's LOI collection. */
+  private fun fetchLoiPages(
+    survey: Survey,
+    fetch: LoiCollectionReference.() -> Flow<List<LocationOfInterest>>,
+  ): Flow<List<LocationOfInterest>> = flow {
+    emitAll(db().surveys().survey(survey.id).lois().fetch())
+  }.flowOn(ioDispatcher)
 
   override suspend fun subscribeToSurveyUpdates(surveyId: String) {
     if (USE_EMULATORS) return

--- a/app/src/main/java/org/groundplatform/android/data/remote/firebase/FirestoreDataStore.kt
+++ b/app/src/main/java/org/groundplatform/android/data/remote/firebase/FirestoreDataStore.kt
@@ -24,6 +24,7 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -97,7 +98,9 @@ internal constructor(
     fetch: LoiCollectionReference.() -> Flow<List<LocationOfInterest>>,
   ): Flow<List<LocationOfInterest>> = flow {
     emitAll(db().surveys().survey(survey.id).lois().fetch())
-  }.flowOn(ioDispatcher)
+  }
+    .buffer(1)
+    .flowOn(ioDispatcher)
 
   override suspend fun subscribeToSurveyUpdates(surveyId: String) {
     if (USE_EMULATORS) return

--- a/app/src/main/java/org/groundplatform/android/data/remote/firebase/schema/LoiCollectionReference.kt
+++ b/app/src/main/java/org/groundplatform/android/data/remote/firebase/schema/LoiCollectionReference.kt
@@ -16,6 +16,7 @@
 
 package org.groundplatform.android.data.remote.firebase.schema
 
+import androidx.annotation.VisibleForTesting
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldPath
@@ -42,7 +43,7 @@ const val OWNER_FIELD = LocationOfInterestProto.OWNER_ID_FIELD_NUMBER.toString()
  * Documents per query. Deliberately small since geometry complexity varies widely and is unknown
  * before fetching. Any limit bounds memory, and the cost of being small is just more round trips.
  */
-private const val PAGE_SIZE = 250
+@VisibleForTesting internal const val PAGE_SIZE = 250
 
 class LoiCollectionReference internal constructor(ref: CollectionReference) :
   FluentCollectionReference(ref) {

--- a/app/src/main/java/org/groundplatform/android/data/remote/firebase/schema/LoiCollectionReference.kt
+++ b/app/src/main/java/org/groundplatform/android/data/remote/firebase/schema/LoiCollectionReference.kt
@@ -17,8 +17,11 @@
 package org.groundplatform.android.data.remote.firebase.schema
 
 import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.Query
-import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.tasks.await
 import org.groundplatform.android.data.remote.firebase.base.FluentCollectionReference
 import org.groundplatform.android.data.remote.firebase.schema.LoiConverter.toLoi
@@ -35,13 +38,19 @@ const val SOURCE_FIELD = LocationOfInterestProto.SOURCE_FIELD_NUMBER.toString()
 /** Path of field on LOI documents representing the creator of the LOI. */
 const val OWNER_FIELD = LocationOfInterestProto.OWNER_ID_FIELD_NUMBER.toString()
 
+/**
+ * Documents per query. Deliberately small since geometry complexity varies widely and is unknown
+ * before fetching. Any limit bounds memory, and the cost of being small is just more round trips.
+ */
+private const val PAGE_SIZE = 250
+
 class LoiCollectionReference internal constructor(ref: CollectionReference) :
   FluentCollectionReference(ref) {
 
   fun loi(id: String) = LoiDocumentReference(reference().document(id))
 
-  /** Retrieves all "predefined" LOIs in the specified survey. Main-safe. */
-  suspend fun fetchPredefined(survey: Survey): List<LocationOfInterest> =
+  /** Emits all "predefined" LOIs in the specified survey, one page at a time. Main-safe. */
+  fun fetchPredefined(survey: Survey): Flow<List<LocationOfInterest>> =
     // Use !=false rather than ==true to not break legacy dev surveys.
     // TODO: Switch to whereEqualTo(true) once legacy dev surveys deleted or migrated.
     // Issue URL: https://github.com/google/ground-android/issues/2375
@@ -50,8 +59,8 @@ class LoiCollectionReference internal constructor(ref: CollectionReference) :
       reference().whereEqualTo(SOURCE_FIELD, LocationOfInterestProto.Source.IMPORTED.number),
     )
 
-  /** Retrieves LOIs created by the specified email in the specified survey. Main-safe. */
-  suspend fun fetchUserDefined(survey: Survey, ownerUserId: String): List<LocationOfInterest> =
+  /** Emits LOIs created by the specified email in the specified survey, a page at a time. */
+  fun fetchUserDefined(survey: Survey, ownerUserId: String): Flow<List<LocationOfInterest>> =
     fetchLois(
       survey,
       reference()
@@ -59,23 +68,40 @@ class LoiCollectionReference internal constructor(ref: CollectionReference) :
         .whereEqualTo(OWNER_FIELD, ownerUserId),
     )
 
-  /** Retrieves all LOIs visible to data collectors in the given survey. */
-  suspend fun fetchSharedLois(survey: Survey): List<LocationOfInterest> =
+  /** Emits all LOIs visible to data collectors in the given survey, a page at a time. */
+  fun fetchSharedLois(survey: Survey): Flow<List<LocationOfInterest>> =
     fetchLois(
       survey,
       reference().whereEqualTo(SOURCE_FIELD, LocationOfInterestProto.Source.FIELD_DATA.number),
     )
 
-  private suspend fun fetchLois(survey: Survey, query: Query): List<LocationOfInterest> =
-    try {
-      val snapshot = query.get().await()
-      snapshot.documents.mapNotNull {
-        toLoi(survey, it)
-          .onFailure { t -> Timber.e(t, "Invalid LOI ${it.id} in remote survey ${survey.id}") }
-          .getOrNull()
+  /**
+   * Emits the LOIs matching [query], a page at a time. Pages are fetched lazily, so a collector
+   * that saves each page before asking for the next never holds more than one page in memory.
+   */
+  private fun fetchLois(survey: Survey, query: Query): Flow<List<LocationOfInterest>> = flow {
+    val orderedQuery = query.orderBy(FieldPath.documentId()).limit(PAGE_SIZE.toLong())
+
+    var startAfter: String? = null
+    var hasMore: Boolean
+
+    do {
+      val pagedQuery = orderedQuery.let {
+        if (startAfter == null) it else it.startAfter(startAfter)
       }
-    } catch (e: CancellationException) {
-      Timber.i(e, "Fetching LOIs was cancelled")
-      listOf()
-    }
+      val documents = pagedQuery.get().await().documents.takeIf { it.isNotEmpty() } ?: break
+
+      emit(documents.mapNotNull { it.toLoiOrNull(survey) })
+
+      // Counted in documents fetched, not LOIs emitted: an unreadable document is dropped by the
+      // conversion above but still takes up a place in the page.
+      hasMore = documents.size == PAGE_SIZE
+      startAfter = documents.last().id
+    } while (hasMore)
+  }
+
+  private fun DocumentSnapshot.toLoiOrNull(survey: Survey): LocationOfInterest? =
+    toLoi(survey, this)
+      .onFailure { Timber.e(it, "Invalid LOI $id in remote survey ${survey.id}") }
+      .getOrNull()
 }

--- a/app/src/main/java/org/groundplatform/android/repository/LocationOfInterestRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/LocationOfInterestRepository.kt
@@ -17,9 +17,6 @@ package org.groundplatform.android.repository
 
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.firstOrNull
@@ -62,23 +59,16 @@ constructor(
   private val uuidGenerator: OfflineUuidGenerator,
   private val authenticationManager: AuthenticationManager,
 ) : LocationOfInterestRepositoryInterface {
-  override suspend fun syncLocationsOfInterest(survey: Survey) = coroutineScope {
+  override suspend fun syncLocationsOfInterest(survey: Survey) {
     val ownerUserId = authenticationManager.getAuthenticatedUser().id
 
-    val predefinedDeferred = async { remoteDataStore.loadPredefinedLois(survey) }
-    val userDeferred = async { remoteDataStore.loadUserLois(survey, ownerUserId) }
-    val sharedDeferred = async {
-      if (survey.dataVisibility == Survey.DataVisibility.ALL_SURVEY_PARTICIPANTS) {
-        remoteDataStore.loadSharedLois(survey)
-      } else {
-        emptyList()
-      }
+    // Single-page buffering. Persist immediately to avoid OOM on geometry-heavy surveys.
+    val syncedLoiIds = mutableSetOf<String>()
+    syncedLoiIds += savePages(remoteDataStore.loadPredefinedLois(survey))
+    syncedLoiIds += savePages(remoteDataStore.loadUserLois(survey, ownerUserId))
+    if (survey.dataVisibility == Survey.DataVisibility.ALL_SURVEY_PARTICIPANTS) {
+      syncedLoiIds += savePages(remoteDataStore.loadSharedLois(survey))
     }
-
-    val (predefinedLois, userLois, sharedLois) =
-      awaitAll(predefinedDeferred, userDeferred, sharedDeferred)
-
-    val allLois = predefinedLois + userLois + sharedLois
 
     val mutations = localLoiStore.getAllSurveyMutations(survey).firstOrNull().orEmpty()
 
@@ -91,27 +81,18 @@ constructor(
         .map { it.locationOfInterestId }
         .toList()
 
-    mergeAll(survey.id, allLois, pendingLois)
-  }
-
-  private suspend fun mergeAll(
-    surveyId: String,
-    lois: List<LocationOfInterest>,
-    pendingLois: List<String>,
-  ) {
-    localLoiStore.insertOrUpdateAll(lois.onEach { validateGeometry(it) })
     // Delete LOIs in local db not returned in latest list from server, skipping pending mutations.
-    localLoiStore.deleteNotIn(surveyId, lois.map { it.id } + pendingLois)
+    localLoiStore.deleteNotIn(survey.id, syncedLoiIds.toList() + pendingLois)
   }
 
-  /**
-   * Throws IllegalArgumentException if the LOI's geometry has empty coordinates, which would
-   * otherwise be persisted and later fail to render.
-   */
-  private fun validateGeometry(loi: LocationOfInterest) {
-    require(!loi.geometry.isEmpty()) {
-      "Attempted to save LOI ${loi.id} with empty geometry. LOI: $loi"
+  /** Saves each page of [pages] as it arrives, returning the ids of every LOI saved. */
+  private suspend fun savePages(pages: Flow<List<LocationOfInterest>>): Set<String> {
+    val savedIds = mutableSetOf<String>()
+    pages.collect { page ->
+      localLoiStore.insertOrUpdateAll(page)
+      savedIds += page.map { it.id }
     }
+    return savedIds
   }
 
   override suspend fun getOfflineLoi(surveyId: String, loiId: String): LocationOfInterest? {

--- a/app/src/test/java/org/groundplatform/android/data/remote/FakeRemoteDataStore.kt
+++ b/app/src/test/java/org/groundplatform/android/data/remote/FakeRemoteDataStore.kt
@@ -30,6 +30,15 @@ import org.groundplatform.domain.model.toListItem
 @Singleton
 class FakeRemoteDataStore @Inject internal constructor() : RemoteDataStore {
   var predefinedLois = emptyList<LocationOfInterest>()
+
+  /**
+   * Pages of predefined LOIs, taking precedence over [predefinedLois] when set.
+   *
+   * Lets a test drive a sync over several pages, or fail one part way through, which
+   * [predefinedLois] cannot express since it always stands for exactly one page.
+   */
+  var predefinedLoiPages: Flow<List<LocationOfInterest>>? = null
+
   var userLois = emptyList<LocationOfInterest>()
   var sharedLois = emptyList<LocationOfInterest>()
   var surveys = emptyList<Survey>()
@@ -55,7 +64,8 @@ class FakeRemoteDataStore @Inject internal constructor() : RemoteDataStore {
 
   override suspend fun loadTermsOfService(): TermsOfService? = termsOfService?.getOrThrow()
 
-  override suspend fun loadPredefinedLois(survey: Survey) = predefinedLois
+  override fun loadPredefinedLois(survey: Survey): Flow<List<LocationOfInterest>> =
+    predefinedLoiPages ?: flowOf(predefinedLois)
 
   override suspend fun applyMutations(mutations: List<Mutation>, user: User) {
     if (applyMutationError != null) {
@@ -71,10 +81,10 @@ class FakeRemoteDataStore @Inject internal constructor() : RemoteDataStore {
     userProfileRefreshCount++
   }
 
-  override suspend fun loadUserLois(survey: Survey, ownerUserId: String): List<LocationOfInterest> =
-    userLois
+  override fun loadUserLois(survey: Survey, ownerUserId: String): Flow<List<LocationOfInterest>> =
+    flowOf(userLois)
 
-  override suspend fun loadSharedLois(survey: Survey): List<LocationOfInterest> = sharedLois
+  override fun loadSharedLois(survey: Survey): Flow<List<LocationOfInterest>> = flowOf(sharedLois)
 
   /** Returns true iff [subscribeToSurveyUpdates] has been called with the specified id. */
   fun isSubscribedToSurveyUpdates(surveyId: String): Boolean =

--- a/app/src/test/java/org/groundplatform/android/data/remote/firebase/schema/LoiCollectionReferenceTest.kt
+++ b/app/src/test/java/org/groundplatform/android/data/remote/firebase/schema/LoiCollectionReferenceTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.groundplatform.android.data.remote.firebase.schema
+
+import com.google.android.gms.tasks.Tasks
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.google.protobuf.timestamp
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.groundplatform.android.FakeData.FAKE_GENERAL_ACCESS
+import org.groundplatform.android.FakeData.USER
+import org.groundplatform.android.data.remote.firebase.protobuf.toFirestoreMap
+import org.groundplatform.android.proto.LocationOfInterest.Source
+import org.groundplatform.android.proto.auditInfo
+import org.groundplatform.android.proto.coordinates
+import org.groundplatform.android.proto.geometry
+import org.groundplatform.android.proto.locationOfInterest
+import org.groundplatform.android.proto.point
+import org.groundplatform.domain.model.Survey
+import org.groundplatform.domain.model.job.Job
+import org.groundplatform.domain.model.job.Style
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Answers
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LoiCollectionReferenceTest {
+  @Mock private lateinit var mockCollectionReference: CollectionReference
+  @Mock(answer = Answers.RETURNS_SELF) private lateinit var mockQuery: Query
+
+  private lateinit var loiCollectionReference: LoiCollectionReference
+
+  // Pages the mocked query returns, in order.
+  private var pages: List<List<DocumentSnapshot>> = listOf()
+  private var pagesFetched = 0
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    whenever(mockCollectionReference.whereEqualTo(any<String>(), any())).thenReturn(mockQuery)
+    whenever(mockQuery.get()).thenAnswer {
+      val page = pages.getOrElse(pagesFetched) { listOf() }
+      pagesFetched++
+      Tasks.forResult(mock<QuerySnapshot> { on { documents } doReturn page })
+    }
+
+    loiCollectionReference = LoiCollectionReference(mockCollectionReference)
+  }
+
+  @Test
+  fun `fetch stops after a page shorter than the page size`() = runTest {
+    pages = mockPages(3)
+
+    val emitted = loiCollectionReference.fetchPredefined(SURVEY).toList()
+
+    assertThat(emitted.flatten().map { it.id }).containsExactly("loi0", "loi1", "loi2").inOrder()
+    assertThat(pagesFetched).isEqualTo(1)
+  }
+
+  @Test
+  fun `fetch keeps requesting while pages come back full`() = runTest {
+    pages = mockPages(PAGE_SIZE, PAGE_SIZE, 2)
+
+    val emitted = loiCollectionReference.fetchPredefined(SURVEY).toList()
+
+    // One emission per page, and the short third page ends it.
+    assertThat(emitted.map { it.size }).containsExactly(PAGE_SIZE, PAGE_SIZE, 2).inOrder()
+    assertThat(pagesFetched).isEqualTo(3)
+  }
+
+  @Test
+  fun `fetch resumes each page after the last document of the previous one`() = runTest {
+    pages = mockPages(PAGE_SIZE, 1)
+
+    loiCollectionReference.fetchPredefined(SURVEY).toList()
+
+    verify(mockQuery).startAfter("loi${PAGE_SIZE - 1}")
+  }
+
+  @Test
+  fun `fetch emits nothing when the collection is empty`() = runTest {
+    pages = mockPages(0)
+
+    val emitted = loiCollectionReference.fetchPredefined(SURVEY).toList()
+
+    assertThat(emitted).isEmpty()
+    assertThat(pagesFetched).isEqualTo(1)
+  }
+
+  @Test
+  fun `fetch drops unreadable documents but still counts them towards the page`() = runTest {
+    val (fullPage, lastPage) = mockPages(PAGE_SIZE, 1)
+    val brokenFirst = listOf(mockDocument("broken", jobId = "job the survey does not have"))
+    pages = listOf(brokenFirst + fullPage.drop(1), lastPage)
+
+    val emitted = loiCollectionReference.fetchPredefined(SURVEY).toList()
+
+    assertThat(emitted.first()).hasSize(PAGE_SIZE - 1)
+    assertThat(emitted.flatten().map { it.id }).doesNotContain("broken")
+    assertThat(pagesFetched).isEqualTo(2)
+  }
+
+  @Test
+  fun `fetch orders by document id and limits each page`() = runTest {
+    pages = mockPages(1)
+
+    loiCollectionReference.fetchPredefined(SURVEY).toList()
+
+    verify(mockQuery).orderBy(FieldPath.documentId())
+    verify(mockQuery).limit(PAGE_SIZE.toLong())
+  }
+
+  @Test
+  fun `fetch is lazy until collected`() = runTest {
+    pages = mockPages(1)
+
+    loiCollectionReference.fetchPredefined(SURVEY)
+
+    verify(mockQuery, never()).get()
+    assertThat(pagesFetched).isEqualTo(0)
+  }
+
+  private fun mockPages(vararg sizes: Int): List<List<DocumentSnapshot>> {
+    var next = 0
+    return sizes.map { size ->
+      (next until next + size).map { mockDocument("loi$it") }.also { next += size }
+    }
+  }
+
+  private fun mockDocument(id: String, jobId: String = JOB_ID): DocumentSnapshot {
+    val audit = auditInfo {
+      userId = USER.id
+      displayName = USER.displayName
+      photoUrl = USER.photoUrl.orEmpty()
+      clientTimestamp = timestamp { seconds = 987654321 }
+      serverTimestamp = timestamp { seconds = 987654321 }
+    }
+    val proto = locationOfInterest {
+      this.id = id
+      this.jobId = jobId
+      source = Source.IMPORTED
+      geometry = geometry {
+        point = point {
+          coordinates = coordinates {
+            latitude = 1.0
+            longitude = 2.0
+          }
+        }
+      }
+      created = audit
+      lastModified = audit
+    }
+    return mock {
+      on { this.id } doReturn id
+      on { data } doReturn proto.toFirestoreMap()
+      on { exists() } doReturn true
+    }
+  }
+
+  companion object {
+    private const val JOB_ID = "job001"
+    private val JOB = Job(JOB_ID, Style("#112233"), "JOB_NAME", mapOf())
+    private val SURVEY =
+      Survey("survey1", "", "", mapOf(JOB.id to JOB), generalAccess = FAKE_GENERAL_ACCESS)
+  }
+}

--- a/app/src/test/java/org/groundplatform/android/repository/LocationOfInterestRepositoryTest.kt
+++ b/app/src/test/java/org/groundplatform/android/repository/LocationOfInterestRepositoryTest.kt
@@ -23,6 +23,8 @@ import javax.inject.Inject
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.groundplatform.android.BaseHiltTest
 import org.groundplatform.android.FakeData
@@ -50,6 +52,9 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
+
+/** Distinguishes a deliberately failed fetch from any other error the sync might raise. */
+private class TestSyncException : RuntimeException("fetch failed")
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
@@ -135,11 +140,98 @@ class LocationOfInterestRepositoryTest : BaseHiltTest() {
     verify(mockWorkManager, times(1)).enqueueSyncWorker()
   }
 
-  // TODO: Add tests for new LOI sync once implemented (create, update, delete, error).
-  // Issue URL: https://github.com/google/ground-android/issues/1373
+  @Test
+  fun `sync saves every page of a multi page source`() = runWithTestDispatcher {
+    fakeRemoteDataStore.predefinedLoiPages =
+      flowOf(
+        listOf(TEST_POINT_OF_INTEREST_1, TEST_POINT_OF_INTEREST_2),
+        listOf(TEST_POINT_OF_INTEREST_3),
+        listOf(TEST_AREA_OF_INTEREST_1, TEST_AREA_OF_INTEREST_2),
+      )
 
-  // TODO: Add tests for getLocationsOfInterest once new LOI sync implemented.
-  // Issue URL: https://github.com/google/ground-android/issues/1373
+    locationOfInterestRepository.syncLocationsOfInterest(TEST_SURVEY)
+
+    assertThat(locationOfInterestRepository.getValidLois(TEST_SURVEY).first())
+      .containsExactlyElementsIn(TEST_LOCATIONS_OF_INTEREST)
+  }
+
+  @Test
+  fun `sync saves each page before requesting the next`() = runWithTestDispatcher {
+    localLoiStore.deleteNotIn(TEST_SURVEY.id, emptyList())
+    val savedWhenPageRequested = mutableListOf<Int>()
+
+    fakeRemoteDataStore.predefinedLoiPages = flow {
+      savedWhenPageRequested += localLoiStore.getLoiCount(TEST_SURVEY.id)
+      emit(listOf(TEST_POINT_OF_INTEREST_1, TEST_POINT_OF_INTEREST_2))
+      savedWhenPageRequested += localLoiStore.getLoiCount(TEST_SURVEY.id)
+      emit(listOf(TEST_POINT_OF_INTEREST_3))
+      savedWhenPageRequested += localLoiStore.getLoiCount(TEST_SURVEY.id)
+    }
+
+    locationOfInterestRepository.syncLocationsOfInterest(TEST_SURVEY)
+
+    assertThat(savedWhenPageRequested).containsExactly(0, 2, 3).inOrder()
+  }
+
+  @Test
+  fun `sync that fails midway keeps saved pages and deletes nothing`() = runWithTestDispatcher {
+    val newLoi = createPoint("6", COORDINATE_2)
+    fakeRemoteDataStore.predefinedLoiPages =
+      flow {
+        emit(listOf(newLoi))
+        throw TestSyncException()
+      }
+
+    assertFailsWith<TestSyncException> {
+      locationOfInterestRepository.syncLocationsOfInterest(TEST_SURVEY)
+    }
+
+    val lois = locationOfInterestRepository.getValidLois(TEST_SURVEY).first()
+    assertThat(lois).contains(newLoi)
+    assertThat(lois).containsAtLeastElementsIn(TEST_LOCATIONS_OF_INTEREST)
+  }
+
+  @Test
+  fun `sync deletes only the lois absent from every page`() = runWithTestDispatcher {
+    // Every LOI is stored to begin with, having been synced during setup.
+    assertThat(locationOfInterestRepository.getValidLois(TEST_SURVEY).first())
+      .containsExactlyElementsIn(TEST_LOCATIONS_OF_INTEREST)
+
+    // Sync again, with the server now returning two of them across separate pages.
+    fakeRemoteDataStore.predefinedLoiPages =
+      flowOf(listOf(TEST_POINT_OF_INTEREST_1), listOf(TEST_AREA_OF_INTEREST_2))
+    locationOfInterestRepository.syncLocationsOfInterest(TEST_SURVEY)
+
+    assertThat(locationOfInterestRepository.getValidLois(TEST_SURVEY).first())
+      .containsExactly(TEST_POINT_OF_INTEREST_1, TEST_AREA_OF_INTEREST_2)
+  }
+
+  @Test
+  fun `sync updates lois that changed remotely`() = runWithTestDispatcher {
+    val updated = TEST_POINT_OF_INTEREST_1.copy(geometry = Point(COORDINATE_3))
+    fakeRemoteDataStore.predefinedLois =
+      TEST_LOCATIONS_OF_INTEREST.map { if (it.id == updated.id) updated else it }
+
+    locationOfInterestRepository.syncLocationsOfInterest(TEST_SURVEY)
+
+    val lois = locationOfInterestRepository.getValidLois(TEST_SURVEY).first()
+    assertThat(lois).contains(updated)
+    assertThat(lois).doesNotContain(TEST_POINT_OF_INTEREST_1)
+  }
+
+  @Test
+  fun `sync does not delete lois with pending mutations`() = runWithTestDispatcher {
+    // Created locally and not yet uploaded, so the server cannot know about it.
+    val pending =
+      LOCATION_OF_INTEREST.copy(customId = "", lastModified = LOCATION_OF_INTEREST.created)
+    locationOfInterestRepository.applyAndEnqueue(pending.toMutation(CREATE, TEST_USER.id))
+
+    fakeRemoteDataStore.predefinedLois = listOf(TEST_POINT_OF_INTEREST_1)
+    locationOfInterestRepository.syncLocationsOfInterest(TEST_SURVEY)
+
+    assertThat(locationOfInterestRepository.getOfflineLoi(TEST_SURVEY.id, pending.id))
+      .isEqualTo(pending)
+  }
 
   @Test
   fun `loi within bounds when out of bounds returns empty list`() = runWithTestDispatcher {


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #3866 

LOIs were fetched in a single unbounded Firestore query and held entirely in memory before anything was written to the local database. For large surveys, this could use a lot of memory and significantly slow down the initial loading.

This PR introduces paginated queries, by requesting only a limited number of documents at a time and writing them to the db before fetching more. For this, the 3 LOI queries were changed to now return `Flow<List<LocationOfInterest>>` and page through with orderBy(documentId()) + limit + startAfter.

`validateGeometry` was removed because it just checked for empty geometries, which is something that it's already done by `RoomLocationOfInterestStore.insertOrUpdateAll`.

@shobhitagarwal1612  PTAL?
