### PR TITLE
Update JDK in CI to version 21

### DIFF
--- a/.github/actions/submit-test/action.yml
+++ b/.github/actions/submit-test/action.yml
@@ -68,11 +68,11 @@ runs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
 
-    - name: Setup JDK 17
-      uses: actions/setup-java@v5
+    - name: Setup JDK 21
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'temurin'
-        java-version: 17
+        java-version: 21
 
     - name: Gradle cache
       uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: 'gradle'
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,12 +58,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -49,6 +49,12 @@ jobs:
 
     # See docs/e2e-testing-doc.md for details on how this is setup
     steps:
+      - name: Setup JDK 21 for Firebase emulator
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
       - name: Start Firebase emulator
         uses: google/ground-platform/.github/actions/start-emulator@b1eeccf9af27205206e0ec7b87ceaf6d7264f4ba
         with:


### PR DESCRIPTION
The firebase emulator is failing to start in the currently open PRs because firebase-tools was recently updated to v15 in ground-platform, and that version is incompatible with jdk versions below 21.

This PR updates CI jdk in order to fix that.

@shobhitagarwal1612 @gino-m PTAL?
