### PR TITLE
Move MOG models to :core:domain

### DIFF
--- a/app/src/main/java/org/groundplatform/android/di/MogProviderModule.kt
+++ b/app/src/main/java/org/groundplatform/android/di/MogProviderModule.kt
@@ -23,9 +23,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.groundplatform.android.data.remote.RemoteStorageManager
 import org.groundplatform.android.di.coroutines.IoDispatcher
 import org.groundplatform.android.ui.map.gms.mog.MogClient
-import org.groundplatform.android.ui.map.gms.mog.MogCollection
 import org.groundplatform.android.ui.map.gms.mog.MogSourceProvider
 import org.groundplatform.android.ui.map.gms.mog.MogTileProvider
+import org.groundplatform.domain.model.imagery.MogCollection
 
 @InstallIn(SingletonComponent::class)
 @Module

--- a/app/src/main/java/org/groundplatform/android/repository/OfflineAreaRepository.kt
+++ b/app/src/main/java/org/groundplatform/android/repository/OfflineAreaRepository.kt
@@ -29,13 +29,13 @@ import org.groundplatform.android.system.GeocodingManager
 import org.groundplatform.android.ui.map.gms.mog.MogClient
 import org.groundplatform.android.ui.map.gms.mog.MogTileDownloader
 import org.groundplatform.android.ui.map.gms.mog.getTilePath
-import org.groundplatform.android.ui.map.gms.mog.maxZoom
 import org.groundplatform.android.ui.util.FileUtil
 import org.groundplatform.android.util.deleteIfEmpty
 import org.groundplatform.android.util.rangeOf
 import org.groundplatform.domain.model.imagery.LocalTileSource
 import org.groundplatform.domain.model.imagery.OfflineArea
 import org.groundplatform.domain.model.imagery.TileSource
+import org.groundplatform.domain.model.imagery.maxZoom
 import org.groundplatform.domain.model.map.Bounds
 import org.groundplatform.domain.model.util.ByteCount
 import org.groundplatform.domain.repository.OfflineAreaRepositoryInterface

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogClient.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogClient.kt
@@ -31,7 +31,16 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.groundplatform.android.data.remote.RemoteStorageManager
+import org.groundplatform.domain.model.imagery.MAX_OVER_FETCH_PER_TILE
+import org.groundplatform.domain.model.imagery.MogCollection
+import org.groundplatform.domain.model.imagery.MogImageMetadata
+import org.groundplatform.domain.model.imagery.MogMetadata
+import org.groundplatform.domain.model.imagery.MogSource
+import org.groundplatform.domain.model.imagery.MogTileMetadata
+import org.groundplatform.domain.model.imagery.MogTilesRequest
 import org.groundplatform.domain.model.imagery.TileCoordinates
+import org.groundplatform.domain.model.imagery.consolidate
+import org.groundplatform.domain.model.imagery.zoomRange
 import org.groundplatform.domain.model.map.Bounds
 import timber.log.Timber
 

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogSourceProvider.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogSourceProvider.kt
@@ -15,6 +15,8 @@
  */
 package org.groundplatform.android.ui.map.gms.mog
 
