### PR TITLE
Add cache for map icons

### DIFF
--- a/app/src/main/java/org/groundplatform/android/ui/IconFactory.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/IconFactory.kt
@@ -39,17 +39,21 @@ import org.groundplatform.android.ui.util.obtainTextPaintFromStyle
 class IconFactory @Inject constructor(@ApplicationContext private val context: Context) {
 
   private val markerIcons =
-    // One icon per job colour at each of two scales, so a handful per survey.
+    // Bitmap cache keyed by job color and scale. Capacity of 16 covers most combinations and avoids
+    // recreating icons.
     object : LruCache<Pair<Int, Float>, BitmapDescriptor>(16) {
       override fun create(key: Pair<Int, Float>): BitmapDescriptor =
         BitmapDescriptorFactory.fromBitmap(getMarkerBitmap(key.first, key.second))
     }
 
   private val clusterIcons =
-    // Clusters sit at least 100dp apart, so ~32 fit on a phone screen.
-    object : LruCache<String, BitmapDescriptor>(32) {
+    object : LruCache<String, BitmapDescriptor>(1) {
       override fun create(key: String): BitmapDescriptor = createClusterIcon(key)
     }
+
+  fun setClusterIconCacheSize(maxVisibleClusters: Int) {
+    clusterIcons.resize(maxVisibleClusters.coerceAtLeast(1))
+  }
 
   /** Create a scaled bitmap based on the dimensions of a given [Drawable]. */
   private fun createBitmap(drawable: Drawable, scale: Float = 1f): Bitmap {

--- a/app/src/main/java/org/groundplatform/android/ui/IconFactory.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/IconFactory.kt
@@ -39,15 +39,15 @@ import org.groundplatform.android.ui.util.obtainTextPaintFromStyle
 class IconFactory @Inject constructor(@ApplicationContext private val context: Context) {
 
   private val markerIcons =
-    // Bitmap cache keyed by job color and scale. Capacity of 16 covers most combinations and avoids
-    // recreating icons.
-    object : LruCache<Pair<Int, Float>, BitmapDescriptor>(16) {
+    // Bitmap cache keyed by job color and scale.
+    object : LruCache<Pair<Int, Float>, BitmapDescriptor>(DEFAULT_ICON_CACHE_SIZE) {
       override fun create(key: Pair<Int, Float>): BitmapDescriptor =
         BitmapDescriptorFactory.fromBitmap(getMarkerBitmap(key.first, key.second))
     }
 
+  // Bitmap cache keyed by cluster label. Resized to fit the visible clusters once the map is ready.
   private val clusterIcons =
-    object : LruCache<String, BitmapDescriptor>(1) {
+    object : LruCache<String, BitmapDescriptor>(DEFAULT_ICON_CACHE_SIZE) {
       override fun create(key: String): BitmapDescriptor = createClusterIcon(key)
     }
 
@@ -112,5 +112,10 @@ class IconFactory @Inject constructor(@ApplicationContext private val context: C
     canvas.drawText(text, x.toFloat(), y.toFloat(), textPaint)
 
     return BitmapDescriptorFactory.fromBitmap(bitmap)
+  }
+
+  companion object {
+    /** Default capacity of the icon caches, sufficient to cover most combinations. */
+    private const val DEFAULT_ICON_CACHE_SIZE = 16
   }
 }

--- a/app/src/main/java/org/groundplatform/android/ui/IconFactory.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/IconFactory.kt
@@ -24,6 +24,7 @@ import android.graphics.PorterDuff
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.os.Build
+import android.util.LruCache
 import androidx.appcompat.content.res.AppCompatResources
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
@@ -36,6 +37,20 @@ import org.groundplatform.android.ui.util.obtainTextPaintFromStyle
 /** Responsible for building dynamically generated icon bitmaps. */
 @Singleton
 class IconFactory @Inject constructor(@ApplicationContext private val context: Context) {
+
+  private val markerIcons =
+    // One icon per job colour at each of two scales, so a handful per survey.
+    object : LruCache<Pair<Int, Float>, BitmapDescriptor>(16) {
+      override fun create(key: Pair<Int, Float>): BitmapDescriptor =
+        BitmapDescriptorFactory.fromBitmap(getMarkerBitmap(key.first, key.second))
+    }
+
+  private val clusterIcons =
+    // Clusters sit at least 100dp apart, so ~32 fit on a phone screen.
+    object : LruCache<String, BitmapDescriptor>(32) {
+      override fun create(key: String): BitmapDescriptor = createClusterIcon(key)
+    }
+
   /** Create a scaled bitmap based on the dimensions of a given [Drawable]. */
   private fun createBitmap(drawable: Drawable, scale: Float = 1f): Bitmap {
     val width = (drawable.intrinsicWidth * scale).toInt()
@@ -67,14 +82,16 @@ class IconFactory @Inject constructor(@ApplicationContext private val context: C
     return bitmap
   }
 
-  /** Returns a [BitmapDescriptor] for representing an individual marker on the map. */
-  fun getMarkerIcon(color: Int, scale: Float): BitmapDescriptor {
-    val bitmap = getMarkerBitmap(color, scale)
-    return BitmapDescriptorFactory.fromBitmap(bitmap)
-  }
+  /**
+   * Returns a cached [BitmapDescriptor] representing an individual marker on the map. Descriptors
+   * are immutable, so one per [color] and [scale] is shared by every marker drawn with it.
+   */
+  fun getMarkerIcon(color: Int, scale: Float): BitmapDescriptor = markerIcons.get(color to scale)
 
-  /** Returns a [BitmapDescriptor] for representing a marker cluster on the map. */
-  fun getClusterIcon(text: String): BitmapDescriptor {
+  /** Returns a cached [BitmapDescriptor] representing a marker cluster on the map. */
+  fun getClusterIcon(text: String): BitmapDescriptor = clusterIcons.get(text)
+
+  private fun createClusterIcon(text: String): BitmapDescriptor {
     val fill = AppCompatResources.getDrawable(context, R.drawable.cluster_marker)
     val bitmap = createBitmap(fill!!)
     val canvas = Canvas(bitmap)

--- a/app/src/main/java/org/groundplatform/android/ui/IconFactory.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/IconFactory.kt
@@ -86,10 +86,7 @@ class IconFactory @Inject constructor(@ApplicationContext private val context: C
     return bitmap
   }
 
-  /**
-   * Returns a cached [BitmapDescriptor] representing an individual marker on the map. Descriptors
-   * are immutable, so one per [color] and [scale] is shared by every marker drawn with it.
-   */
+  /** Returns a cached [BitmapDescriptor] representing an individual marker on the map. */
   fun getMarkerIcon(color: Int, scale: Float): BitmapDescriptor = markerIcons.get(color to scale)
 
   /** Returns a cached [BitmapDescriptor] representing a marker cluster on the map. */

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/features/FeatureClusterRenderer.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/features/FeatureClusterRenderer.kt
@@ -42,6 +42,7 @@ class FeatureClusterRenderer(
   map: GoogleMap,
   clusterManager: ClusterManager<FeatureClusterItem>,
   private var zoom: Float,
+  private val iconFactory: IconFactory,
 ) : DefaultClusterRenderer<FeatureClusterItem>(context, map, clusterManager) {
   /**
    * Called when the cluster balloon is shown so that implementations can unhide related map items.
@@ -51,8 +52,6 @@ class FeatureClusterRenderer(
    * Called when the cluster balloon is display so that implementations can hide related map items.
    */
   lateinit var onClusterItemRendered: (Feature.Tag) -> Unit
-
-  private val markerIconFactory: IconFactory = IconFactory(context)
 
   private var oldZoom = zoom
 
@@ -77,7 +76,7 @@ class FeatureClusterRenderer(
   private fun createClusterIcon(cluster: Cluster<FeatureClusterItem>): BitmapDescriptor {
     val itemsWithFlag = cluster.items.count { it.feature.flag }
     val totalItems = cluster.items.size
-    return markerIconFactory.getClusterIcon("$itemsWithFlag/$totalItems")
+    return iconFactory.getClusterIcon("$itemsWithFlag/$totalItems")
   }
 
   /**

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/features/FeatureManager.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/features/FeatureManager.kt
@@ -75,14 +75,15 @@ constructor(
     mapsItemManager = MapsItemManager(map, pointRenderer, polygonRenderer, lineStringRenderer)
     clusterManager = FeatureClusterManager(context, map, createMarkerManager(map))
     // Render only visible features; off-screen clusterable features are omitted
-    clusterManager.setAlgorithm(
+    val algorithm =
       with(context.resources.displayMetrics) {
-        NonHierarchicalViewBasedAlgorithm(
+        NonHierarchicalViewBasedAlgorithm<FeatureClusterItem>(
           (widthPixels / density).toInt(),
           (heightPixels / density).toInt(),
         )
       }
-    )
+    clusterManager.setAlgorithm(algorithm)
+    iconFactory.setClusterIconCacheSize(maxVisibleClusters(algorithm))
     clusterRenderer =
       FeatureClusterRenderer(context, map, clusterManager, map.cameraPosition.zoom, iconFactory)
     clusterRenderer.onClusterItemRendered = { showClusterableItem(it) }
@@ -186,4 +187,13 @@ constructor(
   fun onCameraIdle() {
     clusterManager.onCameraIdle()
   }
+
+  @VisibleForTesting
+  internal fun maxVisibleClusters(algorithm: NonHierarchicalViewBasedAlgorithm<*>): Int =
+    with(context.resources.displayMetrics) {
+      val spacingDp = algorithm.maxDistanceBetweenClusteredItems
+      val columns = widthPixels / density / spacingDp
+      val rows = heightPixels / density / spacingDp
+      (columns * rows).toInt()
+    }
 }

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/features/FeatureManager.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/features/FeatureManager.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import org.groundplatform.android.di.coroutines.MainScope
+import org.groundplatform.android.ui.IconFactory
 import org.groundplatform.android.ui.map.Feature
 import timber.log.Timber
 
@@ -45,6 +46,8 @@ constructor(
   private val pointRenderer: PointRenderer,
   private val polygonRenderer: PolygonRenderer,
   private val lineStringRenderer: LineStringRenderer,
+  // Shared with PointRenderer so cluster icons hit the same cache instead of a per-renderer one.
+  private val iconFactory: IconFactory,
 ) {
   private val features = mutableSetOf<Feature>()
   private val featuresByTag = mutableMapOf<Feature.Tag, Feature>()
@@ -80,7 +83,8 @@ constructor(
         )
       }
     )
-    clusterRenderer = FeatureClusterRenderer(context, map, clusterManager, map.cameraPosition.zoom)
+    clusterRenderer =
+      FeatureClusterRenderer(context, map, clusterManager, map.cameraPosition.zoom, iconFactory)
     clusterRenderer.onClusterItemRendered = { showClusterableItem(it) }
     clusterRenderer.onClusterRendered = { hideClusterableItem(it) }
     clusterManager.renderer = clusterRenderer

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/features/FeatureManager.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/features/FeatureManager.kt
@@ -46,7 +46,6 @@ constructor(
   private val pointRenderer: PointRenderer,
   private val polygonRenderer: PolygonRenderer,
   private val lineStringRenderer: LineStringRenderer,
-  // Shared with PointRenderer so cluster icons hit the same cache instead of a per-renderer one.
   private val iconFactory: IconFactory,
 ) {
   private val features = mutableSetOf<Feature>()
@@ -189,7 +188,7 @@ constructor(
   }
 
   @VisibleForTesting
-  internal fun maxVisibleClusters(algorithm: NonHierarchicalViewBasedAlgorithm<*>): Int =
+  fun maxVisibleClusters(algorithm: NonHierarchicalViewBasedAlgorithm<*>): Int =
     with(context.resources.displayMetrics) {
       val spacingDp = algorithm.maxDistanceBetweenClusteredItems
       val columns = widthPixels / density / spacingDp

--- a/app/src/test/java/org/groundplatform/android/ui/IconFactoryTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/IconFactoryTest.kt
@@ -19,14 +19,21 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
+import com.google.android.gms.maps.model.BitmapDescriptor
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
 import org.groundplatform.android.BaseHiltTest
 import org.groundplatform.android.R
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 
 @HiltAndroidTest
@@ -38,6 +45,17 @@ class IconFactoryTest : BaseHiltTest() {
   private val testMarker by lazy { getDrawable(context, R.drawable.ic_marker_outline) }
   private val unscaledWidth by lazy { testMarker!!.intrinsicWidth }
   private val unscaledHeight by lazy { testMarker!!.intrinsicHeight }
+
+  private val bitmapDescriptorFactory: MockedStatic<BitmapDescriptorFactory> =
+    mockStatic(BitmapDescriptorFactory::class.java).apply {
+      `when`<BitmapDescriptor> { BitmapDescriptorFactory.fromBitmap(any()) }
+        .thenAnswer { mock<BitmapDescriptor>() }
+    }
+
+  @After
+  fun closeStaticMock() {
+    bitmapDescriptorFactory.close()
+  }
 
   @Test
   fun `getMarkerBitmap() stretches marker`() {
@@ -51,6 +69,41 @@ class IconFactoryTest : BaseHiltTest() {
     val bitmap = iconFactory.getMarkerBitmap(Color.BLUE, 0.5f)
 
     assertBitmapScale(bitmap, 0.5f)
+  }
+
+  @Test
+  fun `getMarkerIcon returns the same instance for the same color and scale`() {
+    val first = iconFactory.getMarkerIcon(Color.BLUE, 2.0f)
+
+    assertThat(iconFactory.getMarkerIcon(Color.BLUE, 2.0f)).isSameInstanceAs(first)
+  }
+
+  @Test
+  fun `getMarkerIcon builds a distinct icon per color and per scale`() {
+    val blue = iconFactory.getMarkerIcon(Color.BLUE, 2.0f)
+    val red = iconFactory.getMarkerIcon(Color.RED, 2.0f)
+    val blueSelected = iconFactory.getMarkerIcon(Color.BLUE, 3.0f)
+
+    assertThat(red).isNotSameInstanceAs(blue)
+    assertThat(blueSelected).isNotSameInstanceAs(blue)
+  }
+
+  @Test
+  fun `getClusterIcon returns the same instance for the same label`() {
+    iconFactory.setClusterIconCacheSize(2)
+    val first = iconFactory.getClusterIcon("3/10")
+
+    assertThat(iconFactory.getClusterIcon("4/10")).isNotSameInstanceAs(first)
+    assertThat(iconFactory.getClusterIcon("3/10")).isSameInstanceAs(first)
+  }
+
+  @Test
+  fun `getClusterIcon evicts the least recently used label once the cache is full`() {
+    iconFactory.setClusterIconCacheSize(1)
+    val first = iconFactory.getClusterIcon("3/10")
+    iconFactory.getClusterIcon("4/10")
+
+    assertThat(iconFactory.getClusterIcon("3/10")).isNotSameInstanceAs(first)
   }
 
   private fun assertBitmapScale(bitmap: Bitmap, scale: Float) {

--- a/app/src/test/java/org/groundplatform/android/ui/map/gms/features/FeatureClusterRendererTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/map/gms/features/FeatureClusterRendererTest.kt
@@ -23,6 +23,7 @@ import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.ClusterManager
 import org.groundplatform.android.FakeData.LOCATION_OF_INTEREST_CLUSTER_ITEM
 import org.groundplatform.android.common.Constants.CLUSTERING_ZOOM_THRESHOLD
+import org.groundplatform.android.ui.IconFactory
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -51,7 +52,8 @@ class FeatureClusterRendererTest {
   fun setUp() {
     context = ApplicationProvider.getApplicationContext()
     com.google.android.gms.maps.MapsInitializer.initialize(context)
-    featureClusterRenderer = FeatureClusterRenderer(context, map, clusterManager, 10f)
+    featureClusterRenderer =
+      FeatureClusterRenderer(context, map, clusterManager, 10f, IconFactory(context))
   }
 
   @Test

--- a/app/src/test/java/org/groundplatform/android/ui/map/gms/features/FeatureManagerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/map/gms/features/FeatureManagerTest.kt
@@ -39,6 +39,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class FeatureManagerTest {
@@ -144,6 +145,26 @@ class FeatureManagerTest {
     featureManager.clusterRenderer.onClusterRendered(feature.tag)
 
     verify(mapsPolygon).remove()
+  }
+
+  @Test
+  @Config(qualifiers = "w360dp-h800dp-xxhdpi")
+  fun `counts the clusters that fit on a phone screen`() {
+    // 360dp / 100dp = 3.6 columns, 800dp / 100dp = 8 rows, 3.6 * 8 = 28.8 cells.
+    assertThat(featureManager.maxVisibleClusters(clusterAlgorithm)).isEqualTo(28)
+  }
+
+  @Test
+  @Config(qualifiers = "w360dp-h800dp-mdpi")
+  fun `counts the clusters that fit on screen independently of density`() {
+    assertThat(featureManager.maxVisibleClusters(clusterAlgorithm)).isEqualTo(28)
+  }
+
+  @Test
+  @Config(qualifiers = "w1280dp-h800dp-xhdpi")
+  fun `counts the clusters that fit on a tablet screen`() {
+    // 1280dp / 100dp = 12.8 columns, 800dp / 100dp = 8 rows, 12.8 * 8 = 102.4 cells.
+    assertThat(featureManager.maxVisibleClusters(clusterAlgorithm)).isEqualTo(102)
   }
 
   private fun clusterableFeature(id: String) =

--- a/app/src/test/java/org/groundplatform/android/ui/map/gms/features/FeatureManagerTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/map/gms/features/FeatureManagerTest.kt
@@ -23,6 +23,7 @@ import com.google.android.gms.maps.model.Polygon as MapsPolygon
 import com.google.common.truth.Truth.assertThat
 import com.google.maps.android.clustering.algo.NonHierarchicalViewBasedAlgorithm
 import kotlinx.coroutines.test.TestScope
+import org.groundplatform.android.ui.IconFactory
 import org.groundplatform.android.ui.map.Feature
 import org.groundplatform.domain.model.geometry.Coordinates
 import org.groundplatform.domain.model.geometry.LinearRing
@@ -67,6 +68,7 @@ class FeatureManagerTest {
         pointRenderer,
         polygonRenderer,
         lineStringRenderer,
+        IconFactory(ApplicationProvider.getApplicationContext()),
       )
     featureManager.onMapReady(map)
   }


### PR DESCRIPTION
<!-- NOTE: The comments can be left as is as they don't end up in the final preview. -->

<!-- Add one or more issues below if already present. Otherwise, create one. -->
Towards #3866

Every icon was rebuilt from scratch (cluster icons and regular marker icons) on panning and zooming the map. On large surveys this could cause the map performance to drop significantly and also lead to OOM crashes due to memory pressure.

This PR introduces a cache for both clusters and marker icons.

The impact of these changes can be seen in the heap dump comparison of before/after.
Before:
<img width="3950" height="2150" alt="Screenshot From 2026-08-14 10-55-40" src="https://github.com/user-attachments/assets/0025168e-803c-49e2-be18-d6f163726ca4" />


After:
<img width="3950" height="2150" alt="image" src="https://github.com/user-attachments/assets/656b040d-5cb3-431d-8941-417c707c164f" />


@shobhitagarwal1612 PTAL?