+import org.groundplatform.domain.model.imagery.MogSource
+
 /**
  * Provides [MogSource]s for MOG (Map Overlay GeoTIFF) collections.
  *

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogTile.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogTile.kt
@@ -18,6 +18,7 @@ package org.groundplatform.android.ui.map.gms.mog
 
 import android.graphics.Color
 import com.google.android.gms.maps.model.Tile
+import org.groundplatform.domain.model.imagery.MogTileMetadata
 
 /** Metadata and image data for a single tile. */
 class MogTile(val metadata: MogTileMetadata, val data: ByteArray) {

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogTileDownloader.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogTileDownloader.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.flow
+import org.groundplatform.domain.model.imagery.MogTilesRequest
 import org.groundplatform.domain.model.imagery.TileCoordinates
 import timber.log.Timber
 

--- a/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogTileReader.kt
+++ b/app/src/main/java/org/groundplatform/android/ui/map/gms/mog/MogTileReader.kt
@@ -19,6 +19,7 @@ package org.groundplatform.android.ui.map.gms.mog
 import java.io.InputStream
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import org.groundplatform.domain.model.imagery.MogTileMetadata
 import timber.log.Timber
 
 // TODO: Add unit tests.

--- a/app/src/test/java/org/groundplatform/android/repository/OfflineAreaRepositoryTest.kt
+++ b/app/src/test/java/org/groundplatform/android/repository/OfflineAreaRepositoryTest.kt
@@ -26,12 +26,12 @@ import org.groundplatform.android.data.local.stores.LocalOfflineAreaStore
 import org.groundplatform.android.data.uuid.OfflineUuidGenerator
 import org.groundplatform.android.system.GeocodingManager
 import org.groundplatform.android.ui.map.gms.mog.MogClient
-import org.groundplatform.android.ui.map.gms.mog.MogCollection
-import org.groundplatform.android.ui.map.gms.mog.MogSource
-import org.groundplatform.android.ui.map.gms.mog.MogTilesRequest
 import org.groundplatform.android.ui.map.gms.mog.getTilePath
 import org.groundplatform.android.ui.util.FileUtil
 import org.groundplatform.domain.model.imagery.LocalTileSource
+import org.groundplatform.domain.model.imagery.MogCollection
+import org.groundplatform.domain.model.imagery.MogSource
+import org.groundplatform.domain.model.imagery.MogTilesRequest
 import org.groundplatform.domain.model.imagery.OfflineArea
 import org.groundplatform.domain.model.map.Bounds
 import org.junit.Before

--- a/app/src/test/java/org/groundplatform/android/ui/map/gms/mog/MogClientTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/map/gms/mog/MogClientTest.kt
@@ -24,6 +24,12 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
 import org.groundplatform.android.data.remote.RemoteStorageManager
 import org.groundplatform.domain.model.geometry.Coordinates
+import org.groundplatform.domain.model.imagery.MogCollection
+import org.groundplatform.domain.model.imagery.MogImageMetadata
+import org.groundplatform.domain.model.imagery.MogMetadata
+import org.groundplatform.domain.model.imagery.MogSource
+import org.groundplatform.domain.model.imagery.MogTileMetadata
+import org.groundplatform.domain.model.imagery.MogTilesRequest
 import org.groundplatform.domain.model.imagery.TileCoordinates
 import org.groundplatform.domain.model.map.Bounds
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/org/groundplatform/android/ui/map/gms/mog/MogTileTest.kt
+++ b/app/src/test/java/org/groundplatform/android/ui/map/gms/mog/MogTileTest.kt
@@ -16,6 +16,7 @@
 package org.groundplatform.android.ui.map.gms.mog
 
 import com.google.common.truth.Truth.assertThat
+import org.groundplatform.domain.model.imagery.MogTileMetadata
 import org.groundplatform.domain.model.imagery.TileCoordinates
 import org.junit.Test
 

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogCollection.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogCollection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogCollection.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogCollection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.groundplatform.android.ui.map.gms.mog
+package org.groundplatform.domain.model.imagery
 
 /** A collection of Maps Optimized GeoTIFFs (MOGs). */
 class MogCollection(val sources: List<MogSource>) {

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadata.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadata.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-package org.groundplatform.android.ui.map.gms.mog
-
-import org.groundplatform.domain.model.imagery.TiffTag
-import org.groundplatform.domain.model.imagery.TileCoordinates
+package org.groundplatform.domain.model.imagery
 
 /** Metadata describing a single full-resolution or overview image in a MOG. */
 data class MogImageMetadata(

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogMetadata.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogMetadata.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package org.groundplatform.android.ui.map.gms.mog
-
-import org.groundplatform.domain.model.imagery.TileCoordinates
+package org.groundplatform.domain.model.imagery
 
 /**
  * Contiguous tiles are fetched in a single request. To minimize the number of server requests, we

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogSource.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogSource.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package org.groundplatform.android.ui.map.gms.mog
-
-import org.groundplatform.domain.model.imagery.TileCoordinates
+package org.groundplatform.domain.model.imagery
 
 /**
  * Provides URLs or relative paths of one or more MOGs partitioned by web mercator tile extents at a

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogTileMetadata.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogTileMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogTileMetadata.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogTileMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package org.groundplatform.android.ui.map.gms.mog
-
-import org.groundplatform.domain.model.imagery.TileCoordinates
+package org.groundplatform.domain.model.imagery
 
 /** Metadata for the tiles with the specified coordinates provided by the specified MOG. */
 data class MogTileMetadata(

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequest.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequest.kt
+++ b/core/domain/src/commonMain/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.groundplatform.android.ui.map.gms.mog
+package org.groundplatform.domain.model.imagery
 
 // TODO: Add unit tests.
 // Issue URL: https://github.com/google/ground-android/issues/1596

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogCollectionTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogCollectionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogCollectionTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogCollectionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.groundplatform.android.ui.map.gms.mog
 
-import com.google.common.truth.Truth.assertThat
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
+package org.groundplatform.domain.model.imagery
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 const val TEST_WORLD_URL = "world_url/5/world.tif"
 const val TEST_HIGH_RES_URL = "high_res_url/5/{x}/{y}.tif"
@@ -29,12 +29,11 @@ val MOG_SOURCE_0_TO_4 = MogSource(IntRange(0, TEST_HIGH_RES_MIN_ZOOM - 1), TEST_
 val MOG_SOURCE_5_TO_14 =
   MogSource(IntRange(TEST_HIGH_RES_MIN_ZOOM, TEST_HIGH_RES_MAX_ZOOM), TEST_HIGH_RES_URL)
 
-@RunWith(MockitoJUnitRunner::class)
 class MogCollectionTest {
 
   private lateinit var mogCollection: MogCollection
 
-  @Before
+  @BeforeTest
   fun setUp() {
     mogCollection = MogCollection(listOf(MOG_SOURCE_0_TO_4, MOG_SOURCE_5_TO_14))
   }
@@ -42,18 +41,18 @@ class MogCollectionTest {
   @Test
   fun `getMogSource returns source for valid zoom level 1`() {
     val mogSource = mogCollection.getMogSource(4)
-    assertThat(mogSource).isEqualTo(MOG_SOURCE_0_TO_4)
+    assertEquals(MOG_SOURCE_0_TO_4, mogSource)
   }
 
   @Test
   fun `getMogSource returns source for valid zoom level 2`() {
     val mogSource = mogCollection.getMogSource(5)
-    assertThat(mogSource).isEqualTo(MOG_SOURCE_5_TO_14)
+    assertEquals(MOG_SOURCE_5_TO_14, mogSource)
   }
 
   @Test
   fun `getMogSource returns null for invalid zoom level`() {
     val mogSource = mogCollection.getMogSource(15)
-    assertThat(mogSource).isNull()
+    assertNull(mogSource)
   }
 }

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadataTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadataTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadataTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadataTest.kt
@@ -89,4 +89,49 @@ class MogImageMetadataTest {
   fun `hashCode() throws error`() {
     assertFailsWith<UnsupportedOperationException> { testMogImageMetadata.hashCode() }
   }
+
+  @Test
+  fun `fromTiffTags creates MogImageMetadata correctly`() {
+    val tagMap =
+      mapOf(
+        TiffTag.TileWidth to 256,
+        TiffTag.TileLength to 256,
+        TiffTag.TileOffsets to listOf(100L, 200L),
+        TiffTag.TileByteCounts to listOf(1000L, 2000L),
+        TiffTag.ImageWidth to 512,
+        TiffTag.ImageLength to 512,
+        TiffTag.JPEGTables to listOf(1, 2, 3),
+        TiffTag.GdalNodata to "0",
+      )
+    val originTile = TileCoordinates(5, 5, 5)
+    val metadata = MogImageMetadata.fromTiffTags(originTile, tagMap)
+
+    assertEquals(originTile, metadata.originTile)
+    assertEquals(256, metadata.tileWidth)
+    assertEquals(256, metadata.tileLength)
+    assertEquals(listOf(100L, 200L), metadata.tileOffsets)
+    assertEquals(listOf(1000L, 2000L), metadata.byteCounts)
+    assertEquals(512, metadata.imageWidth)
+    assertEquals(512, metadata.imageLength)
+    assertEquals(3, metadata.jpegTables.size)
+    assertEquals(0, metadata.noDataValue)
+  }
+
+  @Test
+  fun `fromTiffTags handles missing optional tags`() {
+    val tagMap =
+      mapOf(
+        TiffTag.TileWidth to 256,
+        TiffTag.TileLength to 256,
+        TiffTag.TileOffsets to listOf(100L),
+        TiffTag.TileByteCounts to listOf(1000L),
+        TiffTag.ImageWidth to 256,
+        TiffTag.ImageLength to 256,
+      )
+    val originTile = TileCoordinates(1, 2, 3)
+    val metadata = MogImageMetadata.fromTiffTags(originTile, tagMap)
+
+    assertEquals(0, metadata.jpegTables.size)
+    assertNull(metadata.noDataValue)
+  }
 }

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadataTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogImageMetadataTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.groundplatform.android.ui.map.gms.mog
 
-import com.google.common.truth.Truth.assertThat
-import org.groundplatform.domain.model.imagery.TileCoordinates
-import org.junit.Assert.assertThrows
-import org.junit.Test
+package org.groundplatform.domain.model.imagery
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class MogImageMetadataTest {
 
@@ -37,27 +40,27 @@ class MogImageMetadataTest {
 
   @Test
   fun `hasTile() returns true when coords in range`() {
-    assertThat(testMogImageMetadata.hasTile(12, 12)).isTrue()
+    assertTrue(testMogImageMetadata.hasTile(12, 12))
   }
 
   @Test
   fun `hasTile() returns false when X coord out of range`() {
-    assertThat(testMogImageMetadata.hasTile(16, 12)).isFalse()
+    assertFalse(testMogImageMetadata.hasTile(16, 12))
   }
 
   @Test
   fun `hasTile() returns false when Y coord out of range`() {
-    assertThat(testMogImageMetadata.hasTile(12, 16)).isFalse()
+    assertFalse(testMogImageMetadata.hasTile(12, 16))
   }
 
   @Test
   fun `getByteRange() returns null when coords out of range`() {
-    assertThat(testMogImageMetadata.getByteRange(12, 16)).isNull()
+    assertNull(testMogImageMetadata.getByteRange(12, 16))
   }
 
   @Test
   fun `getByteRange() throws error when index out of bounds`() {
-    assertThrows(IllegalArgumentException::class.java) {
+    assertFailsWith<IllegalArgumentException> {
       testMogImageMetadata
         .copy(tileOffsets = LongRange(1, 12).toList(), byteCounts = LongRange(1, 12).toList())
         .getByteRange(13, 13)
@@ -66,17 +69,17 @@ class MogImageMetadataTest {
 
   @Test
   fun `getByteRange() returns correct range`() {
-    assertThat(
-        testMogImageMetadata
-          .copy(tileOffsets = LongRange(1, 12).toList(), byteCounts = LongRange(1, 12).toList())
-          .getByteRange(11, 11)
-      )
-      .isEqualTo(LongRange(6, 11))
+    assertEquals(
+      LongRange(6, 11),
+      testMogImageMetadata
+        .copy(tileOffsets = LongRange(1, 12).toList(), byteCounts = LongRange(1, 12).toList())
+        .getByteRange(11, 11),
+    )
   }
 
   @Test
   fun `equals() throws error`() {
-    assertThrows(UnsupportedOperationException::class.java) {
+    assertFailsWith<UnsupportedOperationException> {
       @Suppress("UnusedEquals")
       testMogImageMetadata.equals(testMogImageMetadata.copy(tileWidth = 100))
     }
@@ -84,6 +87,6 @@ class MogImageMetadataTest {
 
   @Test
   fun `hashCode() throws error`() {
-    assertThrows(UnsupportedOperationException::class.java) { testMogImageMetadata.hashCode() }
+    assertFailsWith<UnsupportedOperationException> { testMogImageMetadata.hashCode() }
   }
 }

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogMetadataTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogMetadataTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.groundplatform.domain.model.imagery
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MogMetadataTest {
+
+  private val imageMetadataZoom5 =
+    MogImageMetadata(
+      originTile = TileCoordinates(10, 10, 5),
+      tileWidth = 256,
+      tileLength = 256,
+      tileOffsets = listOf(0L),
+      byteCounts = listOf(1024L),
+      imageWidth = 256,
+      imageLength = 256,
+      jpegTables = byteArrayOf(),
+    )
+
+  private val imageMetadataZoom6 =
+    MogImageMetadata(
+      originTile = TileCoordinates(20, 20, 6),
+      tileWidth = 256,
+      tileLength = 256,
+      tileOffsets = listOf(1024L),
+      byteCounts = listOf(2048L),
+      imageWidth = 512,
+      imageLength = 512,
+      jpegTables = byteArrayOf(),
+    )
+
+  private val mogMetadata =
+    MogMetadata(
+      sourceUrl = "https://example.com/world.tif",
+      bounds = TileCoordinates(0, 0, 0),
+      imageMetadata = listOf(imageMetadataZoom5, imageMetadataZoom6),
+    )
+
+  @Test
+  fun `getImageMetadata returns correct metadata for existing zoom`() {
+    assertEquals(imageMetadataZoom5, mogMetadata.getImageMetadata(5))
+    assertEquals(imageMetadataZoom6, mogMetadata.getImageMetadata(6))
+  }
+
+  @Test
+  fun `getImageMetadata returns null for non-existing zoom`() {
+    assertNull(mogMetadata.getImageMetadata(4))
+    assertNull(mogMetadata.getImageMetadata(7))
+  }
+}

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogSourceTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogSourceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogSourceTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogSourceTest.kt
@@ -58,4 +58,12 @@ class MogSourceTest {
       mogSource.getMogBoundsForTile(TileCoordinates(10, 20, 6)),
     )
   }
+
+  @Test
+  fun `list minZoom, maxZoom, and zoomRange return correct values`() {
+    val sources = listOf(MogSource(0..4, "overview.tif"), MogSource(5..14, "{x}/{y}.tif"))
+    assertEquals(0, sources.minZoom())
+    assertEquals(14, sources.maxZoom())
+    assertEquals(0..14, sources.zoomRange())
+  }
 }

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogSourceTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogSourceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,41 +14,33 @@
  * limitations under the License.
  */
 
-package org.groundplatform.android.ui.map.gms.mog
+package org.groundplatform.domain.model.imagery
 
-import com.google.common.truth.Truth.assertThat
-import org.groundplatform.domain.model.imagery.TileCoordinates
-import org.junit.Assert.assertThrows
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
-@RunWith(MockitoJUnitRunner::class)
 class MogSourceTest {
   private val mogSource = MogSource(5..7, "url/{x}/{y}.tif")
 
   @Test
   fun `getMogPath throws an error when zoom is less than min zoom`() {
-    assertThrows(IllegalStateException::class.java) {
-      mogSource.getMogPath(TileCoordinates(250, 500, 2))
-    }
+    assertFailsWith<IllegalStateException> { mogSource.getMogPath(TileCoordinates(250, 500, 2)) }
   }
 
   @Test
   fun `getMogPath returns path when zoom is equal to min zoom`() {
-    assertThat(mogSource.getMogPath(TileCoordinates(250, 500, 5))).isEqualTo("url/250/500.tif")
+    assertEquals("url/250/500.tif", mogSource.getMogPath(TileCoordinates(250, 500, 5)))
   }
 
   @Test
   fun `getMogPath throws an error when zoom is greater than max zoom`() {
-    assertThrows(IllegalStateException::class.java) {
-      mogSource.getMogPath(TileCoordinates(2500, 5000, 9))
-    }
+    assertFailsWith<IllegalStateException> { mogSource.getMogPath(TileCoordinates(2500, 5000, 9)) }
   }
 
   @Test
   fun `getMogBoundsForTile throws an error when zoom is LessThanMinZoom`() {
-    assertThrows(IllegalStateException::class.java) {
+    assertFailsWith<IllegalStateException> {
       mogSource.getMogBoundsForTile(TileCoordinates(10, 20, 4))
     }
   }
@@ -56,12 +48,14 @@ class MogSourceTest {
   @Test
   fun `getMogBoundsForTile returnsSameCoordinates when zoom is EqualToMinZoom`() {
     val testCoords = TileCoordinates(10, 20, 5)
-    assertThat(mogSource.getMogBoundsForTile(testCoords)).isEqualTo(testCoords)
+    assertEquals(testCoords, mogSource.getMogBoundsForTile(testCoords))
   }
 
   @Test
   fun `getMogBoundsForTile returnsScaledCoordinates when zoom is MoreThanMinZoom`() {
-    assertThat(mogSource.getMogBoundsForTile(TileCoordinates(10, 20, 6)))
-      .isEqualTo(TileCoordinates(5, 10, 5))
+    assertEquals(
+      TileCoordinates(5, 10, 5),
+      mogSource.getMogBoundsForTile(TileCoordinates(10, 20, 6)),
+    )
   }
 }

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTileMetadataTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTileMetadataTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTileMetadataTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTileMetadataTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.groundplatform.android.ui.map.gms.mog
 
-import org.groundplatform.domain.model.imagery.TileCoordinates
-import org.junit.Assert.assertThrows
-import org.junit.Test
+package org.groundplatform.domain.model.imagery
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class MogTileMetadataTest {
 
@@ -26,13 +26,13 @@ class MogTileMetadataTest {
 
   @Test
   fun `equals when throws error`() {
-    assertThrows(UnsupportedOperationException::class.java) {
+    assertFailsWith<UnsupportedOperationException> {
       testMogTileMetadata.equals(testMogTileMetadata.copy(width = 100))
     }
   }
 
   @Test
   fun `hashcode when throws error`() {
-    assertThrows(UnsupportedOperationException::class.java) { testMogTileMetadata.hashCode() }
+    assertFailsWith<UnsupportedOperationException> { testMogTileMetadata.hashCode() }
   }
 }

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequestTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequestTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequestTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequestTest.kt
@@ -18,8 +18,64 @@ package org.groundplatform.domain.model.imagery
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class MogTilesRequestTest {
+
+  @Test
+  fun `totalBytes returns sum of byte range counts`() {
+    val tile1 = newTileMetadata(0..9) // 10 bytes
+    val tile2 = newTileMetadata(10..29) // 20 bytes
+    val request = MogTilesRequest("http://url", listOf(tile1, tile2))
+
+    assertEquals(30, request.totalBytes)
+  }
+
+  @Test
+  fun `byteRange returns range spanning from first to last tile`() {
+    val tile1 = newTileMetadata(100..199)
+    val tile2 = newTileMetadata(200..299)
+    val request = MogTilesRequest("http://url", listOf(tile1, tile2))
+
+    assertEquals(100L..299L, request.byteRange)
+  }
+
+  @Test
+  fun `MutableMogTilesRequest appendTile succeeds when range is consecutive or later`() {
+    val tile1 = newTileMetadata(0..9)
+    val tile2 = newTileMetadata(10..19)
+    val request = MutableMogTilesRequest("http://url", mutableListOf(tile1))
+
+    request.appendTile(tile2)
+    assertEquals(listOf(tile1, tile2), request.tiles)
+  }
+
+  @Test
+  fun `MutableMogTilesRequest appendTile throws error when range is non-consecutive backwards or overlapping`() {
+    val tile1 = newTileMetadata(10..20)
+    val overlappingTile = newTileMetadata(15..25)
+    val earlierTile = newTileMetadata(0..5)
+    val request = MutableMogTilesRequest("http://url", mutableListOf(tile1))
+
+    assertFailsWith<IllegalArgumentException> { request.appendTile(overlappingTile) }
+    assertFailsWith<IllegalArgumentException> { request.appendTile(earlierTile) }
+  }
+
+  @Test
+  fun `MutableMogTilesRequest canMergeWith returns expected results`() {
+    val tile1 = newTileMetadata(0..10)
+    val tile2 = newTileMetadata(15..25) // gap of 15 - 10 - 1 = 4 bytes
+    val request1 = MutableMogTilesRequest("http://url1", mutableListOf(tile1))
+    val request2 = MogTilesRequest("http://url1", listOf(tile2))
+    val diffUrlRequest = MogTilesRequest("http://url2", listOf(tile2))
+
+    assertFalse(request1.canMergeWith(diffUrlRequest, 10))
+    assertFalse(request1.canMergeWith(request2, 3))
+    assertTrue(request1.canMergeWith(request2, 4))
+    assertTrue(request1.canMergeWith(request2, 10))
+  }
 
   @Test
   fun `consolidate does not merge different URLs with consecutive ranges`() {

--- a/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequestTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/groundplatform/domain/model/imagery/MogTilesRequestTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-package org.groundplatform.android.ui.map.gms.mog
+package org.groundplatform.domain.model.imagery
 
-import com.google.common.truth.Truth.assertThat
-import org.groundplatform.domain.model.imagery.TileCoordinates
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
-@RunWith(MockitoJUnitRunner::class)
-class MogTileRequestTest {
+class MogTilesRequestTest {
 
   @Test
   fun `consolidate does not merge different URLs with consecutive ranges`() {
@@ -34,8 +30,10 @@ class MogTileRequestTest {
     val request2 = MogTilesRequest("http://url2", listOf(tile2))
     val request3 = MogTilesRequest("http://url3", listOf(tile3))
 
-    assertThat(listOf(request1, request2, request3).consolidate(0))
-      .containsExactly(request1, request2, request3)
+    assertEquals(
+      listOf(request1, request2, request3),
+      listOf(request1, request2, request3).consolidate(0),
+    )
   }
 
   @Test
@@ -45,7 +43,7 @@ class MogTileRequestTest {
     val request1 = MogTilesRequest("http://url", listOf(tile1))
     val request2 = MogTilesRequest("http://url", listOf(tile2))
 
-    assertThat(listOf(request1, request2).consolidate(0)).containsExactly(request1, request2)
+    assertEquals(listOf(request1, request2), listOf(request1, request2).consolidate(0))
   }
 
   @Test
@@ -57,8 +55,10 @@ class MogTileRequestTest {
     val request2 = MogTilesRequest("http://url", listOf(tile2))
     val request3 = MogTilesRequest("http://url", listOf(tile3))
 
-    assertThat(listOf(request1, request2, request3).consolidate(0))
-      .containsExactly(MogTilesRequest("http://url", listOf(tile1, tile2, tile3)))
+    assertEquals(
+      listOf(MogTilesRequest("http://url", listOf(tile1, tile2, tile3))),
+      listOf(request1, request2, request3).consolidate(0),
+    )
   }
 
   @Test
@@ -68,8 +68,10 @@ class MogTileRequestTest {
     val request1 = MogTilesRequest("http://url", listOf(tile1))
     val request2 = MogTilesRequest("http://url", listOf(tile2))
 
-    assertThat(listOf(request1, request2).consolidate(2))
-      .containsExactly(MogTilesRequest("http://url", listOf(tile1, tile2)))
+    assertEquals(
+      listOf(MogTilesRequest("http://url", listOf(tile1, tile2))),
+      listOf(request1, request2).consolidate(2),
+    )
   }
 
   private fun newTileMetadata(byteRange: IntRange): MogTileMetadata =


### PR DESCRIPTION
Towards https://github.com/google/ground-android/issues/3633

This PR moves the MOG models, and all of the classes it uses, to the KMP shared module :core:domain. 

Most of the changes in this PR are just import changes. Also adds missing test coverage for the model classes.

@andreia-ferreira  PTAL?
